### PR TITLE
Add Virtuozzo Loader

### DIFF
--- a/dissect/target/loader.py
+++ b/dissect/target/loader.py
@@ -191,3 +191,4 @@ register("target", "TargetLoader")
 # Disabling ResLoader because of DIS-536
 # register("res", "ResLoader")
 register("phobos", "PhobosLoader")
+register("virtuozzo", "VirtuozzoLoader")

--- a/dissect/target/loaders/kape.py
+++ b/dissect/target/loaders/kape.py
@@ -9,15 +9,19 @@ if TYPE_CHECKING:
     from dissect.target import Target
 
 
+# KAPE doesn't have the correct filenames for several files, like $J or $Secure_$SDS
+# The same applies to Velociraptor offline collector Windows.KapeFiles.Targets
+USNJRNL_PATHS = ["$Extend/$J", "$Extend/$UsnJrnl$J"]
+
 class KapeLoader(DirLoader):
     @staticmethod
     def detect(path: Path) -> bool:
         os_type, dirs = find_dirs(path)
         if os_type == "windows":
             for dir_path in dirs:
-                # KAPE doesn't have the correct filenames for several files, like $J or $Secure_$SDS
-                if dir_path.joinpath("$Extend/$J").exists():
-                    return True
+                for path in USNJRNL_PATHS:
+                    if dir_path.joinpath(path).exists():
+                        return True
 
         return False
 
@@ -26,5 +30,5 @@ class KapeLoader(DirLoader):
             target,
             self.path,
             sds_path="$Secure_$SDS",
-            usnjrnl_path="$Extend/$J",
+            usnjrnl_path=USNJRNL_PATHS,
         )

--- a/dissect/target/loaders/kape.py
+++ b/dissect/target/loaders/kape.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 # The same applies to Velociraptor offline collector Windows.KapeFiles.Targets
 USNJRNL_PATHS = ["$Extend/$J", "$Extend/$UsnJrnl$J"]
 
+
 class KapeLoader(DirLoader):
     @staticmethod
     def detect(path: Path) -> bool:

--- a/dissect/target/loaders/virtuozzo.py
+++ b/dissect/target/loaders/virtuozzo.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from dissect.target.loaders.dir import DirLoader, find_dirs, map_dirs
+
+if TYPE_CHECKING:
+    from dissect.target import Target
+
+
+class VirtuozzoLoader(DirLoader):
+    @staticmethod
+    def detect(path: Path) -> bool:
+        # /
+        #   etc/
+        #   var/
+        #   vz/
+        #       root/
+        #           <container-uuid>
+        #           <container-uuid>
+        os_type, dirs = find_dirs(path)
+        if os_type == "linux":
+            for dir_path in dirs:
+                if dir_path.joinpath("vz/root").exists():
+                    return True
+        return False
+
+    def map(self, target: Target) -> None:
+        # FIXME map multipe targets and test hostname plugin
+        ve_root = self.path.joinpath("vz/root")
+        if ve_root.exists():
+            vz_containers = [p.name for p in ve_root.iterdir()]
+            for container in vz_containers:
+                target.path = ve_root.joinpath(container)
+                map_dirs(target, ve_root.joinpath(container))

--- a/tests/test_loaders_virtuozzo.py
+++ b/tests/test_loaders_virtuozzo.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from dissect.target.loaders.dir import find_dirs
+from dissect.target.loaders.virtuozzo import VirtuozzoLoader
+
+from ._utils import mkdirs
+
+
+def test_virtuozzo_loader(mock_target, tmpdir_name):
+    root = Path(tmpdir_name)
+    mkdirs(
+        root, 
+        [
+            "etc", 
+            "var", 
+            "vz/root/669ef446-683b-11ed-9022-0242ac120002/var",
+            "vz/root/669ef446-683b-11ed-9022-0242ac120002/etc",
+            "vz/root/669ef446-683b-11ed-9022-0242ac120001/var",
+            "vz/root/669ef446-683b-11ed-9022-0242ac120001/etc",
+        ]
+    )
+
+    os_type, dirs = find_dirs(root)
+
+    assert os_type == "linux"
+    assert len(dirs) == 1
+
+    assert VirtuozzoLoader.detect(root)
+
+    loader = VirtuozzoLoader(root)
+    loader.map(mock_target)
+
+    assert len(mock_target.filesystems) == 2


### PR DESCRIPTION
Add Virtuozzo container loader

> VE_ROOT /vz/root/$VEID
> The mount point for container’s root. Must contain the literal string $VEID that will be substituted with the actual container UUID.

## Reference

* [https://docs.virtuozzo.com/virtuozzo_hybrid_server_7_command_line_reference/managing-system/configuration-files.html](https://docs.virtuozzo.com/virtuozzo_hybrid_server_7_command_line_reference/managing-system/configuration-files.html)