### PR TITLE
Adhere to the correct path separators

### DIFF
--- a/dissect/target/filesystems/ad1.py
+++ b/dissect/target/filesystems/ad1.py
@@ -42,7 +42,8 @@ class AD1Filesystem(Filesystem):
 
 class AD1FilesystemEntry(FilesystemEntry):
     def get(self, path):
-        return AD1FilesystemEntry(self.fs, fsutil.join(self.path, path), self.fs._get_node(path, self.entry))
+        path = fsutil.join(self.path, path, alt_separator=self.alt_separator)
+        return AD1FilesystemEntry(self.fs, path, self.fs._get_node(path, self.entry))
 
     def open(self):
         if self.is_dir():
@@ -61,7 +62,8 @@ class AD1FilesystemEntry(FilesystemEntry):
             raise NotADirectoryError(self.path)
 
         for fname, file_ in self.entry.listdir().items():
-            yield AD1FilesystemEntry(self.fs, f"{self.path}/{fname}", file_)
+            path = fsutil.join(self.path, fname, alt_separator=self.alt_separator)
+            yield AD1FilesystemEntry(self.fs, path, file_)
 
     def is_file(self):
         return self.entry.is_file()
@@ -83,4 +85,5 @@ class AD1FilesystemEntry(FilesystemEntry):
 
     def lstat(self):
         size = self.entry.size if self.entry.is_file() else 0
-        return fsutil.stat_result([stat.S_IFREG, fsutil.generate_addr(self.path), id(self.fs), 0, 0, 0, size, 0, 0, 0])
+        entry_addr = fsutil.generate_addr(self.path, alt_separator=self.fs.alt_separator)
+        return fsutil.stat_result([stat.S_IFREG, entry_addr, id(self.fs), 0, 0, 0, size, 0, 0, 0])

--- a/dissect/target/filesystems/cb.py
+++ b/dissect/target/filesystems/cb.py
@@ -94,7 +94,7 @@ class CbFilesystemEntry(FilesystemEntry):
         # mode, ino, dev, nlink, uid, gid, size, atime, mtime, ctime
         st_info = [
             mode | 0o755,
-            fsutil.generate_addr(self.path),
+            fsutil.generate_addr(self.path, alt_separator=self.fs.alt_separator),
             id(self.fs),
             0,
             0,

--- a/dissect/target/filesystems/exfat.py
+++ b/dissect/target/filesystems/exfat.py
@@ -32,7 +32,7 @@ class ExfatFilesystem(Filesystem):
     def get(self, path):
         """Returns a ExfatFilesystemEntry object corresponding to the given pathname"""
         try:
-            dirname, file = fsutil.split(path)
+            dirname, file = fsutil.split(path, alt_separator=self.alt_separator)
             if path == dirname and not file:
                 entry = self._gen_dict_extract(dirname)
             elif dirname and file:
@@ -76,7 +76,7 @@ class ExfatFilesystem(Filesystem):
             if path == "/":
                 yield self.get(file)
             else:
-                paths.append(fsutil.join(path, file))
+                paths.append(fsutil.join(path, file, alt_separator=self.alt_separator))
 
             for path in paths:
                 yield self.get(path)

--- a/dissect/target/filesystems/extfs.py
+++ b/dissect/target/filesystems/extfs.py
@@ -55,7 +55,8 @@ class ExtFilesystemEntry(FilesystemEntry):
         return self
 
     def get(self, path):
-        return ExtFilesystemEntry(self.fs, fsutil.join(self.path, path), self.fs._get_node(path, self.entry))
+        full_path = fsutil.join(self.path, path, alt_separator=self.fs.alt_separator)
+        return ExtFilesystemEntry(self.fs, full_path, self.fs._get_node(path, self.entry))
 
     def open(self):
         if self.is_dir():
@@ -88,7 +89,8 @@ class ExtFilesystemEntry(FilesystemEntry):
                 if fname in (".", ".."):
                     continue
 
-                yield ExtFilesystemEntry(self.fs, fsutil.join(self.path, fname), f)
+                path = fsutil.join(self.path, fname, alt_separator=self.fs.alt_separator)
+                yield ExtFilesystemEntry(self.fs, path, f)
 
     def is_dir(self):
         try:

--- a/dissect/target/filesystems/fat.py
+++ b/dissect/target/filesystems/fat.py
@@ -59,7 +59,8 @@ class FatFilesystem(Filesystem):
 class FatFilesystemEntry(FilesystemEntry):
     def get(self, path):
         """Get a filesystem entry relative from the current one."""
-        return FatFilesystemEntry(self.fs, fsutil.join(self.path, path), self.fs._get_entry(path, self.entry))
+        full_path = fsutil.join(self.path, path, alt_separator=self.fs.alt_separator)
+        return FatFilesystemEntry(self.fs, full_path, self.fs._get_entry(path, self.entry))
 
     def open(self):
         """Returns file handle (file-like object)."""
@@ -85,7 +86,8 @@ class FatFilesystemEntry(FilesystemEntry):
         for f in self.entry.iterdir():
             if f.name in (".", ".."):
                 continue
-            yield FatFilesystemEntry(self.fs, fsutil.join(self.path, f.name), f)
+            path = fsutil.join(self.path, f.name, alt_separator=self.fs.alt_separator)
+            yield FatFilesystemEntry(self.fs, path, f)
 
     def is_symlink(self):
         """Return whether this entry is a link."""

--- a/dissect/target/filesystems/ffs.py
+++ b/dissect/target/filesystems/ffs.py
@@ -61,7 +61,7 @@ class FfsFilesystemEntry(FilesystemEntry):
         return self
 
     def get(self, path):
-        entry_path = fsutil.join(self.path, path)
+        entry_path = fsutil.join(self.path, path, alt_separator=self.fs.alt_separator)
         entry = self.fs._get_node(path, self.entry)
         return FfsFilesystemEntry(self.fs, entry_path, entry)
 
@@ -90,7 +90,7 @@ class FfsFilesystemEntry(FilesystemEntry):
 
     def scandir(self):
         for entry in self._iterdir():
-            entry_path = fsutil.join(self.path, entry.name)
+            entry_path = fsutil.join(self.path, entry.name, alt_separator=self.fs.alt_separator)
             yield FfsFilesystemEntry(self.fs, entry_path, entry)
 
     def is_dir(self):

--- a/dissect/target/filesystems/ntfs.py
+++ b/dissect/target/filesystems/ntfs.py
@@ -88,7 +88,7 @@ class NtfsFilesystemEntry(FilesystemEntry):
     def get(self, path: str) -> NtfsFilesystemEntry:
         return NtfsFilesystemEntry(
             self.fs,
-            fsutil.join(self.path, path),
+            fsutil.join(self.path, path, alt_separator=self.fs.alt_separator),
             self.fs._get_record(path, self.dereference()),
         )
 
@@ -114,9 +114,8 @@ class NtfsFilesystemEntry(FilesystemEntry):
 
     def scandir(self) -> Iterator[NtfsFilesystemEntry]:
         for index_entry in self._iterdir():
-            yield NtfsFilesystemEntry(
-                self.fs, fsutil.join(self.path, index_entry.attribute.file_name), index_entry=index_entry
-            )
+            path = fsutil.join(self.path, index_entry.attribute.file_name, alt_separator=self.fs.alt_separator)
+            yield NtfsFilesystemEntry(self.fs, path, index_entry=index_entry)
 
     def is_dir(self) -> bool:
         return self.dereference().is_dir()

--- a/dissect/target/filesystems/vmfs.py
+++ b/dissect/target/filesystems/vmfs.py
@@ -67,7 +67,8 @@ class VmfsFilesystemEntry(FilesystemEntry):
 
     def get(self, path):
         """Get a filesystem entry relative from the current one."""
-        return VmfsFilesystemEntry(self.fs, fsutil.join(self.path, path), self.fs._get_node(path, self.entry))
+        full_path = fsutil.join(self.path, path, alt_separator=self.fs.alt_separator)
+        return VmfsFilesystemEntry(self.fs, full_path, self.fs._get_node(path, self.entry))
 
     def open(self):
         """Returns file handle (file-like object)."""
@@ -97,7 +98,8 @@ class VmfsFilesystemEntry(FilesystemEntry):
     def scandir(self):
         """List the directory contents of this directory. Returns a generator of filesystem entries."""
         for f in self._iterdir():
-            yield VmfsFilesystemEntry(self.fs, fsutil.join(self.path, f.name), f)
+            path = fsutil.join(self.path, f.name, alt_separator=self.fs.alt_separator)
+            yield VmfsFilesystemEntry(self.fs, path, f)
 
     def is_dir(self):
         """Return whether this entry is a directory. Resolves symlinks when possible."""

--- a/dissect/target/filesystems/xfs.py
+++ b/dissect/target/filesystems/xfs.py
@@ -55,7 +55,8 @@ class XfsFilesystemEntry(FilesystemEntry):
         return self
 
     def get(self, path):
-        return XfsFilesystemEntry(self.fs, fsutil.join(self.path, path), self.fs._get_node(path, self.entry))
+        full_path = fsutil.join(self.path, path, alt_separator=self.fs.alt_separator)
+        return XfsFilesystemEntry(self.fs, full_path, self.fs._get_node(path, self.entry))
 
     def open(self):
         if self.is_dir():
@@ -89,7 +90,8 @@ class XfsFilesystemEntry(FilesystemEntry):
 
                 if filename is None:
                     continue
-                yield XfsFilesystemEntry(self.fs, fsutil.join(self.path, filename), f)
+                path = fsutil.join(self.path, filename, alt_separator=self.fs.alt_separator)
+                yield XfsFilesystemEntry(self.fs, path, f)
 
     def is_dir(self):
         try:

--- a/dissect/target/loaders/dir.py
+++ b/dissect/target/loaders/dir.py
@@ -31,8 +31,14 @@ def map_dirs(target: Target, path: Path, **kwargs) -> None:
     """
     os_type, dirs = find_dirs(path)
 
+    alt_separator = ""
+    case_sensitive = True
+    if os_type == "windows":
+        alt_separator = "\\"
+        case_sensitive = False
+
     for path in dirs:
-        dfs = DirectoryFilesystem(path, case_sensitive=os_type != "windows")
+        dfs = DirectoryFilesystem(path, alt_separator=alt_separator, case_sensitive=case_sensitive)
         target.filesystems.add(dfs)
 
         if os_type == "windows":

--- a/dissect/target/loaders/vmcx.py
+++ b/dissect/target/loaders/vmcx.py
@@ -64,7 +64,7 @@ class VmcxLoader(Loader):
                         continue
 
                     filepath = drive["pathname"]
-                    filename = fsutil.basename(filepath)
+                    filename = fsutil.basename(filepath, alt_separator="\\")
                     relative_path = self.base_dir.joinpath(filename)
                     if relative_path.exists():
                         disk_path = relative_path

--- a/dissect/target/plugins/filesystem/resolver.py
+++ b/dissect/target/plugins/filesystem/resolver.py
@@ -41,14 +41,14 @@ class ResolverPlugin(Plugin):
 
     def resolve_windows(self, path: str, user_sid: Optional[str] = None):
         # Normalize first so the replacements are easier
-        path = fsutil.normalize(path)
+        path = fsutil.normalize(path, alt_separator=self.target.fs.alt_separator)
 
         for entry, environment in REPLACEMENTS:
             path = re.sub(entry, re.escape(environment), path, flags=re.IGNORECASE)
 
         path = self.target.expand_env(path)
         # Normalize again because environment variable expansion may have introduced backslashes again
-        path = fsutil.normalize(path)
+        path = fsutil.normalize(path, alt_separator=self.target.fs.alt_separator)
 
         # The \??\ pseudo path is used to point to the directory containing
         # (the user's) devices, e.g. \??\C:\foo\bar.
@@ -74,7 +74,7 @@ class ResolverPlugin(Plugin):
         if user_path_env:
             for path_env in user_path_env.split(";"):
                 # Normalize because environment variable may contain backslashes
-                path_env = fsutil.normalize(path_env).rstrip("/")
+                path_env = fsutil.normalize(path_env, alt_separator=self.target.fs.alt_separator).rstrip("/")
                 search_paths.append(path_env)
         if not search_paths:
             search_paths = FALLBACK_SEARCH_PATHS
@@ -102,4 +102,4 @@ class ResolverPlugin(Plugin):
         return path
 
     def resolve_default(self, path: str, user_id: Optional[str] = None):
-        return fsutil.normalize(path)
+        return fsutil.normalize(path, alt_separator=self.target.fs.alt_separator)

--- a/dissect/target/plugins/os/windows/clfs.py
+++ b/dissect/target/plugins/os/windows/clfs.py
@@ -93,7 +93,8 @@ class ClfsPlugin(Plugin):
                         if stream.lsn_base.PhysicalOffset <= 0:
                             continue
 
-                        container_path = fsutil.normalize(blf_container.name.replace("%BLF%", str(blf_path.parent)))
+                        container_path = blf_container.name.replace("%BLF%", str(blf_path.parent))
+                        container_path = fsutil.normalize(container_path, alt_separator=blf_path._flavour.altsep)
                         container_file = self.target.fs.path(container_path)
 
                         fh = container_file.open()

--- a/dissect/target/plugins/os/windows/iis.py
+++ b/dissect/target/plugins/os/windows/iis.py
@@ -247,7 +247,7 @@ class IISLogsPlugin(plugin.Plugin):
 
     @plugin.internal
     def iter_log_paths(self, log_dir: str) -> Generator[Path, None, None]:
-        log_dir = fsutil.normalize(log_dir)
+        log_dir = fsutil.normalize(log_dir, alt_separator=self.target.fs.alt_separator)
         yield from self.target.fs.path(log_dir).glob("*/*.log")
 
     @plugin.export(record=BasicRecordDescriptor)

--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -343,7 +343,7 @@ class TargetCli(TargetCmd):
         if isinstance(path, fsutil.TargetPath):
             return path
 
-        path = fsutil.abspath(path, cwd=str(self.cwd))
+        path = fsutil.abspath(path, cwd=str(self.cwd), alt_separator=self.target.fs.alt_separator)
         return self.target.fs.path(path)
 
     def resolveglobpath(self, path):
@@ -505,7 +505,7 @@ class TargetCli(TargetCmd):
         # Entry is an NTFSEntry and has alternative datastream
         if hasattr(entry, "deref") and ":" in name:
             # retrieve the ads from the NTFS entry
-            ads_path = fsutil.join(fsutil.dirname(entry.path), name)
+            ads_path = fsutil.join(fsutil.dirname(entry.path, separator=entry.fs.alt_separator), name)
             entry = entry.fs.get(ads_path)
 
         stat = entry.lstat()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ def tmpdir_name():
 
 @pytest.fixture
 def fs_win(tmpdir_name):
-    fs = VirtualFilesystem(case_sensitive=False)
+    fs = VirtualFilesystem(case_sensitive=False, alt_separator="\\")
     fs.map_dir("windows/system32", tmpdir_name)
     fs.map_dir("windows/system32/config/", tmpdir_name)
     yield fs
@@ -90,7 +90,7 @@ def target_win(hive_hklm, fs_win):
     mock_target.registry.map_hive("HKEY_LOCAL_MACHINE", hive_hklm)
 
     mock_target.filesystems.add(fs_win)
-    mock_target.fs.mount("C:\\", fs_win)
+    mock_target.fs.mount("C:", fs_win)
     mock_target.apply()
 
     yield mock_target

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -396,7 +396,7 @@ def test_filesystem_virtual_filesystem_makedirs(paths):
 
         partial_path = ""
         for part in vfspath.strip("/").split("/"):
-            partial_path = fsutil.join(partial_path, part)
+            partial_path = fsutil.join(partial_path, part, alt_separator=vfs.alt_separator)
             vfs_entry = vfs.get(partial_path)
 
             assert isinstance(vfs_entry, VirtualDirectory)
@@ -418,7 +418,7 @@ def test_filesystem_virtual_filesystem_map_fs(vfs):
     root_vfs = VirtualFilesystem()
     map_path = "/some/dir/"
     file_path = "/path/to/some/file"
-    root_file_path = fsutil.join(map_path, file_path)
+    root_file_path = fsutil.join(map_path, file_path, alt_separator=vfs.alt_separator)
 
     root_vfs.map_fs(map_path, vfs)
 
@@ -448,15 +448,21 @@ def test_filesystem_virtual_filesystem_map_dir():
 
                         vfs.map_dir(vfs_path, tmp_dir)
 
-                        entry_name = fsutil.join(vfs_path, os.path.relpath(some_dir, tmp_dir))
+                        rel_path = os.path.relpath(some_dir, tmp_dir)
+                        rel_path = fsutil.normalize(rel_path, alt_separator=os.path.sep)
+                        entry_name = fsutil.join(vfs_path, rel_path, alt_separator=vfs.alt_separator)
                         dir_entry = vfs.get(entry_name)
                         assert isinstance(dir_entry, VirtualDirectory)
 
-                        entry_name = fsutil.join(vfs_path, os.path.relpath(second_lvl_dir, tmp_dir))
+                        rel_path = os.path.relpath(second_lvl_dir, tmp_dir)
+                        rel_path = fsutil.normalize(rel_path, alt_separator=os.path.sep)
+                        entry_name = fsutil.join(vfs_path, rel_path, alt_separator=vfs.alt_separator)
                         dir_entry = vfs.get(entry_name)
                         assert isinstance(dir_entry, VirtualDirectory)
 
-                        entry_name = fsutil.join(vfs_path, os.path.relpath(some_file.name, tmp_dir))
+                        rel_path = os.path.relpath(some_file.name, tmp_dir)
+                        rel_path = fsutil.normalize(rel_path, alt_separator=os.path.sep)
+                        entry_name = fsutil.join(vfs_path, rel_path, alt_separator=vfs.alt_separator)
                         file_entry = vfs.get(entry_name)
                         assert isinstance(file_entry, MappedFile)
 
@@ -478,7 +484,7 @@ def test_filesystem_virtual_filesystem_map_file(vfs_path):
 
     vfs.map_file(vfs_path, real_path)
 
-    vfs_path = fsutil.normalize(vfs_path).strip("/")
+    vfs_path = fsutil.normalize(vfs_path, alt_separator=vfs.alt_separator).strip("/")
     vfs_entry = vfs.get(vfs_path)
 
     assert isinstance(vfs_entry, MappedFile)
@@ -508,7 +514,7 @@ def test_filesystem_virtual_filesystem_map_file_fh(vfs_path):
 
     vfs.map_file_fh(vfs_path, fh)
 
-    vfs_path = fsutil.normalize(vfs_path).strip("/")
+    vfs_path = fsutil.normalize(vfs_path, alt_separator=vfs.alt_separator).strip("/")
     vfs_entry = vfs.get(vfs_path)
 
     assert isinstance(vfs_entry, VirtualFile)
@@ -541,10 +547,10 @@ def test_filesystem_virtual_filesystem_map_file_fh_as_dir():
 )
 def test_filesystem_virtual_filesystem_map_file_entry(vfs_path):
     vfs = VirtualFilesystem()
-    entry_path = fsutil.normalize(vfs_path).strip("/")
+    entry_path = fsutil.normalize(vfs_path, alt_separator=vfs.alt_separator).strip("/")
     dir_entry = VirtualDirectory(vfs, entry_path)
 
-    file_name = fsutil.join(vfs_path, "test")
+    file_name = fsutil.join(vfs_path, "test", alt_separator=vfs.alt_separator)
     file_entry = VirtualFile(vfs, file_name, Mock())
     dir_entry.add("test", file_entry)
 
@@ -585,14 +591,14 @@ def test_filesystem_virtual_filesystem_map_file_entry(vfs_path):
 )
 def test_filesystem_virtual_filesystem_link(vfs_path, link_path):
     vfs = VirtualFilesystem()
-    entry_path = fsutil.normalize(vfs_path).strip("/")
+    entry_path = fsutil.normalize(vfs_path, alt_separator=vfs.alt_separator).strip("/")
     file_object = Mock()
     file_entry = VirtualFile(vfs, entry_path, file_object)
     vfs.map_file_entry(vfs_path, file_entry)
 
     vfs.link(vfs_path, link_path)
 
-    link_path = fsutil.normalize(link_path).strip("/")
+    link_path = fsutil.normalize(link_path, alt_separator=vfs.alt_separator).strip("/")
     link_entry = vfs.get(link_path)
 
     assert link_entry is file_entry
@@ -628,8 +634,8 @@ def test_filesystem_virtual_filesystem_symlink(vfs_path, link_path):
 
     vfs.symlink(vfs_path, link_path)
 
-    vfs_path = fsutil.normalize(vfs_path).strip("/")
-    link_path = fsutil.normalize(link_path).strip("/")
+    vfs_path = fsutil.normalize(vfs_path, alt_separator=vfs.alt_separator).strip("/")
+    link_path = fsutil.normalize(link_path, alt_separator=vfs.alt_separator).strip("/")
     link_entry = vfs.get(link_path)
 
     assert isinstance(link_entry, VirtualSymlink)

--- a/tests/test_target_path.py
+++ b/tests/test_target_path.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import tempfile
 
@@ -5,7 +6,6 @@ import pytest
 
 from dissect.target.filesystem import VirtualFile, VirtualFilesystem
 from dissect.target.filesystems.dir import DirectoryFilesystem
-from dissect.target.helpers import fsutil
 
 
 def test_target_path_checks_dirfs(tmpdir_name, target_win):
@@ -13,7 +13,7 @@ def test_target_path_checks_dirfs(tmpdir_name, target_win):
     with tempfile.NamedTemporaryFile(dir=tmpdir_name) as tf:
         tf.write(b"dummy")
         tf.flush()
-        tmpfile_name = fsutil.basename(tf.name)
+        tmpfile_name = os.path.basename(tf.name)
 
         fs = DirectoryFilesystem(path=pathlib.Path(tmpdir_name))
         target_win.filesystems.add(fs)
@@ -28,7 +28,7 @@ def test_target_path_checks_mapped_dir(tmpdir_name, target_win):
     with tempfile.NamedTemporaryFile(dir=tmpdir_name) as tf:
         tf.write(b"dummy")
         tf.flush()
-        tmpfile_name = fsutil.basename(tf.name)
+        tmpfile_name = os.path.basename(tf.name)
 
         target_win.filesystems.entries[0].map_dir("test-dir", tmpdir_name)
         assert target_win.fs.path("C:\\test-dir\\").is_dir()


### PR DESCRIPTION
Path normalization is now done using the correct (alternative) path separators according to the path's source (filesystem).

TargetPath's flavours are now also set when not constructed through _from_parts().

(DIS-1639)