### PR TITLE
Fix external references in documentation

### DIFF
--- a/dissect/target/plugins/apps/containers/docker.py
+++ b/dissect/target/plugins/apps/containers/docker.py
@@ -39,10 +39,10 @@ DOCKER_NS_REGEX = re.compile(r"\.(?P<nanoseconds>\d{7,})(?P<postfix>Z|\+\d{2}:\d
 
 class DockerPlugin(Plugin):
     """
-    Resources:
-    - https://didactic-security.com/resources/docker-forensics.pdf
-    - https://didactic-security.com/resources/docker-forensics-cheatsheet.pdf
-    - https://github.com/google/docker-explorer
+    References:
+        - https://didactic-security.com/resources/docker-forensics.pdf
+        - https://didactic-security.com/resources/docker-forensics-cheatsheet.pdf
+        - https://github.com/google/docker-explorer
     """
 
     __namespace__ = "docker"

--- a/dissect/target/plugins/apps/remoteaccess/anydesk.py
+++ b/dissect/target/plugins/apps/remoteaccess/anydesk.py
@@ -44,7 +44,7 @@ class AnydeskPlugin(Plugin):
         AnyDesk is a remote desktop application and can be used by adversaries to get (persistent) access to a machine.
         Log files (.trace files) are retrieved from /ProgramData/AnyDesk/ and AppData/roaming/AnyDesk/
 
-        Sources:
+        References:
             - https://www.inversecos.com/2021/02/forensic-analysis-of-anydesk-logs.html
         """
         for logfile, user in self.logfiles:

--- a/dissect/target/plugins/apps/remoteaccess/teamviewer.py
+++ b/dissect/target/plugins/apps/remoteaccess/teamviewer.py
@@ -45,7 +45,7 @@ class TeamviewerPlugin(Plugin):
         TeamViewer is a commercial remote desktop application. An adversary may use it to gain persistence on a
         system.
 
-        Sources:
+        References:
             - https://www.teamviewer.com/nl/
         """
         for logfile, user in self.logfiles:

--- a/dissect/target/plugins/apps/vpns/wireguard.py
+++ b/dissect/target/plugins/apps/vpns/wireguard.py
@@ -42,9 +42,9 @@ WireGuardPeerRecord = TargetRecordDescriptor(
 class WireGuardPlugin(Plugin):
     """WireGuard configuration parser.
 
-    Resources:
-    - https://manpages.debian.org/testing/wireguard-tools/wg.8.en.html#CONFIGURATION_FILE_FORMAT
-    - https://github.com/pirate/wireguard-docs
+    References:
+        - https://manpages.debian.org/testing/wireguard-tools/wg.8.en.html#CONFIGURATION_FILE_FORMAT
+        - https://github.com/pirate/wireguard-docs
     """
 
     __namespace__ = "wireguard"

--- a/dissect/target/plugins/apps/webservers/apache.py
+++ b/dissect/target/plugins/apps/webservers/apache.py
@@ -71,7 +71,7 @@ class ApachePlugin(plugin.Plugin):
         """
         Discover any present Apache log paths on the target system.
 
-        Resources:
+        References:
             - https://www.cyberciti.biz/faq/apache-logs/
             - https://unix.stackexchange.com/a/269090
         """

--- a/dissect/target/plugins/apps/webservers/caddy.py
+++ b/dissect/target/plugins/apps/webservers/caddy.py
@@ -88,7 +88,7 @@ class CaddyPlugin(plugin.Plugin):
     def access(self) -> Iterator[WebserverAccessLogRecord]:
         """Parses Caddy V1 CRF and Caddy V2 JSON access logs.
 
-        Resources:
+        References:
             - https://caddyserver.com/docs/caddyfile/directives/log#format-modules
         """
         for path in self.log_paths:

--- a/dissect/target/plugins/apps/webservers/iis.py
+++ b/dissect/target/plugins/apps/webservers/iis.py
@@ -44,9 +44,9 @@ FIELD_NAME_INVALID_CHARS_RE = re.compile(r"[^a-zA-Z0-9]")
 class IISLogsPlugin(plugin.Plugin):
     """IIS 7 (and above) logs plugin.
 
-    Sources:
-        - `<https://docs.microsoft.com/en-us/iis/get-started/planning-your-iis-architecture/introduction-to-applicationhostconfig>`_
-        - `<https://docs.microsoft.com/en-us/previous-versions/iis/6.0-sdk/ms525807(v=vs.90)>`_
+    References:
+        - https://docs.microsoft.com/en-us/iis/get-started/planning-your-iis-architecture/introduction-to-applicationhostconfig
+        - https://docs.microsoft.com/en-us/previous-versions/iis/6.0-sdk/ms525807%28v=vs.90%29
     """  # noqa: E501
 
     APPLICATION_HOST_CONFIG = "sysvol/windows/system32/inetsrv/config/applicationHost.config"
@@ -91,10 +91,10 @@ class IISLogsPlugin(plugin.Plugin):
 
         This format is not the default IIS log format.
 
-        Sources:
-            - `<https://docs.microsoft.com/en-us/previous-versions/iis/6.0-sdk/ms525807(v=vs.90)#iis-log-file-format>`_
-            - `<https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc728311(v=ws.10)>`_
-            - `<https://learn.microsoft.com/en-us/iis/configuration/system.applicationHost/sites/site/logFile/>`_
+        References:
+            - https://docs.microsoft.com/en-us/previous-versions/iis/6.0-sdk/ms525807%28v=vs.90%29#iis-log-file-format
+            - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc728311%28v=ws.10%29
+            - https://learn.microsoft.com/en-us/iis/configuration/system.applicationHost/sites/site/logFile
         """  # noqa: E501
 
         tzinfo = self.target.datetime.tzinfo
@@ -149,10 +149,10 @@ class IISLogsPlugin(plugin.Plugin):
 
         This is the default logging format for IIS [^3].
 
-        Sources:
-            - `<https://docs.microsoft.com/en-us/previous-versions/iis/6.0-sdk/ms525807(v=vs.90)#w3c-extended-log-file-format>`_
-            - `<https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc786596(v=ws.10)>`_
-            - `<https://learn.microsoft.com/en-us/iis/configuration/system.applicationHost/sites/site/logFile/>`_
+        References:
+            - https://docs.microsoft.com/en-us/previous-versions/iis/6.0-sdk/ms525807%28v=vs.90%29#w3c-extended-log-file-format
+            - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc786596%28v=ws.10%29
+            - https://learn.microsoft.com/en-us/iis/configuration/system.applicationHost/sites/site/logFile
         """  # noqa: E501
 
         basic_fields = {

--- a/dissect/target/plugins/apps/webservers/iis.py
+++ b/dissect/target/plugins/apps/webservers/iis.py
@@ -44,9 +44,9 @@ FIELD_NAME_INVALID_CHARS_RE = re.compile(r"[^a-zA-Z0-9]")
 class IISLogsPlugin(plugin.Plugin):
     """IIS 7 (and above) logs plugin.
 
-    References:
-        - https://docs.microsoft.com/en-us/iis/get-started/planning-your-iis-architecture/introduction-to-applicationhostconfig
-        - https://docs.microsoft.com/en-us/previous-versions/iis/6.0-sdk/ms525807(v=vs.90)
+    Sources:
+        - `<https://docs.microsoft.com/en-us/iis/get-started/planning-your-iis-architecture/introduction-to-applicationhostconfig>`_
+        - `<https://docs.microsoft.com/en-us/previous-versions/iis/6.0-sdk/ms525807(v=vs.90)>`_
     """  # noqa: E501
 
     APPLICATION_HOST_CONFIG = "sysvol/windows/system32/inetsrv/config/applicationHost.config"
@@ -91,10 +91,10 @@ class IISLogsPlugin(plugin.Plugin):
 
         This format is not the default IIS log format.
 
-        References:
-            - https://docs.microsoft.com/en-us/previous-versions/iis/6.0-sdk/ms525807(v=vs.90)#iis-log-file-format
-            - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc728311(v=ws.10)
-            - https://learn.microsoft.com/en-us/iis/configuration/system.applicationHost/sites/site/logFile/#attributes-logFormat-IIS
+        Sources:
+            - `<https://docs.microsoft.com/en-us/previous-versions/iis/6.0-sdk/ms525807(v=vs.90)#iis-log-file-format>`_
+            - `<https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc728311(v=ws.10)>`_
+            - `<https://learn.microsoft.com/en-us/iis/configuration/system.applicationHost/sites/site/logFile/>`_
         """  # noqa: E501
 
         tzinfo = self.target.datetime.tzinfo
@@ -149,10 +149,10 @@ class IISLogsPlugin(plugin.Plugin):
 
         This is the default logging format for IIS [^3].
 
-        References:
-            - https://docs.microsoft.com/en-us/previous-versions/iis/6.0-sdk/ms525807(v=vs.90)#w3c-extended-log-file-format
-            - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc786596(v=ws.10)
-            - https://learn.microsoft.com/en-us/iis/configuration/system.applicationHost/sites/site/logFile/#attributes-logFormat-W3C
+        Sources:
+            - `<https://docs.microsoft.com/en-us/previous-versions/iis/6.0-sdk/ms525807(v=vs.90)#w3c-extended-log-file-format>`_
+            - `<https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc786596(v=ws.10)>`_
+            - `<https://learn.microsoft.com/en-us/iis/configuration/system.applicationHost/sites/site/logFile/>`_
         """  # noqa: E501
 
         basic_fields = {

--- a/dissect/target/plugins/apps/webservers/nginx.py
+++ b/dissect/target/plugins/apps/webservers/nginx.py
@@ -53,7 +53,7 @@ class NginxPlugin(plugin.Plugin):
     def access(self) -> Iterator[WebserverAccessLogRecord]:
         """Return contents of NGINX access log files in unified WebserverAccessLogRecord format.
 
-        Resources:
+        References:
             - https://docs.nginx.com/nginx/admin-guide/monitoring/logging/#access_log
             - http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format
         """

--- a/dissect/target/plugins/child/virtuozzo.py
+++ b/dissect/target/plugins/child/virtuozzo.py
@@ -16,7 +16,7 @@ class VirtuozzoChildTargetPlugin(ChildTargetPlugin):
               <container-uuid>/
               <container-uuid>/
 
-    Sources:
+    References:
         - https://docs.virtuozzo.com/virtuozzo_hybrid_server_7_command_line_reference/managing-system/configuration-files.html
     """  # noqa: E501
 

--- a/dissect/target/plugins/child/wsl.py
+++ b/dissect/target/plugins/child/wsl.py
@@ -31,7 +31,7 @@ class WSLChildTargetPlugin(ChildTargetPlugin):
     Windows WSL VHDX conatiners are stored at ``%AppData%\\Local\\Packages\\$DistFolder\\LocalState\\ext4.vhdx``,
     where ``$DistFolder`` will be substituted with a unix distribution folder.
 
-    Sources:
+    References:
         - https://www.osdfcon.org/presentations/2020/Asif-Matadar_Investigating-WSL-Endpoints.pdf
         - https://www.sans.org/white-papers/39330/
     """  # noqa: E501

--- a/dissect/target/plugins/filesystem/ntfs/mft.py
+++ b/dissect/target/plugins/filesystem/ntfs/mft.py
@@ -121,7 +121,7 @@ class MftPlugin(Plugin):
 
         The Master File Table (MFT) contains primarily metadata about every file and folder on a NFTS filesystem.
 
-        Sources:
+        References:
             - https://docs.microsoft.com/en-us/windows/win32/fileio/master-file-table
         """
 

--- a/dissect/target/plugins/filesystem/ntfs/mft_timeline.py
+++ b/dissect/target/plugins/filesystem/ntfs/mft_timeline.py
@@ -103,7 +103,7 @@ class MftTimelinePlugin(Plugin):
 
         The Master File Table (MFT) contains metadata about every file and folder on a NFTS filesystem.
 
-        Sources:
+        References:
             - https://docs.microsoft.com/en-us/windows/win32/fileio/master-file-table
         """
         for fs in self.target.filesystems:

--- a/dissect/target/plugins/filesystem/ntfs/usnjrnl.py
+++ b/dissect/target/plugins/filesystem/ntfs/usnjrnl.py
@@ -35,7 +35,7 @@ class UsnjrnlPlugin(Plugin):
         The Update Sequence Number Journal (UsnJrnl) is a feature of an NTFS file system and contains information about
         filesystem activities. Each volume has its own UsnJrnl.
 
-        Sources:
+        References:
             - https://en.wikipedia.org/wiki/USN_Journal
             - https://velociraptor.velocidex.com/the-windows-usn-journal-f0c55c9010e
         """

--- a/dissect/target/plugins/filesystem/unix/suid.py
+++ b/dissect/target/plugins/filesystem/unix/suid.py
@@ -22,7 +22,7 @@ class SuidPlugin(Plugin):
         SUID binary owned by the root user can be run with root privileges by any user. Such binaries can be leveraged
         by an adversary to perform privilege escalation.
 
-        Sources:
+        References:
             - https://steflan-security.com/linux-privilege-escalation-suid-binaries/
         """
         for record in self.target.walkfs():

--- a/dissect/target/plugins/os/unix/log/atop.py
+++ b/dissect/target/plugins/os/unix/log/atop.py
@@ -265,7 +265,7 @@ class AtopPlugin(Plugin):
         and for every process (and thread) it shows e.g. the CPU utilization, memory growth, disk utilization,
         priority, username, state, and exit code.
 
-        Sources:
+        References:
             - https://diablohorn.com/2022/11/17/parsing-atop-files-with-python-dissect-cstruct/
 
         Yields AtopRecord with fields:

--- a/dissect/target/plugins/os/unix/log/audit.py
+++ b/dissect/target/plugins/os/unix/log/audit.py
@@ -56,7 +56,7 @@ class AuditPlugin(Plugin):
         The audit log file on a Linux machine stores security-relevant information.
         Based on pre-configured rules. Log messages consist of space delimited key=value pairs.
 
-        Sources:
+        References:
             - https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security_guide/chap-system_auditing
             - https://linux-audit.com/linux-audit-log-files-in-var-log-audit/
             - https://man7.org/linux/man-pages/man8/auditd.8.html

--- a/dissect/target/plugins/os/unix/log/btmp.py
+++ b/dissect/target/plugins/os/unix/log/btmp.py
@@ -35,7 +35,7 @@ class BtmpPlugin(Plugin):
 
         On a Linux system, failed login attempts are stored in the btmp file located in the var/log/ folder.
 
-        Sources:
+        References:
             - https://en.wikipedia.org/wiki/Utmp
             - https://www.thegeekdiary.com/what-is-the-purpose-of-utmp-wtmp-and-btmp-files-in-linux/
         """

--- a/dissect/target/plugins/os/unix/log/lastlog.py
+++ b/dissect/target/plugins/os/unix/log/lastlog.py
@@ -63,7 +63,7 @@ class LastLogPlugin(Plugin):
 
         The lastlog file contains the most recent logins of all users on a Unix based operating system.
 
-        Sources:
+        References:
             - https://www.tutorialspoint.com/unix_commands/lastlog.htm
         """
         try:

--- a/dissect/target/plugins/os/unix/log/messages.py
+++ b/dissect/target/plugins/os/unix/log/messages.py
@@ -49,7 +49,7 @@ class MessagesPlugin(Plugin):
         startups and shutdowns, change in the network configuration, etc. Aims to store valuable, non-debug and
         non-critical messages. This log should be considered the "general system activity" log.
 
-        Sources:
+        References:
             - https://geek-university.com/linux/var-log-messages-file/
             - https://www.geeksforgeeks.org/file-timestamps-mtime-ctime-and-atime-in-linux/
         """

--- a/dissect/target/plugins/os/unix/log/wtmp.py
+++ b/dissect/target/plugins/os/unix/log/wtmp.py
@@ -35,7 +35,7 @@ class WtmpPlugin(Plugin):
         logins at which terminals, logouts, system events and current status of the system, system boot time
         (used by uptime) etc.
 
-        Sources:
+        References:
             - https://www.thegeekdiary.com/what-is-the-purpose-of-utmp-wtmp-and-btmp-files-in-linux/
         """
         wtmp_paths = self.target.fs.glob("/var/log/wtmp*")

--- a/dissect/target/plugins/os/windows/activitiescache.py
+++ b/dissect/target/plugins/os/windows/activitiescache.py
@@ -42,7 +42,7 @@ class ActivitiesCachePlugin(Plugin):
     """Plugin that parses the ActivitiesCache.db on newer Windows 10 machines.
 
     Resources:
-        https://cclgroupltd.com/windows-10-timeline-forensic-artefacts/
+        https://www.cclsolutionsgroup.com/resources/technical-papers
         https://salt4n6.com/2018/05/03/windows-10-timeline-forensic-artefacts/
     """
 
@@ -143,6 +143,6 @@ class ActivitiesCachePlugin(Plugin):
 def mkts(ts):
     """Timestamps inside ActivitiesCache.db are stored in a Unix-like format.
 
-    Source: https://salt4n6.com/2018/05/03/windows-10-timeline-forensic-artefacts/#timestamps
+    Source: https://salt4n6.com/2018/05/03/windows-10-timeline-forensic-artefacts/
     """
     return from_unix(ts) if ts else None

--- a/dissect/target/plugins/os/windows/activitiescache.py
+++ b/dissect/target/plugins/os/windows/activitiescache.py
@@ -41,7 +41,7 @@ ActivitiesCacheRecord = create_extended_descriptor([UserRecordDescriptorExtensio
 class ActivitiesCachePlugin(Plugin):
     """Plugin that parses the ActivitiesCache.db on newer Windows 10 machines.
 
-    Resources:
+    References:
         https://www.cclsolutionsgroup.com/resources/technical-papers
         https://salt4n6.com/2018/05/03/windows-10-timeline-forensic-artefacts/
     """
@@ -72,7 +72,7 @@ class ActivitiesCachePlugin(Plugin):
         Currently only puts the database records straight into Flow Records. Ideally
         we do some additional parsing on this later.
 
-        Sources:
+        References:
             - https://artifacts-kb.readthedocs.io/en/latest/sources/windows/ActivitiesCacheDatabase.html
             - https://salt4n6.com/2018/05/03/windows-10-timeline-forensic-artefacts/
 

--- a/dissect/target/plugins/os/windows/adpolicy.py
+++ b/dissect/target/plugins/os/windows/adpolicy.py
@@ -45,7 +45,7 @@ ADPolicyRecord = TargetRecordDescriptor(
 class ADPolicyPlugin(Plugin):
     """Plugin that parses AD policies present on Windows Server and Desktop systems
 
-    Sources:
+    References:
         - https://docs.microsoft.com/en-us/previous-versions/windows/desktop/policy/registry-policy-file-format
     """
 
@@ -69,7 +69,7 @@ class ADPolicyPlugin(Plugin):
         An Active Directory (AD) maintains global policies that should be adhered by all systems in the domain.
         Example policies are password policies, account lockout policies and group policies.
 
-        Sources:
+        References:
             - https://www.windows-active-directory.com/windows-active-directory-policies.html
         """
         for policy_dir in self.dirs:

--- a/dissect/target/plugins/os/windows/amcache.py
+++ b/dissect/target/plugins/os/windows/amcache.py
@@ -321,7 +321,7 @@ class AmcachePlugin(AmcachePluginOldMixin, Plugin):
         • InventoryApplicationFile
         * InventoryApplicationShortcut
 
-    Resources:
+    References:
         https://binaryforay.blogspot.com/2015/04/appcompatcache-changes-in-windows-10.html
         https://www.ssi.gouv.fr/uploads/2019/01/anssi-coriin_2019-analysis_amcache.pdf
         https://aboutdfir.com/new-windows-11-pro-22h2-evidence-of-execution-artifact/
@@ -356,7 +356,7 @@ class AmcachePlugin(AmcachePluginOldMixin, Plugin):
     def parse_inventory_application(self):
         """Parse Root\\InventoryApplication registry key subkeys.
 
-        Resources:
+        References:
             - https://docs.microsoft.com/en-us/windows/privacy/required-windows-diagnostic-data-events-and-fields-2004#microsoftwindowsinventorycoreinventoryapplicationadd
 
         """  # noqa
@@ -426,7 +426,7 @@ class AmcachePlugin(AmcachePluginOldMixin, Plugin):
     def parse_inventory_application_file(self):
         """Parse Root\\InventoryApplicationFile registry key subkeys.
 
-        Resources:
+        References:
             - https://docs.microsoft.com/en-us/windows/privacy/required-windows-diagnostic-data-events-and-fields-2004#microsoftwindowsinventorycoreinventoryapplicationadd
 
         """  # noqa
@@ -552,7 +552,7 @@ class AmcachePlugin(AmcachePluginOldMixin, Plugin):
         Amcache is a registry hive that stores information about executed programs. The InventoryApplication key holds
         all application objects that are in cache.
 
-        Sources:
+        References:
             - https://docs.microsoft.com/en-us/windows/privacy/basic-level-windows-diagnostic-events-and-fields-1803
             - https://www.andreafortuna.org/2017/10/16/amcache-and-shimcache-in-forensic-analysis/
         """
@@ -566,7 +566,7 @@ class AmcachePlugin(AmcachePluginOldMixin, Plugin):
         Amcache is a registry hive that stores information about executed programs. The InventoryApplicationFile key
         holds the application files that are in cache.
 
-        Sources:
+        References:
             - https://docs.microsoft.com/en-us/windows/privacy/basic-level-windows-diagnostic-events-and-fields-1803
             - https://www.andreafortuna.org/2017/10/16/amcache-and-shimcache-in-forensic-analysis/
         """
@@ -580,7 +580,7 @@ class AmcachePlugin(AmcachePluginOldMixin, Plugin):
         Amcache is a registry hive that stores information about executed programs. The InventoryDriverBinary key holds
         the driver binaries that are in cache.
 
-        Sources:
+        References:
             - https://binaryforay.blogspot.com/2017/10/amcache-still-rules-everything-around.html
             - https://docs.microsoft.com/en-us/windows/privacy/basic-level-windows-diagnostic-events-and-fields-1803
             - https://www.andreafortuna.org/2017/10/16/amcache-and-shimcache-in-forensic-analysis/
@@ -596,7 +596,7 @@ class AmcachePlugin(AmcachePluginOldMixin, Plugin):
         field holds the shortcuts that are in cache. The key values contain information about the target of the lnk
         file.
 
-        Sources:
+        References:
             - https://binaryforay.blogspot.com/2017/10/amcache-still-rules-everything-around.html
             - https://docs.microsoft.com/en-us/windows/privacy/basic-level-windows-diagnostic-events-and-fields-1803
             - https://www.andreafortuna.org/2017/10/16/amcache-and-shimcache-in-forensic-analysis/
@@ -611,7 +611,7 @@ class AmcachePlugin(AmcachePluginOldMixin, Plugin):
         Amcache is a registry hive that stores information about executed programs. The InventoryDeviceContainer key
         holds the device containers that are in cache. Example devices are bluetooth, printers, audio, etc.
 
-        Sources:
+        References:
             - https://binaryforay.blogspot.com/2017/10/amcache-still-rules-everything-around.html
             - https://docs.microsoft.com/en-us/windows/privacy/basic-level-windows-diagnostic-events-and-fields-1803
             - https://www.andreafortuna.org/2017/10/16/amcache-and-shimcache-in-forensic-analysis/
@@ -626,7 +626,7 @@ class AmcachePlugin(AmcachePluginOldMixin, Plugin):
         TODO: Research C:\\Windows\\appcompat\\pca\\PcaGeneralDb0.txt and
               C:\\Windows\\appcompat\\pca\\PcaGeneralDb1.txt files.
 
-        Sources:
+        References:
             - https://aboutdfir.com/new-windows-11-pro-22h2-evidence-of-execution-artifact/
         """
 

--- a/dissect/target/plugins/os/windows/catroot.py
+++ b/dissect/target/plugins/os/windows/catroot.py
@@ -52,7 +52,7 @@ class CatrootPlugin(Plugin):
         A catalog file contains a collection of cryptographic hashes, or thumbprints. These files are generally used to
         verify the integrity of Windows operating system files, instead of per-file authenticode signatures.
 
-        Sources:
+        References:
             - https://www.thewindowsclub.com/catroot-catroot2-folder-reset-windows
             - https://docs.microsoft.com/en-us/windows-hardware/drivers/install/catalog-files
 

--- a/dissect/target/plugins/os/windows/cim.py
+++ b/dissect/target/plugins/os/windows/cim.py
@@ -55,7 +55,7 @@ class CimPlugin(Plugin):
         action to be performed, including executing a command, running a script, adding an entry to a log, or sending
         an email. WMI Filters define conditions that will trigger a Consumer.
 
-        Sources:
+        References:
             - https://learn-powershell.net/2013/08/14/powershell-and-events-permanent-wmi-event-subscriptions/
             - https://www.mandiant.com/resources/dissecting-one-ofap
             - https://support.sophos.com/support/s/article/KB-000038535?language=en_US&c__displayLanguage=en_US

--- a/dissect/target/plugins/os/windows/clfs.py
+++ b/dissect/target/plugins/os/windows/clfs.py
@@ -69,7 +69,7 @@ class ClfsPlugin(Plugin):
 
         Containers are used to store the transactional logs in the form of records.
 
-        Sources:
+        References:
             - https://docs.microsoft.com/en-us/windows-hardware/drivers/kernel/introduction-to-the-common-log-file-system
         """  # noqa: E501
 

--- a/dissect/target/plugins/os/windows/env.py
+++ b/dissect/target/plugins/os/windows/env.py
@@ -329,7 +329,7 @@ class EnvironmentVariablePlugin(Plugin):
         Examples variables are PATH, HOME and TEMP. Adversaries may alter or create environment variables to exploit
         a system.
 
-        Sources:
+        References:
             - https://en.wikipedia.org/wiki/Environment_variable
             - https://www.elttam.com/blog/env/
         """

--- a/dissect/target/plugins/os/windows/exchange/exchange.py
+++ b/dissect/target/plugins/os/windows/exchange/exchange.py
@@ -31,7 +31,7 @@ class ExchangePlugin(Plugin):
         A Transport Agent is additional software on a Microsoft Exchange server that allows for custom processing of
         email messages that go through the transport pipeline.
 
-        Sources:
+        References:
             - https://docs.microsoft.com/en-us/exchange/mail-flow/transport-agents/transport-agents?view=exchserver-2019
         """
         for path in self.install_paths():

--- a/dissect/target/plugins/os/windows/generic.py
+++ b/dissect/target/plugins/os/windows/generic.py
@@ -135,7 +135,7 @@ class GenericPlugin(Plugin):
         programs are located. Adversaries may add the directories in which they have stored their (malicious) binaries.
 
         Sources:
-            - https://en.wikipedia.org/wiki/PATH_(variable)
+            - `<https://en.wikipedia.org/wiki/PATH_(variable)>`_
         """
         key = "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment"
         for r in self.target.registry.keys(key):
@@ -413,8 +413,8 @@ class GenericPlugin(Plugin):
         exploited by an adversary to hide malicious commands or leverage as a persistence mechanism
 
         Sources:
-            - https://devblogs.microsoft.com/oldnewthing/20071121-00/?p=24433
-            - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc779439(v=ws.10)?redirectedfrom=MSDN
+            - `<https://devblogs.microsoft.com/oldnewthing/20071121-00/?p=24433>`_
+            - `<https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc779439(v=ws.10)?redirectedfrom=MSDN>`_
         """  # noqa: E501
         keys = [
             ("HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Command Processor", "AutoRun"),
@@ -497,9 +497,9 @@ class GenericPlugin(Plugin):
         reboot. Can be used to hunt for malicious binaries.
 
         Sources:
-            - https://forensicatorj.wordpress.com/2014/06/25/interpreting-the-pendingfilerenameoperations-registry-key-for-forensics/
-            - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-2000-server/cc960241(v=technet.10)?redirectedfrom=MSDN
-            - https://qtechbabble.wordpress.com/2020/06/26/use-pendingfilerenameoperations-registry-key-to-automatically-delete-a-file-on-reboot/
+            - `<https://forensicatorj.wordpress.com/2014/06/25/interpreting-the-pendingfilerenameoperations-registry-key-for-forensics/>`_
+            - `<https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-2000-server/cc960241(v=technet.10)?redirectedfrom=MSDN>`_
+            - `<https://qtechbabble.wordpress.com/2020/06/26/use-pendingfilerenameoperations-registry-key-to-automatically-delete-a-file-on-reboot/>`_
         """  # noqa: E501
         key = "HKLM\\System\\CurrentControlSet\\Control\\Session Manager"
         for r in self.target.registry.keys(key):

--- a/dissect/target/plugins/os/windows/generic.py
+++ b/dissect/target/plugins/os/windows/generic.py
@@ -134,8 +134,8 @@ class GenericPlugin(Plugin):
         PATH is an environment variable on an operating system that specifies a set of directories where executable
         programs are located. Adversaries may add the directories in which they have stored their (malicious) binaries.
 
-        Sources:
-            - `<https://en.wikipedia.org/wiki/PATH_(variable)>`_
+        References:
+            - https://en.wikipedia.org/wiki/PATH_%28variable%29
         """
         key = "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment"
         for r in self.target.registry.keys(key):
@@ -147,7 +147,7 @@ class GenericPlugin(Plugin):
 
         Corporate Windows systems are usually connected to a domain (active directory).
 
-        Sources:
+        References:
             - https://en.wikipedia.org/wiki/Active_Directory
         """
         keys = [
@@ -198,7 +198,7 @@ class GenericPlugin(Plugin):
 
         The value of the registry key is stored as a Unix epoch timestamp.
 
-        Resources:
+        References:
             - https://winreg-kb.readthedocs.io/en/latest/_modules/winregrc/sysinfo.html?highlight=_ParseInstallDate
             - https://www.forensics-matters.com/2018/09/15/find-out-windows-installation-date/
         """
@@ -221,7 +221,7 @@ class GenericPlugin(Plugin):
         HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows are loaded by
         user32.dll into every process that loads user32.dll.
 
-        Sources:
+        References:
             - https://attack.mitre.org/techniques/T1546/010/
             - https://docs.microsoft.com/en-us/windows/win32/win7appqual/appinit-dlls-in-windows-7-and-windows-server-2008-r2?redirectedfrom=MSDN
             - https://docs.microsoft.com/en-US/windows/win32/dlls/secure-boot-and-appinit-dlls
@@ -268,7 +268,7 @@ class GenericPlugin(Plugin):
         the version from the application folder will be ignored). However, these registry keys can still be leveraged
         to perform DLL injection.
 
-        Sources:
+        References:
             - https://www.apriorit.com/dev-blog/257-dll-injection
         """
         key = "HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Session Manager\\KnownDlls"
@@ -297,7 +297,7 @@ class GenericPlugin(Plugin):
         registry key holds the Windows tasks that cannot be performed when Windows is running, the Execute registry key
         should never be populated when Windows is installed. Can be leveraged as persistence mechanisms.
 
-        Sources:
+        References:
             - https://en.wikipedia.org/wiki/Session_Manager_Subsystem
             - https://www.microsoftpressstore.com/articles/article.aspx?p=2762082&seqNum=2
         """
@@ -352,7 +352,7 @@ class GenericPlugin(Plugin):
         guest access. These can thus be accessed without authentication and can be leveraged for latteral movement
         and/or privilege escalation.
 
-        Sources:
+        References:
             - https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/network-access-restrict-anonymous-access-to-named-pipes-and-shares
         """  # noqa: E501
         key = "HKLM\\System\\CurrentControlSet\\Services\\LanManServer\\Parameters"
@@ -412,9 +412,9 @@ class GenericPlugin(Plugin):
         (cmd.exe) is started. Since these commands are not shown to the user in the Command Processor, it can be
         exploited by an adversary to hide malicious commands or leverage as a persistence mechanism
 
-        Sources:
-            - `<https://devblogs.microsoft.com/oldnewthing/20071121-00/?p=24433>`_
-            - `<https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc779439(v=ws.10)?redirectedfrom=MSDN>`_
+        References:
+            - https://devblogs.microsoft.com/oldnewthing/20071121-00/?p=24433
+            - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc779439%28v=ws.10%29?redirectedfrom=MSDN
         """  # noqa: E501
         keys = [
             ("HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Command Processor", "AutoRun"),
@@ -447,7 +447,7 @@ class GenericPlugin(Plugin):
         shell that is used when a Windows system is started in "Safe Mode with Command Prompt". Can be leveraged as a
         persistence mechanism.
 
-        Sources:
+        References:
             - https://technet.microsoft.com/en-us/library/cc976124.aspx
         """
         key = "HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Safeboot"
@@ -496,10 +496,10 @@ class GenericPlugin(Plugin):
         The PendingFileRenameOperations registry key value contains information about files that will be renamed on
         reboot. Can be used to hunt for malicious binaries.
 
-        Sources:
-            - `<https://forensicatorj.wordpress.com/2014/06/25/interpreting-the-pendingfilerenameoperations-registry-key-for-forensics/>`_
-            - `<https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-2000-server/cc960241(v=technet.10)?redirectedfrom=MSDN>`_
-            - `<https://qtechbabble.wordpress.com/2020/06/26/use-pendingfilerenameoperations-registry-key-to-automatically-delete-a-file-on-reboot/>`_
+        References:
+            - https://forensicatorj.wordpress.com/2014/06/25/interpreting-the-pendingfilerenameoperations-registry-key-for-forensics/
+            - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-2000-server/cc960241%28v=technet.10%29?redirectedfrom=MSDN
+            - https://qtechbabble.wordpress.com/2020/06/26/use-pendingfilerenameoperations-registry-key-to-automatically-delete-a-file-on-reboot/
         """  # noqa: E501
         key = "HKLM\\System\\CurrentControlSet\\Control\\Session Manager"
         for r in self.target.registry.keys(key):
@@ -545,7 +545,7 @@ class GenericPlugin(Plugin):
     def winsocknamespaceprovider(self):
         """Return available protocols stored in the Winsock catalog database.
 
-        Sources:
+        References:
             - https://docs.microsoft.com/en-us/windows/win32/winsock/name-space-service-providers-2?redirectedfrom=MSDN
         """
         keys = [

--- a/dissect/target/plugins/os/windows/log/etl.py
+++ b/dissect/target/plugins/os/windows/log/etl.py
@@ -105,7 +105,7 @@ class EtlPlugin(Plugin):
         application or kernel-mode driver that uses Event Tracing for Windows (ETW) technology to generate trace
         messages or trace events) is generating trace messages.
 
-        Sources:
+        References:
             - https://www.hecfblog.com/2018/06/etw-event-tracing-for-windows-and-etl.html
             - https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/trace-log
 

--- a/dissect/target/plugins/os/windows/log/evtx.py
+++ b/dissect/target/plugins/os/windows/log/evtx.py
@@ -40,7 +40,7 @@ class EvtxPlugin(WindowsEventlogsMixin, plugin.Plugin):
         diagnose a system or find future issues. Up until Windows XP the extension .evt was used, hereafter .evtx
         became the new standard.
 
-        Sources:
+        References:
             - https://www.techtarget.com/searchwindowsserver/definition/Windows-event-log
             - https://serverfault.com/questions/441050/what-are-the-differences-between-windows-evt-and-evtx-log-files
 

--- a/dissect/target/plugins/os/windows/log/pfro.py
+++ b/dissect/target/plugins/os/windows/log/pfro.py
@@ -38,7 +38,7 @@ class PfroPlugin(Plugin):
         files that are locked or being used and that will be renamed on reboot. This is related to the filerenameop
         plugin.
 
-        Sources:
+        References:
             - https://social.technet.microsoft.com/Forums/en-US/9b66a7b0-16d5-4d22-be4e-51df12db9f80/issue-understanding-pfro-log
             - https://community.ccleaner.com/topic/49106-pending-file-rename-operations-log/
 

--- a/dissect/target/plugins/os/windows/notifications.py
+++ b/dissect/target/plugins/os/windows/notifications.py
@@ -73,7 +73,7 @@ class NotificationsPlugin(Plugin):
     def wpndatabase(self):
         """Returns Windows Notifications from wpndatabase.db (post Windows 10 Anniversary).
 
-        Resources:
+        References:
             - https://inc0x0.com/2018/10/windows-10-notification-database/
         """
         for user, wpndatabase in self.wpndb_files:

--- a/dissect/target/plugins/os/windows/powershell.py
+++ b/dissect/target/plugins/os/windows/powershell.py
@@ -37,7 +37,7 @@ class PowerShellHistoryPlugin(Plugin):
         The PowerShell ConsoleHost_history.txt file contains information about the commands executed with PowerShell in
         a terminal. No data is recorded from terminal-less PowerShell sessions.
 
-        Sources:
+        References:
             - https://0xdf.gitlab.io/2018/11/08/powershell-history-file.html
         """
         for user, path in self._history:

--- a/dissect/target/plugins/os/windows/prefetch.py
+++ b/dissect/target/plugins/os/windows/prefetch.py
@@ -255,7 +255,7 @@ class PrefetchPlugin(Plugin):
         Prefetch is a memory management feature in Windows. It contains information (for example run count and
         timestamp) about executable applications that have been executed recently or are frequently executed.
 
-        Sources:
+        References:
             - https://www.geeksforgeeks.org/prefetch-files-in-windows/
 
         Yields PrefetchRecords with fields:

--- a/dissect/target/plugins/os/windows/regf/7zip.py
+++ b/dissect/target/plugins/os/windows/regf/7zip.py
@@ -80,7 +80,7 @@ class SevenZipPlugin(Plugin):
         additional registry keys, such as ArcHistory and FolderHistory. This might provide insight in which files have
         been archived by 7-Zip.
 
-        Sources:
+        References:
             - https://www.7-zip.org/
         """
         target = self.target

--- a/dissect/target/plugins/os/windows/regf/auditpol.py
+++ b/dissect/target/plugins/os/windows/regf/auditpol.py
@@ -145,7 +145,7 @@ class AuditpolPlugin(Plugin):
         For Windows, the audit policy settings are stored in the HKEY_LOCAL_MACHINE\\Security\\Policy\\PolAdtEv registry
         key. It shows for each possible audit event if it is logged.
 
-        Sources:
+        References:
             - https://countuponsecurity.com/tag/poladtev/
         """
         for regf in self.target.registry.keys(self.KEY):

--- a/dissect/target/plugins/os/windows/regf/clsid.py
+++ b/dissect/target/plugins/os/windows/regf/clsid.py
@@ -31,7 +31,7 @@ class CLSIDPlugin(Plugin):
     HKEY_CURRENT_USER\\Software\\Classes\\CLSID and HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\CLSID. Malware may make use
     of the CLSID system to launch themselves automatically or when certain conditions are triggered.
 
-    Sources:
+    References:
         - https://docs.microsoft.com/en-us/windows/win32/com/clsid-key-hklm
         - https://www.enigmasoftware.com/what-is-clsid-registry-key/
     """

--- a/dissect/target/plugins/os/windows/regf/mru.py
+++ b/dissect/target/plugins/os/windows/regf/mru.py
@@ -110,7 +110,7 @@ class MRUPlugin(Plugin):
 
     The Windows registry contains various keys about Most Recently Used (MRU) files.
 
-    Sources:
+    References:
         - https://winreg-kb.readthedocs.io/en/latest/sources/explorer-keys/Most-recently-used.html
     """
 
@@ -126,7 +126,7 @@ class MRUPlugin(Plugin):
         The ``HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\RunMRU`` registry key contains information
         about the most recent commands that have been performed by the Run application
 
-        Sources:
+        References:
             - https://digitalf0rensics.wordpress.com/2014/01/17/windows-registry-and-forensics-part2/
         """
         KEY = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\RunMRU"
@@ -142,7 +142,7 @@ class MRUPlugin(Plugin):
         information about the last 10 documents that the currently logged on user accessed or executed via Windows
         Explorer.
 
-        Sources:
+        References:
             - https://digitalf0rensics.wordpress.com/2014/01/17/windows-registry-and-forensics-part2/
         """
 
@@ -158,7 +158,7 @@ class MRUPlugin(Plugin):
         The ``HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComDlg32\\OpenSaveMRU`` registry key
         contains information about the most recently opened or saved files.
 
-        Sources:
+        References:
             - https://digitalf0rensics.wordpress.com/2014/01/17/windows-registry-and-forensics-part2/
         """
 
@@ -176,7 +176,7 @@ class MRUPlugin(Plugin):
         OpenSaveMRU registry key. Also each value tracks the directory location for the last file that was accessed by
         that application.
 
-        Sources:
+        References:
             - https://digitalf0rensics.wordpress.com/2014/01/17/windows-registry-and-forensics-part2/
         """
 
@@ -218,7 +218,7 @@ class MRUPlugin(Plugin):
           - ``HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\WordWheelQuery``:
             This registry key contains the most recent search history from Windows Explorer. (Windows >=7)
 
-        Sources:
+        References:
             - https://digitalf0rensics.wordpress.com/2014/01/17/windows-registry-and-forensics-part2/
 
         Known categories:
@@ -257,7 +257,7 @@ class MRUPlugin(Plugin):
         The HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Map Network Drive MRU registry key contains
         information about the most recently used mapped network drives.
 
-        Sources:
+        References:
             - https://winreg-kb.readthedocs.io/en/latest/sources/explorer-keys/Most-recently-used.html#keys-with-a-mrulist-value
         """  # noqa: E501
 

--- a/dissect/target/plugins/os/windows/regf/muicache.py
+++ b/dissect/target/plugins/os/windows/regf/muicache.py
@@ -43,7 +43,7 @@ class MuiCachePlugin(Plugin):
         the Multilingual User Interface service in Windows. MUIcache references the file description contained within
         the executable's resource section and populates that value.
 
-        Sources:
+        References:
             - https://www.magnetforensics.com/blog/forensic-analysis-of-muicache-files-in-windows/
             - https://forensafe.com/blogs/muicache.html
 

--- a/dissect/target/plugins/os/windows/regf/nethist.py
+++ b/dissect/target/plugins/os/windows/regf/nethist.py
@@ -37,7 +37,7 @@ class NethistPlugin(Plugin):
         HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Networklist\\Profiles registry keys contain information
         about the networks to which the system has been connected, both wireless and wired.
 
-        Sources:
+        References:
             - https://www.weaklink.org/2016/11/windows-network-profile-registry-keys/
         """
         for key in self.target.registry.keys(self.KEY):

--- a/dissect/target/plugins/os/windows/regf/regf.py
+++ b/dissect/target/plugins/os/windows/regf/regf.py
@@ -43,7 +43,7 @@ class RegfPlugin(Plugin):
         The Windows Registry is a hierarchical database that stores low-level settings for the Windows operating system
         and for applications that opt to use it.
 
-        Sources:
+        References:
             - https://en.wikipedia.org/wiki/Windows_Registry
 
         Yields RegistryKeyRecords and RegistryValueRecords

--- a/dissect/target/plugins/os/windows/regf/runkeys.py
+++ b/dissect/target/plugins/os/windows/regf/runkeys.py
@@ -57,7 +57,7 @@ class RunKeysPlugin(Plugin):
         time the user logs on and the RunOnce key makes the program run once and deletes the key after. Often leveraged
         as a persistence mechanism.
 
-        Sources:
+        References:
             - https://docs.microsoft.com/en-us/windows/win32/setupapi/run-and-runonce-registry-keys
 
         Yields RunKeyRecords with fields:

--- a/dissect/target/plugins/os/windows/regf/shellbags.py
+++ b/dissect/target/plugins/os/windows/regf/shellbags.py
@@ -264,7 +264,7 @@ class ShellBagsPlugin(Plugin):
     """Windows Shellbags plugin.
 
     References:
-        https://github.com/libyal/libfwsi
+        - https://github.com/libyal/libfwsi
     """
 
     KEYS = [

--- a/dissect/target/plugins/os/windows/regf/shellbags.py
+++ b/dissect/target/plugins/os/windows/regf/shellbags.py
@@ -263,7 +263,7 @@ ShellBagRecord = create_extended_descriptor([RegistryRecordDescriptorExtension, 
 class ShellBagsPlugin(Plugin):
     """Windows Shellbags plugin.
 
-    Resources:
+    References:
         https://github.com/libyal/libfwsi
     """
 
@@ -292,7 +292,7 @@ class ShellBagsPlugin(Plugin):
         Shellbags are registry keys to improve user experience when using Windows Explorer. It stores information about
         for example file/folder creation time and access time.
 
-        Sources:
+        References:
             - https://www.hackingarticles.in/forensic-investigation-shellbags/
         """
         for regkey in self.bagkeys:

--- a/dissect/target/plugins/os/windows/regf/shimcache.py
+++ b/dissect/target/plugins/os/windows/regf/shimcache.py
@@ -316,7 +316,7 @@ class ShimcachePlugin(Plugin):
         compatibility purposes. Since it contains information about files such as the last
         modified date and the file size, it can be useful in forensic investigations.
 
-        Sources:
+        References:
             - https://www.andreafortuna.org/2017/10/16/amcache-and-shimcache-in-forensic-analysis/
 
         Yields ShimcacheRecords with the following fields:

--- a/dissect/target/plugins/os/windows/regf/userassist.py
+++ b/dissect/target/plugins/os/windows/regf/userassist.py
@@ -68,7 +68,7 @@ class UserAssistPlugin(Plugin):
         The UserAssist registry keys contain information about programs that were recently executed on the system.
         Programs launch via the commandline are not registered within these registry keys.
 
-        Sources:
+        References:
             - https://www.magnetforensics.com/blog/artifact-profile-userassist/
             - https://www.aldeid.com/wiki/Windows-userassist-keys
 

--- a/dissect/target/plugins/os/windows/sam.py
+++ b/dissect/target/plugins/os/windows/sam.py
@@ -281,7 +281,7 @@ def decrypt_single_hash(rid: int, samkey: bytes, enc_hash: bytes, apwd: bytes) -
 class SamPlugin(Plugin):
     """SAM plugin.
 
-    Resources:
+    References:
         MS-SAMR Specification
         Reversing samsrv.dll
         https://github.com/gentilkiwi/mimikatz
@@ -354,7 +354,7 @@ class SamPlugin(Plugin):
         The Security Account Manager (SAM) registry hive contains registry keys that store usernames, full names and
         passwords in a hashed format, either an LM or NT hash.
 
-        Sources:
+        References:
             - https://en.wikipedia.org/wiki/Security_Account_Manager
 
         Yields SamRecords with fields:

--- a/dissect/target/plugins/os/windows/sam.py
+++ b/dissect/target/plugins/os/windows/sam.py
@@ -282,11 +282,11 @@ class SamPlugin(Plugin):
     """SAM plugin.
 
     References:
-        MS-SAMR Specification
-        Reversing samsrv.dll
-        https://github.com/gentilkiwi/mimikatz
-        https://github.com/skelsec/pypykatz
-        https://web.archive.org/web/20190717124313/http://www.beginningtoseethelight.org/ntsecurity/index.htm
+        - MS-SAMR Specification
+        - Reversing samsrv.dll
+        - https://github.com/gentilkiwi/mimikatz
+        - https://github.com/skelsec/pypykatz
+        - https://web.archive.org/web/20190717124313/http://www.beginningtoseethelight.org/ntsecurity/index.htm
     """
 
     SAM_KEY = "HKEY_LOCAL_MACHINE\\SAM\\SAM\\Domains\\Account"

--- a/dissect/target/plugins/os/windows/services.py
+++ b/dissect/target/plugins/os/windows/services.py
@@ -70,7 +70,7 @@ class ServicesPlugin(Plugin):
         The HKLM\\SYSTEM\\CurrentControlSet\\Services registry key contains information about the installed services and
         drivers on the system.
 
-        Sources:
+        References:
             - https://artifacts-kb.readthedocs.io/en/latest/sources/windows/ServicesAndDrivers.html
 
         Yields ServiceRecords with fields:

--- a/dissect/target/plugins/os/windows/sru.py
+++ b/dissect/target/plugins/os/windows/sru.py
@@ -347,7 +347,6 @@ class SRUPlugin(Plugin):
     Sources:
         - https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/monitor-resource-usage-system-monitor?view=sql-server-ver15
         - https://blog.1234n6.com/2019/01/
-        - http://dfir.pro/index.php?link_id=92259
     """  # noqa: E501
 
     __namespace__ = "sru"

--- a/dissect/target/plugins/os/windows/sru.py
+++ b/dissect/target/plugins/os/windows/sru.py
@@ -344,7 +344,7 @@ class SRUPlugin(Plugin):
     The System Resource Usage Monitor (SRUM) stores its information in a SRUDB.dat file. As the names suggests, it
     contains data about resource usage, such as network and memory usage by applications.
 
-    Sources:
+    References:
         - https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/monitor-resource-usage-system-monitor?view=sql-server-ver15
         - https://blog.1234n6.com/2019/01/
     """  # noqa: E501

--- a/dissect/target/plugins/os/windows/startupinfo.py
+++ b/dissect/target/plugins/os/windows/startupinfo.py
@@ -62,7 +62,7 @@ class StartupInfoPlugin(Plugin):
         On a Windows system, the StartupInfo log files contain information about process execution for the first 90
         seconds of user logon activity, such as process name and CPU usage.
 
-        Sources:
+        References:
             - https://www.trustedsec.com/blog/who-left-the-backdoor-open-using-startupinfo-for-the-win/
         """
         for path in self._files:

--- a/dissect/target/plugins/os/windows/tasks.py
+++ b/dissect/target/plugins/os/windows/tasks.py
@@ -383,7 +383,7 @@ class TasksPlugin(Plugin):
         On a Windows system, a scheduled task is a program or script that is executed on a specific time or at specific
         intervals. An adversary may leverage such scheduled tasks to gain persistence on a system.
 
-        Sources:
+        References:
             - https://en.wikipedia.org/wiki/Windows_Task_Scheduler
         """
         for f in self.files:

--- a/dissect/target/plugins/os/windows/ual.py
+++ b/dissect/target/plugins/os/windows/ual.py
@@ -142,7 +142,7 @@ class UalPlugin(Plugin):
     a local server.
 
     Sources:
-        - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/hh849634(v=ws.11)
+        - `<https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/hh849634(v=ws.11)>`_
     """  # noqa: E501
 
     __namespace__ = "ual"

--- a/dissect/target/plugins/os/windows/ual.py
+++ b/dissect/target/plugins/os/windows/ual.py
@@ -141,8 +141,8 @@ class UalPlugin(Plugin):
     server. It helps Windows server administrators to quantify requests from client computers for roles and services on
     a local server.
 
-    Sources:
-        - `<https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/hh849634(v=ws.11)>`_
+    References:
+        - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/hh849634%28v=ws.11%29
     """  # noqa: E501
 
     __namespace__ = "ual"

--- a/dissect/target/plugins/os/windows/wer.py
+++ b/dissect/target/plugins/os/windows/wer.py
@@ -117,7 +117,7 @@ class WindowsErrorReportingPlugin(Plugin):
         information within may be useful for analysis. For example, it may contain the file hash of the crashed
         application within the target_app_id field.
 
-        Sources:
+        References:
             - https://learn.microsoft.com/en-us/windows/win32/wer/windows-error-reporting
             - https://medium.com/dfir-dudes/amcache-is-not-alone-using-wer-files-to-hunt-evil-86bdfdb216d7
 


### PR DESCRIPTION
Website links with a '(' in the URL were not parsed correctly by Sphinx, resulting in broken links. In addition, the word 'References:' is rendered as all caps by Sphinx, whereas in other places 'Sources:' or 'Resources:' are used.

This change set formats the URLs in Sphinx format so that they will render properly. It also changes 'References:' to 'Sources:'.