### PR TITLE
Remove duplicate Unix log functions.

### DIFF
--- a/dissect/target/plugins/os/unix/log/auth.py
+++ b/dissect/target/plugins/os/unix/log/auth.py
@@ -26,11 +26,6 @@ class AuthPlugin(Plugin):
         return any(var_log.glob("auth.log*")) or any(var_log.glob("secure*"))
 
     @export(record=[AuthLogRecord])
-    def securelog(self) -> Iterator[AuthLogRecord]:
-        """Return contents of /var/log/auth.log* and /var/log/secure*."""
-        return self.authlog()
-
-    @export(record=[AuthLogRecord])
     def authlog(self) -> Iterator[AuthLogRecord]:
         """Return contents of /var/log/auth.log* and /var/log/secure*."""
 

--- a/dissect/target/plugins/os/unix/log/messages.py
+++ b/dissect/target/plugins/os/unix/log/messages.py
@@ -30,14 +30,6 @@ class MessagesPlugin(Plugin):
         return any(var_log.glob("syslog*")) or any(var_log.glob("messages*"))
 
     @export(record=MessagesRecord)
-    def syslog(self) -> Iterator[MessagesRecord]:
-        """Return contents of /var/log/messages* and /var/log/syslog*.
-
-        See ``messages`` for more information.
-        """
-        return self.messages()
-
-    @export(record=MessagesRecord)
     def messages(self) -> Iterator[MessagesRecord]:
         """Return contents of /var/log/messages* and /var/log/syslog*.
 

--- a/tests/test_plugins_os_unix_log_messages.py
+++ b/tests/test_plugins_os_unix_log_messages.py
@@ -45,11 +45,6 @@ def test_unix_log_messages_plugin(target_unix_users, fs_unix):
         assert results[1].pid == 1
         assert results[1].source == path.from_posix("/var/log/messages")
 
-    # assure syslog() behaves the same as messages()
-    syslogs = list(target_unix_users.syslog())
-    assert len(syslogs) == len(results)
-    assert isinstance(syslogs[0], type(MessagesRecord()))
-
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="ZoneInfoNotFoundError. Needs to be fixed.")
 def test_unix_log_messages_compressed_timezone_year_rollover():


### PR DESCRIPTION
The duplicate functions behave the same. This creates duplicate records when executing all `target-query` functions in an automated manner.