### PR TITLE
Fix false positive detection McAfee plugin

### DIFF
--- a/dissect/target/plugins/apps/av/mcafee.py
+++ b/dissect/target/plugins/apps/av/mcafee.py
@@ -56,7 +56,7 @@ class McAfeePlugin(Plugin):
     TABLE_FIELD = "field"
 
     def check_compatible(self) -> bool:
-        if not self.get_log_files():
+        if not list(self.get_log_files()):
             raise UnsupportedPluginError("No McAfee Log files found")
 
     def get_log_files(self) -> Iterator[Path]:


### PR DESCRIPTION
This fixes a minor issue in the McAfee plugin that wrongly suggests that the McAfee plugin is applicable to a certain target when it's not.