### PR TITLE
Update WSL plugin to use registry to find all WSL instances

### DIFF
--- a/dissect/target/plugins/child/wsl.py
+++ b/dissect/target/plugins/child/wsl.py
@@ -22,9 +22,7 @@ def find_wsl_installs(target: Target) -> Iterator[Path]:
         for distribution_key in lxss_key.subkeys():
             if not distribution_key.name.startswith("{"):
                 continue
-            base_path = distribution_key.value("BasePath").value.replace(
-                "\\\\?\\", ""
-            )  # "\\?\" not resolved by Dissect, temporary replace.
+            base_path = target.resolve(distribution_key.value("BasePath").value)
             # WSL needs diskname to be ext4.vhdx, but they can be renamed when WSL is not active
             yield from target.fs.path(base_path).glob("*.vhdx")
 

--- a/dissect/target/plugins/child/wsl.py
+++ b/dissect/target/plugins/child/wsl.py
@@ -8,11 +8,11 @@ from dissect.target.target import Target
 
 def find_wsl_installs(target: Target) -> Iterator[Path]:
     """Find all WSL disk files.
-    
+
     Disk files for working (custom) Linux distributions can be located anywhere on the system.
     Locations to disk files for each user's WSL instance is stored in the Windows registry at
     ``HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss``.
-    
+
     References:
         - https://learn.microsoft.com/en-us/windows/wsl/use-custom-distro
         - https://learn.microsoft.com/en-us/windows/wsl/enterprise

--- a/dissect/target/plugins/child/wsl.py
+++ b/dissect/target/plugins/child/wsl.py
@@ -1,39 +1,64 @@
+import re
 from pathlib import Path
 from typing import Iterator
 
 from dissect.target.helpers.record import ChildTargetRecord
 from dissect.target.plugin import ChildTargetPlugin
+from dissect.target.plugins.general.users import UsersPlugin
 from dissect.target.target import Target
 
 
 def find_wsl_installs(target: Target) -> Iterator[Path]:
-    # Officially supported distro's by Microsoft can be found under "PackageFamilyName" at
-    # https://github.com/microsoft/WSL/blob/master/distributions/DistributionInfo.json
+    """Function finds WSL distributions based off the locations stored in subkeys in the Windows Registry.
+    # It is possible to have WSL disk files of perfectly working (custom imported) distributions anywhere on the filesystem ...
+    # ... which is why the registry is used to locate their disk files. See:
+    # https://learn.microsoft.com/en-us/windows/wsl/use-custom-distro
+    # https://learn.microsoft.com/en-us/windows/wsl/enterprise
+    """
 
-    dist_folders = [
-        "CanonicalGroupLimited.Ubuntu*",
-        "TheDebianProject.DebianGNULinux_*",
-        "KaliLinux.*",
-        "*SUSE.openSUSE*",
-        "*OracleAmericaInc.OracleLinux*",
-    ]
+    # Iterates the registry key generator objects to eventually get the BasePath of WSL distribution registry keys.
+    def recursive_registry(generatorKey, subpath):
+        for subkey in generatorKey:
+            key_name = subkey.name
+            next_generator = subkey
+            if key_name == subpath[0]:
+                if (subkeys := next_generator.subkeys()) is not None:
+                    if len(subpath) > 1:
+                        yield from recursive_registry(subkeys, subpath[1:])
+                    else:  # This means the current registry generator object is the Lxss key.
+                        for distribution_GUID in subkey.subkeys():
+                            if re.match(
+                                r"\{.*\}", distribution_GUID.name
+                            ):  # Filters out subkeys that aren't distribution keys, such as AppxInstallerCache.
+                                yield distribution_GUID.value(
+                                    "BasePath"
+                                ).value  # Location of the disk file is stored in BasePath value.
 
-    for user_details in target.user_details.all_with_home():
-        for dist_folder in dist_folders:
-            for install_path in user_details.home_path.joinpath("AppData/Local/Packages").glob(dist_folder):
-                if (vhdx := install_path.joinpath("LocalState/ext4.vhdx")).exists():
+    # Uses the recursive_registry key function to get WSL distributions for all users.
+    all_user_sids = [user_details.user.sid for user_details in UsersPlugin(target).all()]
+    for user_sid in all_user_sids:
+        user_wsl_key = ("HKEY_USERS/" + str(user_sid) + "/Software/Microsoft/Windows/CurrentVersion/Lxss").split("/")
+        for wsl_install in recursive_registry(target.registry.keys("HKU"), user_wsl_key):
+            wsl_install = str(Path(wsl_install)).replace(
+                "\\\\?\\", ""
+            )  # Dissect currently doesn't normalize \\?\, so the replace is a temporary solution.
+            for disk_path in target.fs.path(wsl_install).glob(
+                "*.vhdx"
+            ):  # WSL does not work when the filename is not ext4.vhdx, but it is possible to change disk names when not using WSL.
+                if (vhdx := target.fs.path(target.resolve(str(disk_path)))).exists():
                     yield vhdx
 
 
 class WSLChildTargetPlugin(ChildTargetPlugin):
     """Child target plugin that yields WSL VHDX file locations.
 
-    Windows WSL VHDX conatiners are stored at ``%AppData%\\Local\\Packages\\$DistFolder\\LocalState\\ext4.vhdx``,
-    where ``$DistFolder`` will be substituted with a unix distribution folder.
+    Windows WSL VHDX disk file locations are stored in the Windows Registry in `HKEY_USERS/$sid/Software/Microsoft/Windows/CurrentVersion/Lxss`,
+    where $sid is substituted with any SID of users on the Windows machine.
 
     References:
         - https://www.osdfcon.org/presentations/2020/Asif-Matadar_Investigating-WSL-Endpoints.pdf
         - https://www.sans.org/white-papers/39330/
+        - https://learn.microsoft.com/en-us/windows/wsl/disk-space#how-to-locate-the-vhdx-file-and-disk-path-for-your-linux-distribution
     """  # noqa: E501
 
     __type__ = "wsl"

--- a/dissect/target/plugins/child/wsl.py
+++ b/dissect/target/plugins/child/wsl.py
@@ -7,32 +7,32 @@ from dissect.target.target import Target
 
 
 def find_wsl_installs(target: Target) -> Iterator[Path]:
-    """Disk files for working (custom) Linux distributions can be located anywhere on the system.
-    Locations to disk files for each user's WSL instance is stored in the Windows Registry in the following subkey:
-    - HKCU\Software\Microsoft\Windows\CurrentVersion\Lxss
+    """Find all WSL disk files.
+    
+    Disk files for working (custom) Linux distributions can be located anywhere on the system.
+    Locations to disk files for each user's WSL instance is stored in the Windows registry at
+    ``HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss``.
+    
     References:
         - https://learn.microsoft.com/en-us/windows/wsl/use-custom-distro
         - https://learn.microsoft.com/en-us/windows/wsl/enterprise
     """
 
-    for lxss_key in target.registry.key("HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss"):
+    for lxss_key in target.registry.keys("HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss"):
         for distribution_key in lxss_key.subkeys():
             if not distribution_key.name.startswith("{"):
                 continue
-            base_path = str(distribution_key.value("BasePath").value).replace(
+            base_path = distribution_key.value("BasePath").value.replace(
                 "\\\\?\\", ""
             )  # "\\?\" not resolved by Dissect, temporary replace.
-            for disk_file in target.fs.path(base_path).glob(
-                "*.vhdx"
-            ):  # WSL needs diskname to be ext4.vhdx, but this can be renamed when WSL is not active.
-                yield disk_file
+            # WSL needs diskname to be ext4.vhdx, but they can be renamed when WSL is not active
+            yield from target.fs.path(base_path).glob("*.vhdx")
 
 
 class WSLChildTargetPlugin(ChildTargetPlugin):
     """Child target plugin that yields WSL VHDX file locations.
 
-    Windows WSL VHDX disk file locations are stored in the Windows Registry in `HKEY_USERS/$sid/Software/Microsoft/Windows/CurrentVersion/Lxss`,
-    where $sid is substituted with any SID of users on the Windows machine.
+    Windows WSL VHDX disk file locations are stored in the Windows registry in ``HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss``.
 
     References:
         - https://www.osdfcon.org/presentations/2020/Asif-Matadar_Investigating-WSL-Endpoints.pdf

--- a/dissect/target/plugins/child/wsl.py
+++ b/dissect/target/plugins/child/wsl.py
@@ -3,7 +3,6 @@ from typing import Iterator
 
 from dissect.target.helpers.record import ChildTargetRecord
 from dissect.target.plugin import ChildTargetPlugin
-from dissect.target.plugins.general.users import UsersPlugin
 from dissect.target.target import Target
 
 

--- a/dissect/target/plugins/filesystem/resolver.py
+++ b/dissect/target/plugins/filesystem/resolver.py
@@ -51,11 +51,14 @@ class ResolverPlugin(Plugin):
         path = fsutil.normalize(path, alt_separator=self.target.fs.alt_separator)
 
         # The \??\ pseudo path is used to point to the directory containing
-        # (the user's) devices, e.g. \??\C:\foo\bar.
+        # (the user's) devices, e.g. \??\C:\foo\bar. 
+        # The \\?\ prefix in Windows file I/O bypasses string parsing and
+        # allows exceeding the MAX_PATH limit, e.g. \\?\C:\very\long\path.
         # For more information see:
         # - https://googleprojectzero.blogspot.com/2016/02/the-definitive-guide-on-win32-to-nt.html
         # - https://stackoverflow.com/questions/23041983/path-prefixes-and
-        path = path.replace("/??/", "")
+        # - https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces
+        path = path.replace("/??/", "").replace("/?/", "")
 
         if self.target.fs.exists(path):
             return path

--- a/dissect/target/plugins/filesystem/resolver.py
+++ b/dissect/target/plugins/filesystem/resolver.py
@@ -51,7 +51,7 @@ class ResolverPlugin(Plugin):
         path = fsutil.normalize(path, alt_separator=self.target.fs.alt_separator)
 
         # The \??\ pseudo path is used to point to the directory containing
-        # (the user's) devices, e.g. \??\C:\foo\bar. 
+        # (the user's) devices, e.g. \??\C:\foo\bar.
         # The \\?\ prefix in Windows file I/O bypasses string parsing and
         # allows exceeding the MAX_PATH limit, e.g. \\?\C:\very\long\path.
         # For more information see:

--- a/tests/test_plugins_child_wsl.py
+++ b/tests/test_plugins_child_wsl.py
@@ -1,13 +1,30 @@
 import io
 
+from dissect.target.helpers.regutil import VirtualKey, VirtualValue
 from dissect.target.plugins.child.wsl import WSLChildTargetPlugin
 
 
-def test_plugins_child_wsl(target_win_users, fs_win):
+def test_plugins_child_wsl(target_win_users, hive_hku, fs_win):
     fs_win.map_file_fh(
         "users/john/appdata/local/Packages/CanonicalGroupLimited.Ubuntu22.04LTS_79rhkp1fndgsc/LocalState/ext4.vhdx",
         io.BytesIO(),
     )
+
+    wsl_keys_name = "Software\\Microsoft\\Windows\\CurrentVersion\\Lxss"
+    wsl_keys = VirtualKey(hive_hku, wsl_keys_name)
+
+    wsl_key = VirtualKey(hive_hku, "{12345678-1234-1234-1234-123456789012}")
+    wsl_key.add_value(
+        "BasePath",
+        VirtualValue(
+            hive_hku,
+            "BasePath",
+            "C:\\Users\\John\\AppData\\Local\\Packages\\CanonicalGroupLimited.Ubuntu22.04LTS_79rhkp1fndgsc\\LocalState",
+        ),
+    )
+
+    wsl_keys.add_subkey(wsl_key.name, wsl_key)
+    hive_hku.map_key(wsl_keys_name, wsl_keys)
 
     target_win_users.add_plugin(WSLChildTargetPlugin)
 

--- a/tests/test_plugins_filesystem_resolver.py
+++ b/tests/test_plugins_filesystem_resolver.py
@@ -101,6 +101,11 @@ def mock_user_env(user):
             "C:/windows/system32/calc.exe",
         ),
         (
+            "\\\\?\\C:\\Users\\Testpath\\Testfile",
+            None,
+            "C:/Users/Testpath/Testfile",
+        ),
+        (
             "C:/windows/system32/calc.exe -args",
             None,
             "C:/windows/system32/calc.exe",


### PR DESCRIPTION
Updated wsl.py to not only look for WSL distribution disks (.vhdx) in default install location, but to use the Windows Registry of the Windows target to find other disk files for WSL on other locations as well which may not be on the default location.