### PR TITLE
Use lstat instead of stat in target-mount

### DIFF
--- a/dissect/target/helpers/mount.py
+++ b/dissect/target/helpers/mount.py
@@ -31,7 +31,7 @@ class DissectMount(Operations):
         fe = self._get(path)
 
         try:
-            st = fe.stat()
+            st = fe.lstat()
             return dict(
                 (key, getattr(st, key))
                 for key in ("st_atime", "st_ctime", "st_gid", "st_mode", "st_mtime", "st_nlink", "st_size", "st_uid")


### PR DESCRIPTION
Fixes https://github.com/fox-it/dissect.target/issues/340

Because `.stat()` was used, the stat of the symlink/reparse point target was returned instead that of the file entry itself. This will make symlinks and reparse points correctly show up as symlinks.

One caveat, however, is that reparse points are always absolute. This means that they'll show up as this:
```bash
$ ls -lah /path/to/mnt/fs/sysvol
[...]
lrwxrwxrwx. 2 root root    0 Aug  1  2020 'Documents and Settings' -> /C:/Users
[...]
```
The same "problem" will occur with absolute symlinks.

A future improvement may want to dive into making these relative specifically within target-mount, but this seems to be a bit tough at the moment. Future improvements regarding sysvol on Windows may make this easier.