### PR TITLE
Add setuptools package-data to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,4 +89,7 @@ license-files = ["LICENSE", "COPYRIGHT"]
 [tool.setuptools.packages.find]
 include = ["dissect.*"]
 
+[tool.setuptools.package-data]
+"dissect.target" = ["helpers/data/*.xml"]
+
 [tool.setuptools_scm]


### PR DESCRIPTION
This patch explicitly adds `helpers/data/*.xml` to setuptools' package_data. This was [previously implemented](https://github.com/fox-it/dissect.target/pull/150/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R54) in `setup.py` but seems to have been implicitly ported to the new `pyproject.toml`.

Certain build processes can cause unexpected behavior if package data is not explicitly added to `pyproject.toml` files.