### PR TITLE
Skip directories in _parse_os_release

### DIFF
--- a/dissect/target/plugins/os/unix/_os.py
+++ b/dissect/target/plugins/os/unix/_os.py
@@ -228,7 +228,7 @@ class UnixPlugin(OSPlugin):
         os_release = {}
 
         for path in self.target.fs.glob(glob):
-            if self.target.fs.path(path).exists():
+            if self.target.fs.path(path).is_file():
                 with self.target.fs.path(path).open("rt") as release_file:
                     for line in release_file:
                         if line.startswith("#"):

--- a/tests/test_plugins_os_unix_version.py
+++ b/tests/test_plugins_os_unix_version.py
@@ -59,3 +59,26 @@ def test_unix_version_detection_short(fs_unix, target_unix, content, target_path
     target_unix.add_plugin(os_plugin)
 
     assert target_unix.version == content
+
+
+def test_unix_os_release_directory_regression(fs_unix, target_unix):
+    fs_unix.map_file_fh(
+        "/etc/upstream-release/lsb-release",
+        BytesIO(
+            b"DISTRIB_ID=Ubuntu\n"
+            b"DISTRIB_RELEASE=16.04\n"
+            b"DISTRIB_CODENAME=xenial\n"
+            b'DISTRIB_DESCRIPTION="Ubuntu 16.04 LTS"'
+        ),
+    )
+    fs_unix.map_file_fh(
+        "/etc/lsb-release",
+        BytesIO(
+            b"DISTRIB_ID=LinuxMint\n"
+            b"DISTRIB_RELEASE=19\n"
+            b"DISTRIB_CODENAME=tara\n"
+            b'DISTRIB_DESCRIPTION="Linux Mint 19 Tara"'
+        ),
+    )
+    target_unix.add_plugin(LinuxPlugin)
+    assert target_unix.version == "Linux Mint 19 Tara"


### PR DESCRIPTION
When globbing for `/etc/*-release` it can encounter a directory, for example in Linux Mint:

`/etc/upstream-release/lsb-release`

This change ensures that we only parse files and not directories so it doesn't break parsing.