### PR TITLE
Fix logic bug in unix history plugin

### DIFF
--- a/dissect/target/plugins/os/unix/history.py
+++ b/dissect/target/plugins/os/unix/history.py
@@ -59,9 +59,9 @@ class CommandHistoryPlugin(Plugin):
 
                 # NOTE: Starting with Python 3.10 we can use pattern matching (PEP 634)
                 if file.name == ".zsh_history":
-                    return self.parse_zsh_history(file, user_details.user)
-
-                return self.parse_bash_history(file, user_details.user)
+                    yield from self.parse_zsh_history(file, user_details.user)
+                else:
+                    yield from self.parse_bash_history(file, user_details.user)
 
     @internal
     def parse_bash_history(self, file, user: str) -> Iterator[CommandHistoryRecord]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pathlib
 import tempfile
+import textwrap
 from io import BytesIO
 
 import pytest
@@ -167,6 +168,9 @@ def target_win_tzinfo(hive_hklm, target_win):
 
 @pytest.fixture
 def target_unix_users(target_unix, fs_unix):
-    fs_unix.map_file_fh("/etc/passwd", BytesIO("root:x:0:0:root:/root:/bin/bash".encode()))
-
+    passwd = """
+    root:x:0:0:root:/root:/bin/bash
+    user:x:1000:1000:user:/home/user:/bin/bash
+    """
+    fs_unix.map_file_fh("/etc/passwd", BytesIO(textwrap.dedent(passwd).encode()))
     yield target_unix

--- a/tests/test_plugins_os_unix_history.py
+++ b/tests/test_plugins_os_unix_history.py
@@ -16,15 +16,24 @@ def test_commandhistory_with_timestamps(target_unix_users, fs_unix):
     exit
     """
 
+    commandhistory2_data = """\
+    echo "this for user 2"
+    """
+
     fs_unix.map_file_fh(
         "/root/.bash_history",
         BytesIO(textwrap.dedent(commandhistory_data).encode()),
     )
 
+    fs_unix.map_file_fh(
+        "/home/user/.bash_history",
+        BytesIO(textwrap.dedent(commandhistory2_data).encode()),
+    )
+
     target_unix_users.add_plugin(CommandHistoryPlugin)
 
     results = list(target_unix_users.commandhistory())
-    assert len(results) == 3
+    assert len(results) == 4
 
     assert results[0].ts == dt("2022-03-29T23:58:59Z")
     assert results[0].command == 'echo "this is a test"'
@@ -37,6 +46,8 @@ def test_commandhistory_with_timestamps(target_unix_users, fs_unix):
     assert results[2].ts == dt("2022-07-23T12:14:28Z")
     assert results[2].command == "exit"
     assert results[2].source.as_posix() == "/root/.bash_history"
+
+    assert results[3].source.as_posix() == "/home/user/.bash_history"
 
 
 def test_commandhistory_without_timestamps(target_unix_users, fs_unix):


### PR DESCRIPTION
This patch ensures all command history files on a target are parsed instead of only one.