### PR TITLE
Fix resolving invalid symlinks on NTFS

### DIFF
--- a/dissect/target/filesystems/ntfs.py
+++ b/dissect/target/filesystems/ntfs.py
@@ -118,7 +118,8 @@ class NtfsFilesystemEntry(FilesystemEntry):
         return not self.is_dir()
 
     def is_symlink(self) -> bool:
-        return self.dereference().is_reparse_point()
+        entry = self.dereference()
+        return entry.is_symlink() or entry.is_mount_point()
 
     def readlink(self) -> str:
         # Note: we only need to check and resolve symlinks when actually interacting with the target, such as

--- a/tests/test_filesystems_ntfs.py
+++ b/tests/test_filesystems_ntfs.py
@@ -39,7 +39,8 @@ def test_ntfs_fileentry_open(ads, name, output):
     mocked_entry = Mock()
     mocked_entry.attributes = AttributeMap()
     mocked_entry.is_dir.return_value = False
-    mocked_entry.is_reparse_point.return_value = False
+    mocked_entry.is_symlink.return_value = False
+    mocked_entry.is_mount_point.return_value = False
     entry = NtfsFilesystemEntry(vfs, "some/random/path", entry=mocked_entry)
     entry.ads = ads
     entry.open(name)
@@ -52,7 +53,8 @@ def test_ntfs_unknown_file():
     mocked_entry = Mock()
     mocked_entry.attributes = AttributeMap()
     mocked_entry.is_dir.return_value = False
-    mocked_entry.is_reparse_point.return_value = False
+    mocked_entry.is_symlink.return_value = False
+    mocked_entry.is_mount_point.return_value = False
     mocked_entry.size.side_effect = [NtfsFileNotFoundError]
     entry = NtfsFilesystemEntry(vfs, "some/random/path", entry=mocked_entry)
     with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
(DIS-2061)

Related: https://github.com/fox-it/dissect.ntfs/pull/21