### PR TITLE
Make lazy import exception handler more broad

### DIFF
--- a/dissect/target/helpers/lazy.py
+++ b/dissect/target/helpers/lazy.py
@@ -10,7 +10,7 @@ class LazyImport:
         if not self._module:
             try:
                 self._module = importlib.import_module(self._module_name)
-            except ImportError as e:
+            except Exception as e:
                 self._module = FailedImport(e, self)
 
     def __getattr__(self, attr):


### PR DESCRIPTION
Sometimes an import might exist, but something that runs in the global scope of that import might break. Currently this would result in an infinite loop in the lazy importer. By catching all errors, the lazy import will be marked as failed regardless of error.