### PR TITLE
Check for "instance" on the _loader variable

### DIFF
--- a/dissect/target/tools/utils.py
+++ b/dissect/target/tools/utils.py
@@ -133,7 +133,7 @@ def generate_argparse_for_plugin(
 
 
 def plugin_factory(target: Target, plugin: Union[type, object], funcname: str) -> tuple[Plugin, str]:
-    if hasattr(target, "instance"):
+    if hasattr(target._loader, "instance"):
         return target.get_function(funcname)
 
     if isinstance(plugin, type):


### PR DESCRIPTION
The target itself did not contain the variable, so it failed to resolve it when
hasattr got called. Now we check the underlying loader for the "instance"
variable

(DIS-2131)
