### PR TITLE
Add `IndexRecord` to export thumbcache functions

### DIFF
--- a/dissect/target/plugins/os/windows/thumbcache.py
+++ b/dissect/target/plugins/os/windows/thumbcache.py
@@ -91,11 +91,11 @@ class ThumbcachePlugin(Plugin):
                 pass
 
     @arg("--output", "-o", dest="output_dir", type=Path, help="Path to extract thumbcache thumbnails to.")
-    @export(record=ThumbcacheRecord)
-    def thumbcache(self, output_dir: Optional[Path] = None) -> Iterator[ThumbcacheRecord]:
+    @export(record=[ThumbcacheRecord, IndexRecord])
+    def thumbcache(self, output_dir: Optional[Path] = None) -> Iterator[Union[ThumbcacheRecord, IndexRecord]]:
         yield from self._parse_thumbcache(ThumbcacheRecord, "thumbcache", output_dir)
 
     @arg("--output", "-o", dest="output_dir", type=Path, help="Path to extract iconcache thumbnails to.")
-    @export(record=IconcacheRecord)
-    def iconcache(self, output_dir: Optional[Path] = None) -> Iterator[IconcacheRecord]:
+    @export(record=[IconcacheRecord, IndexRecord])
+    def iconcache(self, output_dir: Optional[Path] = None) -> Iterator[Union[IconcacheRecord, IndexRecord]]:
         yield from self._parse_thumbcache(IconcacheRecord, "iconcache", output_dir)


### PR DESCRIPTION
The same issue as in #152