### PR TITLE
Refine plugin system

### DIFF
--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -843,8 +843,8 @@ def plugin_function_index(target: Target) -> tuple[dict[str, Any], set[str]]:
         modulepath = available["module"]
         if modulepath.endswith("._os"):
             if not target._os:
-                # if no target available mention general OS instead of specific one
-                available["module"] = "OS"
+                # if no target available add a namespaceless section
+                available["module"] = ""
             elif target._os.__class__.__name__ != available["class"]:
                 continue
             rootset.add(modulepath.split(".")[0])

--- a/dissect/target/plugins/general/osinfo.py
+++ b/dissect/target/plugins/general/osinfo.py
@@ -1,0 +1,39 @@
+from typing import Callable, Generator
+
+from flow.record import GroupedRecord, Record
+
+from dissect.target import plugin
+from dissect.target.exceptions import PluginError
+from dissect.target.helpers.record import TargetRecordDescriptor
+
+OSInfoRecord = TargetRecordDescriptor(
+    "generic/osinfo",
+    [
+        ("string", "name"),
+        ("string", "value"),
+    ],
+)
+
+
+class OSInfoPlugin(plugin.Plugin):
+    """Convenience plugin that wraps _os.* functions in records."""
+
+    def check_compatible(self) -> bool:
+        return True
+
+    @plugin.export(record=OSInfoRecord)
+    def osinfo(self) -> Generator[Record, None, None]:
+        for os_func in self.target._os.__functions__:
+            if os_func in ["is_compatible", "get_all_records"]:
+                continue
+            value = getattr(self.target._os, os_func)
+            record = OSInfoRecord(name=os_func, value=repr(value), _target=self.target)
+            yield record
+            if isinstance(value, Callable):
+                try:
+                    for subvalue in value():
+                        yield GroupedRecord("generic/osinfo/grouped", [record, subvalue])
+                except (PluginError, TypeError):
+                    # Ignore exceptions triggered by functions
+                    # that cannot be executed in this context
+                    continue

--- a/dissect/target/plugins/general/osinfo.py
+++ b/dissect/target/plugins/general/osinfo.py
@@ -1,9 +1,8 @@
 from typing import Callable, Generator, Iterator, Union
 
-from flow.record import GroupedRecord, Record
+from flow.record import GroupedRecord
 
 from dissect.target import plugin
-from dissect.target.exceptions import PluginError
 from dissect.target.helpers.record import TargetRecordDescriptor
 
 OSInfoRecord = TargetRecordDescriptor(

--- a/dissect/target/plugins/general/plugins.py
+++ b/dissect/target/plugins/general/plugins.py
@@ -87,7 +87,7 @@ def get_description_dict(
     output_descriptions = []
     for key in structure_dict.keys():
         output_descriptions += [
-            textwrap.indent(key + ":", prefix=" " * indentation_step) if key != "" else "OS plugins (no namespace)"
+            textwrap.indent(key + ":", prefix=" " * indentation_step) if key != "" else "OS plugins"
         ] + output_plugin_description_recursive(
             structure_dict[key],
             print_docs,

--- a/dissect/target/plugins/general/plugins.py
+++ b/dissect/target/plugins/general/plugins.py
@@ -87,7 +87,7 @@ def get_description_dict(
     output_descriptions = []
     for key in structure_dict.keys():
         output_descriptions += [
-            textwrap.indent(key + ":", prefix=" " * indentation_step)
+            textwrap.indent(key + ":", prefix=" " * indentation_step) if key != "" else "OS plugins (no namespace)"
         ] + output_plugin_description_recursive(
             structure_dict[key],
             print_docs,

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -194,12 +194,7 @@ def main():
 
     default_output_type = None
 
-    if not len(output_types):
-        # Otherwise you see a confusing mixed output types message, can still generate output
-        # because some plugins have output file/dir options
-        pass
-
-    elif len(output_types) > 1:
+    if len(output_types) > 1:
         # Give this warning beforehand, if mixed, set default to record (no errors)
         log.warning("Mixed output types detected: %s. Only outputting records.", ",".join(output_types))
         default_output_type = "record"

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -195,10 +195,10 @@ def main():
     default_output_type = None
 
     if not len(output_types):
+        # Otherwise you see a confusing mixed output types message, can still generate output
+        # because some plugins have output file/dir options
         pass
 
-    # Otherwise you see a confusing mixed output types message, can still generate output
-    # because some plugins have output file/dir options
     elif len(output_types) > 1:
         # Give this warning beforehand, if mixed, set default to record (no errors)
         log.warning("Mixed output types detected: %s. Only outputting records.", ",".join(output_types))

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -175,14 +175,32 @@ def main():
     if not args.function:
         parser.error("argument -f/--function is required")
 
-    # Verify uniformity of output types, otherwise default to records
+    # Verify uniformity of output types, otherwise default to records.
+    # Note that this is a heuristic, the targets are not opened yet because of
+    # performance, so it might generate a false positive
+    # (os.* on Windows includes other OS plugins),
+    # however this is highly hypothetical, most plugins across OSes have
+    # the same output types and most output types are records anyway.
+    # Furthermore we really want the notification at the top, so this is the only
+    # way forward. In the very unlikely case you have a
+    # collection of non-record plugins that have record counterparts for
+    # other OSes just refine the wildcard to exclude other OSes.
+    # The only scenario that might cause this is with
+    # custom plugins with idiosyncratic output across OS-versions/branches.
     output_types = set()
     funcs = find_plugin_functions(Target(), args.function, False)
     for func in funcs:
         output_types.add(func.output_type)
 
     default_output_type = None
-    if len(output_types) > 1:
+
+    if not len(output_types):
+        pass
+
+    # Otherwise you see a confusing mixed output types message, can still generate output
+    # because some plugins have output file/dir options
+    elif len(output_types) > 1:
+        # Give this warning beforehand, if mixed, set default to record (no errors)
         log.warning("Mixed output types detected: %s. Only outputting records.", ",".join(output_types))
         default_output_type = "record"
 
@@ -214,6 +232,14 @@ def main():
             if func_def.method_name in executed_plugins:
                 continue
 
+            # If the default type is record (meaning we skip everything else)
+            # and actual output type is not record, continue.
+            # We perform this check here because plugins that require output files/dirs
+            # will exit if we attempt to exec them without (because they are implied by the wildcard).
+            # Also this saves cycles of course.
+            if default_output_type == "record" and func_def.output_type != "record":
+                continue
+
             try:
                 output_type, result, cli_params_unparsed = execute_function_on_target(
                     target, func_def, cli_params_unparsed
@@ -235,9 +261,6 @@ def main():
                 continue
 
             if first_seen_output_type and output_type != first_seen_output_type:
-                # if default is set to record, we already know so continue... (probably a wildcard)
-                if default_output_type == "record":
-                    continue
                 target.log.error(
                     (
                         "Can't mix functions that generate different outputs: output type `%s` from `%s` "


### PR DESCRIPTION
- make plugin system compatible with plugins that require output files/dirs by checking output types early (None)
- allow users to get an OS summary in records by referencing the OS header in the -l output (-f OS)