### PR TITLE
Make PyYAML optional in Network Template.

### DIFF
--- a/dissect/target/helpers/network_managers.py
+++ b/dissect/target/helpers/network_managers.py
@@ -493,7 +493,7 @@ TEMPLATES = {
         ["netctl"],
         ["address", "gateway", "dns", "ip"],
     ),
-    "netplan": Template("netplan", yaml.load, ["network"], ["addresses", "dhcp4", "gateway4"]),
+    "netplan": Template("netplan", yaml.load if PY_YAML else None, ["network"], ["addresses", "dhcp4", "gateway4"]),
     "NetworkManager": Template(
         "NetworkManager",
         ConfigParser(delimiters=("="), comment_prefixes="#", dict_type=dict),


### PR DESCRIPTION
As discussed, the PyYAML loader has been made optional because PyYAML does not seem to be quite compatible with PyStandalone. More research is needed to see if we can work out these integration issues but for now it has been decided to make the yaml loader optional. Tested with TarLoader on Linux. Confirmed that this solution does not raise unwanted Exceptions.