### PR TITLE
Fix child detection on Unix

### DIFF
--- a/dissect/target/plugins/child/wsl.py
+++ b/dissect/target/plugins/child/wsl.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Iterator
 
+from dissect.target.exceptions import PluginNotFoundError
 from dissect.target.helpers.record import ChildTargetRecord
 from dissect.target.plugin import ChildTargetPlugin
 from dissect.target.target import Target
@@ -18,13 +19,16 @@ def find_wsl_installs(target: Target) -> Iterator[Path]:
         - https://learn.microsoft.com/en-us/windows/wsl/enterprise
     """
 
-    for lxss_key in target.registry.keys("HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss"):
-        for distribution_key in lxss_key.subkeys():
-            if not distribution_key.name.startswith("{"):
-                continue
-            base_path = target.resolve(distribution_key.value("BasePath").value)
-            # WSL needs diskname to be ext4.vhdx, but they can be renamed when WSL is not active
-            yield from target.fs.path(base_path).glob("*.vhdx")
+    try:
+        for lxss_key in target.registry.keys("HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss"):
+            for distribution_key in lxss_key.subkeys():
+                if not distribution_key.name.startswith("{"):
+                    continue
+                base_path = target.resolve(distribution_key.value("BasePath").value)
+                # WSL needs diskname to be ext4.vhdx, but they can be renamed when WSL is not active
+                yield from target.fs.path(base_path).glob("*.vhdx")
+    except PluginNotFoundError:
+        pass
 
 
 class WSLChildTargetPlugin(ChildTargetPlugin):


### PR DESCRIPTION
#290 added WSL detection through the registry. This improvement however does not account for running `target-query --children` on non-Windows targets. This patch prevents the WSL child plugin from crashing when `self.target.registry` is not registered.