### PR TITLE
Update flow.record dependency to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "dissect.regf>=3.3.dev,<4.0.dev",
     "dissect.util>=3.0.dev,<4.0.dev",
     "dissect.volume>=3.0.dev,<4.0.dev",
-    "flow.record~=3.9",
+    "flow.record~=3.10",
     "structlog",
 ]
 dynamic = ["version"]

--- a/tests/test_plugins_apps_shell_powershell.py
+++ b/tests/test_plugins_apps_shell_powershell.py
@@ -11,7 +11,7 @@ from ._utils import absolute_path
         (
             "target_win_users",
             "fs_win",
-            "users/John/AppData/Roaming/Microsoft/Windows/PowerShell/psreadline/ConsoleHost_history.txt",
+            "users\\John\\AppData\\Roaming\\Microsoft\\Windows\\PowerShell\\psreadline\\ConsoleHost_history.txt",
         ),
         ("target_unix_users", "fs_unix", "/root/.local/share/powershell/PSReadLine/ConsoleHost_history.txt"),
     ],
@@ -23,8 +23,8 @@ def test_plugins_os_windows_powershell(target, fs, target_file, request):
     history_file = absolute_path("data/plugins/os/windows/powershell/ConsoleHost_history.txt")
     fs.map_file(target_file, history_file)
 
-    if target_file.startswith("users/"):
-        target_file = target_file.replace("users/", "C:/Users/")
+    if target_file.startswith("users\\"):
+        target_file = target_file.replace("users\\", "C:\\Users\\")
 
     target.add_plugin(PowerShellHistoryPlugin)
 

--- a/tests/test_plugins_child_hyperv.py
+++ b/tests/test_plugins_child_hyperv.py
@@ -34,5 +34,5 @@ def test_plugins_child_wsl(target_win, fs_win):
     )
     assert (
         str(children[4].path)
-        == "/sysvol/ProgramData/Microsoft/Windows/Hyper-V/Virtual Machines/B90AC31B-C6F8-479F-9B91-07B894A6A3F6.xml"
+        == "\\sysvol\\ProgramData\\Microsoft\\Windows\\Hyper-V\\Virtual Machines\\B90AC31B-C6F8-479F-9B91-07B894A6A3F6.xml"  # noqa E501
     )

--- a/tests/test_plugins_child_wsl.py
+++ b/tests/test_plugins_child_wsl.py
@@ -16,5 +16,5 @@ def test_plugins_child_wsl(target_win_users, fs_win):
     assert children[0].type == "wsl"
     assert (
         str(children[0].path)
-        == "C:/Users/John/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu22.04LTS_79rhkp1fndgsc/LocalState/ext4.vhdx"  # noqa E501
+        == "C:\\Users\\John\\AppData\\Local\\Packages\\CanonicalGroupLimited.Ubuntu22.04LTS_79rhkp1fndgsc\\LocalState\\ext4.vhdx"  # noqa E501
     )

--- a/tests/test_plugins_os_windows_lnk.py
+++ b/tests/test_plugins_os_windows_lnk.py
@@ -18,7 +18,7 @@ def test_lnk(target_win, fs_win):
     record = records[0]
 
     assert isinstance(record, type(LnkRecord()))
-    assert str(record.lnk_path) == "sysvol/users/pestudio.lnk"
+    assert str(record.lnk_path) == "sysvol\\users\\pestudio.lnk"
     assert record.lnk_name is None
     assert str(record.lnk_relativepath) == "pestudio.exe"
     assert str(record.lnk_workdir) == "C:\\Program Files\\pestudio"


### PR DESCRIPTION
Some testcases are updated as record contents now contain the proper path separators.

(DIS-1848)