### PR TITLE
Proposal processing directory target without wildcard

### DIFF
--- a/dissect/target/loader.py
+++ b/dissect/target/loader.py
@@ -122,7 +122,9 @@ def register(module_name: str, class_name: str, internal: bool = True) -> None:
     LOADERS_BY_SCHEME[module_name] = loader
 
 
-def find_loader(item: Path, parsed_path: Optional[urllib.parse.ParseResult] = None) -> Optional[Loader]:
+def find_loader(
+    item: Path, parsed_path: Optional[urllib.parse.ParseResult] = None, fallbacks: list = [DirLoader]
+) -> Optional[Loader]:
     """Finds a :class:`Loader` class for the specific ``item``.
 
     This searches for a specific :class:`Loader` classs that is able to load a target pointed to by ``item``.
@@ -134,6 +136,7 @@ def find_loader(item: Path, parsed_path: Optional[urllib.parse.ParseResult] = No
 
     Args:
         item: The target path to load.
+        fallbacks: Fallback loaders to try
 
     Returns:
         A :class:`Loader` class for the specific target if one exists.
@@ -142,7 +145,7 @@ def find_loader(item: Path, parsed_path: Optional[urllib.parse.ParseResult] = No
         if loader := LOADERS_BY_SCHEME.get(parsed_path.scheme):
             return loader
 
-    for loader in LOADERS + [DirLoader]:
+    for loader in LOADERS + fallbacks:
         try:
             if loader.detect(item):
                 return loader

--- a/dissect/target/loader.py
+++ b/dissect/target/loader.py
@@ -123,7 +123,7 @@ def register(module_name: str, class_name: str, internal: bool = True) -> None:
 
 
 def find_loader(
-    item: Path, parsed_path: Optional[urllib.parse.ParseResult] = None, fallbacks: list = [DirLoader]
+    item: Path, parsed_path: Optional[urllib.parse.ParseResult] = None, fallbacks: list[Loader] = [DirLoader]
 ) -> Optional[Loader]:
     """Finds a :class:`Loader` class for the specific ``item``.
 

--- a/dissect/target/loader.py
+++ b/dissect/target/loader.py
@@ -136,7 +136,7 @@ def find_loader(
 
     Args:
         item: The target path to load.
-        fallbacks: Fallback loaders to try
+        fallbacks: Fallback loaders to try.
 
     Returns:
         A :class:`Loader` class for the specific target if one exists.

--- a/dissect/target/loaders/cb.py
+++ b/dissect/target/loaders/cb.py
@@ -43,10 +43,6 @@ class CbLoader(Loader):
     def detect(path):
         return urlparse(str(path)).scheme == "cb"
 
-    @staticmethod
-    def find_all(path):
-        yield path
-
     def map(self, target):
         for drive in self.session.session_data["drives"]:
             cbfs = CbFilesystem(self.cb, self.sensor, self.session, drive)

--- a/dissect/target/loaders/raw.py
+++ b/dissect/target/loaders/raw.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
-from dissect.target import Target, container
+from dissect.target import container
 from dissect.target.loader import Loader
+from dissect.target.target import Target
 
 
 class RawLoader(Loader):
@@ -9,5 +10,5 @@ class RawLoader(Loader):
     def detect(path: Path) -> bool:
         return not path.is_dir()
 
-    def map(self, target: Target):
+    def map(self, target: Target) -> None:
         target.disks.add(container.open(self.path))

--- a/dissect/target/loaders/raw.py
+++ b/dissect/target/loaders/raw.py
@@ -6,7 +6,7 @@ from dissect.target.loader import Loader
 
 class RawLoader(Loader):
     @staticmethod
-    def detect(path: Path):
+    def detect(path: Path) -> bool:
         return not path.is_dir()
 
     def map(self, target):

--- a/dissect/target/loaders/raw.py
+++ b/dissect/target/loaders/raw.py
@@ -1,11 +1,13 @@
+from pathlib import Path
+
 from dissect.target import container
 from dissect.target.loader import Loader
 
 
 class RawLoader(Loader):
     @staticmethod
-    def detect(path):
-        return True
+    def detect(path: Path):
+        return not path.is_dir()
 
     def map(self, target):
         target.disks.add(container.open(self.path))

--- a/dissect/target/loaders/raw.py
+++ b/dissect/target/loaders/raw.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from dissect.target import container
+from dissect.target import Target, container
 from dissect.target.loader import Loader
 
 
@@ -9,5 +9,5 @@ class RawLoader(Loader):
     def detect(path: Path) -> bool:
         return not path.is_dir()
 
-    def map(self, target):
+    def map(self, target: Target):
         target.disks.add(container.open(self.path))

--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -266,12 +266,9 @@ class Target:
 
             # Search for targets one directory deep
             for entry in _find(path):
-                loader_cls = loader.find_loader(entry, parsed_path=parsed_path)
+                loader_cls = loader.find_loader(entry, parsed_path=parsed_path, fallbacks=[DirLoader, RawLoader])
                 if not loader_cls:
-                    if not entry.is_dir():
-                        loader_cls = RawLoader
-                    else:
-                        continue
+                    continue
 
                 getlogger(entry).debug("Attempting to use loader: %s for: %s", loader_cls, entry)
                 for sub_entry in loader_cls.find_all(entry):

--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -270,7 +270,7 @@ class Target:
                 if not loader_cls:
                     continue
 
-                getlogger(entry).debug("Attempting to use loader: %s for: %s", loader_cls, entry)
+                getlogger(entry).debug("Attempting to use loader: %s", loader_cls)
                 for sub_entry in loader_cls.find_all(entry):
                     try:
                         ldr = loader_cls(sub_entry, parsed_path=parsed_path)

--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -284,8 +284,8 @@ class Target:
                         at_least_one_loaded = True
                         yield target
 
-                    except Exception as error:
-                        getlogger(sub_entry).error("Failed to load target with loader %s", ldr, exc_info=error)
+                    except Exception as e:
+                        getlogger(sub_entry).error("Failed to load target with loader %s", ldr, exc_info=e)
 
                     if include_children:
                         try:

--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -285,11 +285,12 @@ class Target:
                         at_least_one_loaded = True
                         yield target
 
-                        # If DirLoader, ignore further entries. Otherwise search children/nested
-                        if isinstance(ldr, DirLoader):
-                            break
                     except Exception as error:
                         getlogger(sub_entry).error("Failed to load target with loader %s", ldr, exc_info=error)
+
+                    # If DirLoader, ignore further entries. Otherwise search children.
+                    if isinstance(ldr, DirLoader):
+                        continue
 
                     if include_children:
                         try:


### PR DESCRIPTION
- Load all targets in dir instead of just one
- If it's a loadable dir, ignore non-targets
- Allows for multiple loadable dirs
- Suppress unnecessary errors
- For detailed description of behaviors see scenarios in unit tests (https://github.com/fox-it/dissect.target/pull/218/files#diff-bc9ab330a035ca1d92114c9b2cd7896e93e3def74e0ab9a6c22fa5bbeebcbb0dR23)

(DIS-1919)

Fixes https://github.com/fox-it/dissect.target/issues/215