### PR TITLE
Adjust RemoteLoader to handle unreliable connections (DIS-1495).

### DIFF
--- a/dissect/target/loaders/remote.py
+++ b/dissect/target/loaders/remote.py
@@ -50,7 +50,7 @@ class RemoteStreamConnection:
 
     # Remote agent understands 3 commands:
     # 1      INFO: return disk size and sector size for each remote disk
-    # 2      QUIT: shutdown remote agent
+    # 2      QUIT: stops the agent on the remote machine
     # 50 + X READ: read disk number X (starts with 0)
     COMMAND_INFO = 1
     COMMAND_QUIT = 2


### PR DESCRIPTION
Adjusted the RemoteLoader to deal with less reliable connections:

- Retry reading after failure
- Retry SSL handshake
- Set connection max timeout (otherwise it will wait forever)
- Enforce valid certificates (although self-signed is still ok)
- Added logging
- Applied a patch in info to extract disk size correctly
- Added some more source code documentation to explain rationale
- Some other minor fixes and tuning

Works with up to approx. ~ 30% packet loss.
