### PR TITLE
Add fix command to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ commands =
 # Python version. There should be no difference between the CPython and pypy
 # implementations, so we pick one.
 basepython = python3
+skip_install = true
 deps =
     black==23.1.0
     flake8
@@ -48,6 +49,16 @@ deps =
 commands =
     flake8 dissect tests setup.py
     vermin -t=3.9- --no-tips --lint dissect tests setup.py
+
+[testenv:fix]
+basepython = python3
+skip_install = true
+deps =
+    black==23.1.0
+    isort==5.11.4
+commands =
+    black dissect tests setup.py
+    isort dissect tests setup.py
 
 [testenv:build]
 # Force the Python version here, so building will be done with the correct


### PR DESCRIPTION
This PR introduces the `tox -e fix` command and makes the linter faster with `skip_install = true`.