### PR TITLE
Configure the minimum python version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ long_description_content_type = text/markdown
 license_files = LICENSE, COPYRIGHT
 classifiers =
   Programming Language :: Python :: 3
+
+[options]
+python_requires = ~=3.9


### PR DESCRIPTION
The Python version dissect is developed and tested against is currently 3.9. It
is set as minimum version and not also as maximum version because newer
versions (like 3.10) might work and because it makes transitioning to newer
Python versions easier.

(DIS-1490)
