### PR TITLE
Improve unix services plugin

### DIFF
--- a/dissect/target/plugins/os/unix/services.py
+++ b/dissect/target/plugins/os/unix/services.py
@@ -34,7 +34,7 @@ class ServicesPlugin(Plugin):
     def services(self) -> Iterator[LinuxServiceRecord]:
         """Return information about all installed systemd and init.d services.
 
-        Resources:
+        References:
         - https://geeksforgeeks.org/what-is-init-d-in-linux-service-management
         - http://0pointer.de/blog/projects/systemd-for-admins-3.html
         - https://www.freedesktop.org/software/systemd/man/systemd.syntax.html

--- a/dissect/target/plugins/os/unix/services.py
+++ b/dissect/target/plugins/os/unix/services.py
@@ -1,86 +1,147 @@
 import re
+from itertools import chain
+from typing import BinaryIO, Iterator
 
 from dissect.target.exceptions import UnsupportedPluginError
 from dissect.target.helpers.record import TargetRecordDescriptor
-from dissect.target.plugin import Plugin, export
+from dissect.target.plugin import Plugin, export, internal
 
 LinuxServiceRecord = TargetRecordDescriptor(
     "linux/service",
     [
         ("datetime", "ts"),
         ("string", "name"),
-        ("string", "servicepath"),
-        ("string", "servicevariables"),
+        ("string", "config"),
+        ("path", "source"),
     ],
 )
 
 
-class ServicePlugin(Plugin):
-    PATHS = (
+class ServicesPlugin(Plugin):
+    SYSTEMD_PATHS = [
         "/etc/systemd/system",
         "/lib/systemd/system",
         "/usr/lib/systemd/system",
-    )
+    ]
+
+    INITD_PATHS = ["/etc/rc.d/init.d", "/etc/init.d"]
 
     def check_compatible(self):
-        if (
-            not any([self.target.fs.path(p).exists() for p in self.PATHS])
-            and not self.target.fs.path("/etc/init.d").exists()
-        ):
+        if not any([self.target.fs.path(p).exists() for p in self.SYSTEMD_PATHS + self.INITD_PATHS]):
             raise UnsupportedPluginError("No supported service directories found")
 
     @export(record=LinuxServiceRecord)
-    def services(self):
-        """Return information about all installed services."""
+    def services(self) -> Iterator[LinuxServiceRecord]:
+        """Return information about all installed systemd and init.d services.
 
-        for systemd_path in self.PATHS:
+        Resources:
+        - https://geeksforgeeks.org/what-is-init-d-in-linux-service-management
+        - http://0pointer.de/blog/projects/systemd-for-admins-3.html
+        - https://www.freedesktop.org/software/systemd/man/systemd.syntax.html
+        """
+
+        return chain(self.systemd(), self.initd())
+
+    @internal
+    def systemd(self) -> Iterator[LinuxServiceRecord]:
+        ignored_suffixes = [".wants", ".requires", ".d"]
+
+        for systemd_path in self.SYSTEMD_PATHS:
             path = self.target.fs.path(systemd_path)
             if not path.exists() or not path.is_dir():
                 continue
 
             for file_ in path.iterdir():
-                if file_.name.endswith(".wants"):
+                if should_ignore_file(file_.name, ignored_suffixes):
                     continue
-                elif file_.name.endswith(".requires"):
-                    continue
-                elif file_.name.endswith(".d"):
-                    continue
-
-                fh = file_.open("rt")
-                variables = ""
 
                 try:
-                    for line in fh:
-                        line = line.strip().replace("\n", "")
+                    fh = file_.open("rt")
+                except FileNotFoundError:
+                    # The service is registered but the symlink is broken.
+                    yield LinuxServiceRecord(
+                        ts=file_.stat().st_mtime,
+                        name=file_.name,
+                        config=None,
+                        source=str(file_),
+                        _target=self.target,
+                    )
 
-                        if line[:1] == "[":
-                            segment = re.sub(r"\[|\]", "", line)
-                        elif line[:1] == ";" or line[:1] == "#" or line == "":
-                            pass
-                        else:
-                            line = line.split("=", 1)
-                            if "segment" in locals():
-                                variables = f'{variables} {segment}_{line[0]}="{line[1]}" '
-                            else:
-                                variables = f"{variables} {line} "
-                except UnicodeDecodeError:
-                    break
+                config = parse_systemd_config(fh)
 
                 yield LinuxServiceRecord(
                     ts=file_.stat().st_mtime,
                     name=file_.name,
-                    servicepath=str(file_),
-                    servicevariables=variables,
+                    config=config,
+                    source=str(file_),
                     _target=self.target,
                 )
 
-        path = self.target.fs.path("/etc/init.d")
-        if path.exists():
-            for file_ in path.iterdir():
-                yield LinuxServiceRecord(
-                    ts=file_.stat().st_mtime,
-                    name=file_.name,
-                    servicepath=str(file_),
-                    servicevariables=None,
-                    _target=self.target,
-                )
+    @internal
+    def initd(self) -> Iterator[LinuxServiceRecord]:
+        ignored_suffixes = ["README"]
+
+        for initd_path in self.INITD_PATHS:
+            path = self.target.fs.path(initd_path)
+
+            if path.exists():
+                for file_ in path.iterdir():
+                    if should_ignore_file(file_.name, ignored_suffixes):
+                        continue
+
+                    yield LinuxServiceRecord(
+                        ts=file_.stat().st_mtime,
+                        name=file_.name,
+                        config=None,
+                        source=str(file_),
+                        _target=self.target,
+                    )
+
+
+def should_ignore_file(needle: str, haystack: list) -> bool:
+    for stray in haystack:
+        if needle.endswith(stray):
+            return True
+    return False
+
+
+def parse_systemd_config(fh: BinaryIO) -> str:
+    """Returns a string of key/value pairs from a toml/ini-like string.
+
+    This should probably be rewritten to return a proper dict as in
+    its current form this is only useful when used in Splunk.
+    """
+    variables = ""
+
+    try:
+        for line in fh:
+            line = line.strip().replace("\n", "")
+
+            # segment start eg. [ExampleSegment]
+            if line[:1] == "[":
+                segment = re.sub(r"\[|\]", "", line)
+
+            # ignore comments and empty lines
+            elif line[:1] == ";" or line[:1] == "#" or line == "":
+                continue
+
+            # if line ends with \ it is likely part of a multi-line command argument
+            elif line[-1] == "\\" or line[-1] == "'":
+                variables = f"{variables} {line} "
+
+            else:
+                line = line.split("=", 1)
+                if "segment" in locals():
+                    # some variables/arguments are not delimited by a '='
+                    # (eg. '-Kvalue' instead of '-key=value')
+                    if len(line) < 2:
+                        variables = f"{variables} {segment}_{line[0]} "
+                    else:
+                        variables = f'{variables} {segment}_{line[0]}="{line[1]}" '
+                else:
+                    variables = f"{variables} {line} ".strip()
+
+    except UnicodeDecodeError:
+        pass
+
+    return variables

--- a/tests/data/plugins/os/unix/services/initd.sh
+++ b/tests/data/plugins/os/unix/services/initd.sh
@@ -1,0 +1,16 @@
+#! /bin/sh
+
+### BEGIN INIT INFO
+# Provides:             exampled
+# Required-Start:	    $foo $bar
+# Required-Stop:	    $foo $bar
+# Default-Start:	    2 3 4 5
+# Default-Stop:		    
+# Short-Description:	Example initd service
+### END INIT INFO
+
+set -e
+
+echo "Example initd service"
+
+exit 0

--- a/tests/data/plugins/os/unix/services/systemd.service
+++ b/tests/data/plugins/os/unix/services/systemd.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=an example systemd service
+After=foobar.service
+Requires=foo.service bar.service
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/simple-command --key value
+SyslogIdentifier=
+TimeoutStopSec=5
+
+[Install]
+WantedBy=multi-user.target
+Alias=example.service

--- a/tests/data/plugins/os/unix/services/systemd2.service
+++ b/tests/data/plugins/os/unix/services/systemd2.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=an example systemd service
+After=foobar.service
+Requires=foo.service bar.service
+
+[Service]
+Type=simple
+ExecStart=/bin/bash -c 'exec /usr/bin/example param1 --param2=value2 -P3value3 -param4 value4; \
+                        exit 0'
+SyslogIdentifier=example-service
+TimeoutStopSec=5
+
+[Install]
+WantedBy=multi-user.target
+Alias=example.service

--- a/tests/test_plugins_os_unix_services.py
+++ b/tests/test_plugins_os_unix_services.py
@@ -1,0 +1,30 @@
+from dissect.target.plugins.os.unix.services import ServicesPlugin
+
+from ._utils import absolute_path
+
+
+def test_unix_services(target_unix_users, fs_unix):
+    systemd_service_1 = absolute_path("data/plugins/os/unix/services/systemd.service")
+    systemd_service_2 = absolute_path("data/plugins/os/unix/services/systemd2.service")
+    initd_service_1 = absolute_path("data/plugins/os/unix/services/initd.sh")
+    fs_unix.map_file("/lib/systemd/system/example.service", systemd_service_1)
+    fs_unix.map_file("/usr/lib/systemd/system/example2.service", systemd_service_2)
+    fs_unix.map_file("/etc/init.d/example", initd_service_1)
+    target_unix_users.add_plugin(ServicesPlugin)
+
+    results = list(target_unix_users.services())
+    assert len(results) == 3
+
+    results[0].name == "example.service"
+    expected_config_1 = 'Unit_After="foobar.service"  Unit_Requires="foo.service bar.service"  Service_Type="simple"  Service_ExecStart="/usr/sbin/simple-command --key value"  Service_SyslogIdentifier=""  Service_TimeoutStopSec="5"  Install_WantedBy="multi-user.target"  Install_Alias="example.service"'  # noqa E501
+    results[0].config == expected_config_1
+    results[0].source == "/lib/systemd/system/example.service"
+
+    results[1].name == "example2.service"
+    expected_config_2 = 'Unit_Description="an example systemd service"  Unit_After="foobar.service"  Unit_Requires="foo.service bar.service"  Service_Type="simple"  ExecStart=/bin/bash -c \'exec /usr/bin/example param1 --param2=value2 -P3value3 -param4 value4; \\  exit 0\'  Service_SyslogIdentifier="example-service"  Service_TimeoutStopSec="5"  Install_WantedBy="multi-user.target"  Install_Alias="example.service"'  # noqa E501
+    results[1].config == expected_config_2
+    results[1].source == "/usr/lib/systemd/system/example2.service"
+
+    results[2].name == "example"
+    results[2].config is None
+    results[2].source == "/etc/init.d/example"


### PR DESCRIPTION
This PR adds general improvements to the unix services plugin.

- adds support for initd services
- adds unit tests for systemd and initd services
- adds support for multi-line `ExecStart` commands in systemd service config files
