### PR TITLE
New implementation of -l/-f/-h

### DIFF
--- a/dissect/target/plugins/apps/webservers/webservers.py
+++ b/dissect/target/plugins/apps/webservers/webservers.py
@@ -25,6 +25,7 @@ WebserverAccessLogRecord = TargetRecordDescriptor(
 
 class WebserverPlugin(Plugin):
     __namespace__ = "webserver"
+    __findable__ = False
 
     WEBSERVERS = [
         "apache",

--- a/dissect/target/plugins/browsers/browser.py
+++ b/dissect/target/plugins/browsers/browser.py
@@ -35,6 +35,8 @@ class BrowserPlugin(Plugin):
     """
 
     __namespace__ = "browser"
+    __findable__ = False
+
     BROWSERS = [
         "chrome",
         "chromium",

--- a/dissect/target/plugins/general/plugins.py
+++ b/dissect/target/plugins/general/plugins.py
@@ -6,11 +6,14 @@ from dissect.target.helpers.docs import INDENT_STEP, get_plugin_overview
 from dissect.target.plugin import Plugin, arg, export
 
 
-def categorize_plugins() -> dict:
+def categorize_plugins(plugins_selection: list[dict] = None) -> dict:
     """Categorize plugins based on the module it's from."""
 
     output_dict = dict()
-    for plugin_dict in get_exported_plugins():
+
+    plugins_selection = plugins_selection or get_exported_plugins()
+
+    for plugin_dict in plugins_selection:
         tmp_dict = dictify_module_recursive(
             list_of_items=plugin_dict["module"].split("."),
             last_value=plugin.load(plugin_dict),
@@ -98,10 +101,10 @@ class PluginListPlugin(Plugin):
     def check_compatible(self):
         return True
 
-    @export(output="none")
+    @export(output="none", cache=False)
     @arg("--docs", dest="print_docs", action="store_true")
-    def plugins(self, print_docs=False):
-        categorized_plugins = dict(sorted(categorize_plugins().items()))
+    def plugins(self, plugins: list[dict] = None, print_docs: bool = False) -> None:
+        categorized_plugins = dict(sorted(categorize_plugins(plugins).items()))
         plugin_descriptions = output_plugin_description_recursive(categorized_plugins, print_docs)
 
         plugins_list = textwrap.indent(

--- a/dissect/target/plugins/os/windows/_os.py
+++ b/dissect/target/plugins/os/windows/_os.py
@@ -288,17 +288,6 @@ class WindowsPlugin(OSPlugin):
         except RegistryError:
             pass
 
-    @export(property=True)
-    def codepage(self) -> Optional[str]:
-        """Returns the current active codepage on the system."""
-
-        key = "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
-
-        try:
-            return self.target.registry.key(key).value("ACP").value
-        except RegistryError:
-            pass
-
     @export(record=WindowsUserRecord)
     def users(self) -> Iterator[WindowsUserRecord]:
         key = "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList"

--- a/dissect/target/plugins/os/windows/amcache.py
+++ b/dissect/target/plugins/os/windows/amcache.py
@@ -196,6 +196,8 @@ AppLaunchAppcompatRecord = TargetRecordDescriptor(
 
 
 class AmcachePluginOldMixin:
+    __namespace__ = "amcache"
+
     def _replace_indices_with_fields(self, mapping, record):
         record_data = {v.name: v.value for v in record.values()}
         result = {}

--- a/dissect/target/plugins/os/windows/generic.py
+++ b/dissect/target/plugins/os/windows/generic.py
@@ -568,3 +568,14 @@ class GenericPlugin(Plugin):
                         _user=user,
                         _key=s,
                     )
+
+    @export(property=True)
+    def codepage(self) -> Optional[str]:
+        """Returns the current active codepage on the system."""
+
+        key = "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
+
+        try:
+            return self.target.registry.key(key).value("ACP").value
+        except RegistryError:
+            pass

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,11 +1,12 @@
 import os
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from dissect.target.plugin import (
     environment_variable_paths,
+    find_plugin_functions,
     get_external_module_paths,
     save_plugin_import_failure,
 )
@@ -45,3 +46,61 @@ def test_load_module_paths():
 def test_load_paths_with_env():
     with patch.object(os, "environ", {"DISSECT_PLUGINS": ":"}):
         assert get_external_module_paths([Path(""), Path("")]) == [Path("")]
+
+
+@patch(
+    "dissect.target.plugin.plugins",
+    return_value=[
+        {"module": "test.x13", "exports": ["f3"], "namespace": "Warp", "class": "x13"},
+        {"module": "os", "exports": ["f3"], "namespace": None, "class": "f3"},
+    ],
+)
+@patch(
+    "dissect.target.plugin.os_plugins",
+    return_value=[{"module": "os.warp._os", "exports": ["f6"], "namespace": None, "class": "warp"}],
+)
+@patch("dissect.target.Target", create=True)
+@patch("dissect.target.plugin.load")
+@pytest.mark.parametrize(
+    "search, findable, assert_num_found",
+    [
+        ("*", True, 4),  # Found with tree search using wildcard, OS plugin also registered without ns
+        ("*", False, 0),  # Unfindable plugins are not found...
+        ("test.x13.*", True, 1),  # Found with tree search using wildcard, expands to test.x13.f3
+        ("test.x13.*", False, 0),  # Unfindable plugins are not found...
+        ("test.x13", True, 1),  # Found with tree search, same as above, because users expect +*
+        ("test.*", True, 1),  # Found with tree search
+        ("test.[!x]*", True, 0),  # Not Found with tree search, all in test not starting with x (no x13)
+        ("test.[!y]*", True, 1),  # Found with tree search, all in test not starting with y (so x13 is ok)
+        ("test.???.??", True, 1),  # Found with tree search, using question marks
+        ("x13", True, 0),  # Not Found: Part of namespace but no match
+        ("Warp.*", True, 0),  # Not Found: Namespace != Module so 0
+        ("os.warp._os.f6", True, 1),  # Found, OS-plugins also available under verbose name
+        ("f6", True, 1),  # Found with classic search
+        ("f6", False, 1),  # Backward compatible: unfindable has no effect on classic search
+        ("Warp.f3", True, 1),  # Found with classic style search using namespace + function
+        ("Warp.f3", False, 1),  # Backward compatible: unfindable has no effect on classic search
+        ("f3", True, 1),  # Found with classic style search using only function
+        ("os.*", True, 2),  # Found matching os.f3, os.warp._os.f6
+        ("os", True, 0),  # Exception for os, because it can be a 'special' plugin (tree match ignored)
+    ],
+)
+def test_find_plugin_functions(plugin_loader, target, os_plugins, plugins, search, findable, assert_num_found):
+    class MockPlugin(MagicMock):
+        __exports__ = ["f6"]  # OS exports f6
+        __findable__ = findable
+
+        def get_all_records():
+            return []
+
+        def f3(self):
+            return "F3"
+
+        def f6(self):
+            return "F6"
+
+    plugin_loader.return_value = MockPlugin()
+    target._os = MagicMock()
+    target._os.__class__.__name__ = "warp"
+    found = find_plugin_functions(target, search)
+    assert len(found) == assert_num_found


### PR DESCRIPTION
Features:

- Allow wildcards/fnmatch expression with -l/-f/-h
- If the output is mixed, ignore non-records and emit warning
- If -f/-l matches the root of the plugin tree then also execute based on tree
- Only allow exported functions with -l/-f/-h
- Only execute/show relevant functions with -f/-l if a target is provided
- Show functions supported by ANY of the specified targets
- Show loaders only if no target has been provided
- List generic OS functions under OS if no target has been specified
- Make -l work with multiple functions
- Batch mode: If multiple functions are requested, don't break on intermediate errors
- Allow child plugins to appear in plugin list as well (future)
- Allow quick and exceptionless compatibility checks (is_compatible)
- Allow plugins to "hide" from wildcard (is_findable) (i.e. Browser, Webserver)
- Move Windows _os.codepage to os.windows.generic.codepage
- Fix amcache issue
- Add data class to encapsulate PluginFunction
- Remove redundant code
- Don't execute any properties/functions when inspecting/listing/checking
- Backward compatibility & Tests

Also fixes:
(https://github.com/fox-it/dissect.target/issues/149)
(DIS-1379)
(DIS-1426)
(DIS-1702)

