### PR TITLE
Make defusedxml a main dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     name="dissect.target",
     packages=list(map(lambda v: "dissect." + v, find_packages("dissect"))),
     install_requires=[
+        "defusedxml",
         "dissect.cstruct>=3.0.dev,<4.0.dev",
         "dissect.eventlog>=3.0.dev,<4.0.dev",
         "dissect.evidence>=3.0.dev,<4.0.dev",
@@ -66,7 +67,6 @@ setup(
     extras_require={
         "full": [
             "asn1crypto",
-            "defusedxml",
             "dissect.cim>=3.0.dev,<4.0.dev",
             "dissect.clfs>=1.0.dev,<2.0.dev",
             "dissect.esedb>=3.0.dev,<4.0.dev",


### PR DESCRIPTION
The reasons for this are three-fold:

- Basic acquire behaviour depends on the iis plugin, which requires defusedxml.
- The _os.py for esxi, which contains the basic esxi plugins, depends on it.
- Official Python documentation states that it is better to use defusedxml.etree.ElementTree when parsing XML from untrusted source then the build in ElementTree.

(DIS-1712)