### PR TITLE
Backward compatibility fix for plugin namespaces

### DIFF
--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -868,6 +868,11 @@ def find_plugin_functions(target: Target, patterns: str, compatibility: bool = F
     functions, rootset = plugin_function_index(target)
 
     for pattern in patterns.split(","):
+        # backward compatibility fix for namespace-level plugins (i.e. chrome)
+        for index_name, func in functions.items():
+            if func["namespace"] == pattern:
+                pattern = func["module"] + "*"
+
         wildcard = any(char in pattern for char in ["*", "!", "?", "[", "]"])
         treematch = pattern.split(".")[0] in rootset and pattern != "os"
 


### PR DESCRIPTION
Execute entire namespace plugins like before.
(basically converts NS to MOD + * )

(DIS-1861)