### PR TITLE
Use the correct volume in the tar loader

### DIFF
--- a/dissect/target/loaders/tar.py
+++ b/dissect/target/loaders/tar.py
@@ -48,7 +48,7 @@ class TarLoader(Loader):
                     target.filesystems.add(vol)
 
                 volume = volumes["/"]
-                entry = TarFile(vol, member.name, member.name, self.tar)
+                entry = TarFile(volume, member.name, member.name, self.tar)
             else:
                 if not member.name.startswith("/sysvol"):
                     parts = member.name.replace("fs/", "").split("/")


### PR DESCRIPTION
File entries for legacy tar files (without an "fs/" path) now get the correct filesystem associated.

(DIS-1680)