### PR TITLE
Fix Citrix NetScaler version check

### DIFF
--- a/dissect/target/plugins/os/unix/bsd/citrix/_os.py
+++ b/dissect/target/plugins/os/unix/bsd/citrix/_os.py
@@ -72,13 +72,21 @@ class CitrixBsdPlugin(BsdPlugin):
 
     @export(property=True)
     def version(self) -> Optional[str]:
+        version = "Unknown"
         version_path = self.target.fs.path("/flash/.version")
-        version = version_path.read_text().strip()
-        loader_conf = self.target.fs.path("/flash/boot/loader.conf").read_text()
-        if match := RE_LOADER_CONFIG_KERNEL_VERSION.search(loader_conf):
-            kernel_version = match.groupdict()["version"]
-            return f"{version} ({kernel_version})"
-        self.target.log.warn("Could not determine kernel version")
+        if version_path.is_file():
+            version = version_path.read_text().strip()
+
+        loader_conf_path = self.target.fs.path("/flash/boot/loader.conf")
+        if loader_conf_path.is_file():
+            loader_conf = loader_conf_path.read_text()
+            if match := RE_LOADER_CONFIG_KERNEL_VERSION.search(loader_conf):
+                kernel_version = match.groupdict()["version"]
+                version = f"{version} ({kernel_version})" if version else kernel_version
+
+        if not version:
+            self.target.log.warn("Could not determine kernel version")
+
         return version
 
     @export(property=True)


### PR DESCRIPTION
`/flash/.version` doesn't always seem to exist

See also https://github.com/fox-it/citrix-netscaler-triage/issues/4