### PR TITLE
Update to flow.record 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "dissect.regf>=3.3.dev,<4.0.dev",
     "dissect.util>=3.0.dev,<4.0.dev",
     "dissect.volume>=3.0.dev,<4.0.dev",
-    "flow.record~=3.10",
+    "flow.record~=3.12.0",
     "structlog",
 ]
 dynamic = ["version"]

--- a/tests/test_plugins_apps_remoteaccess_anydesk.py
+++ b/tests/test_plugins_apps_remoteaccess_anydesk.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from dissect.target.plugins.apps.remoteaccess.anydesk import AnydeskPlugin
 
@@ -18,7 +18,7 @@ def test_anydesk_plugin_global_log(target_win_users, fs_win):
     assert len(records) == 1
 
     record = records[0]
-    assert record.ts == datetime(2021, 11, 11, 12, 34, 56)
+    assert record.ts == datetime(2021, 11, 11, 12, 34, 56, tzinfo=timezone.utc)
     assert record.description == "LEVEL Strip the headers, trace the source!"
     assert record.logfile == target_logfile_name
     assert record.username is None
@@ -40,7 +40,7 @@ def test_anydesk_plugin_user_log(target_win_users, fs_win):
     assert len(records) == 1
 
     record = records[0]
-    assert record.ts == datetime(2021, 11, 11, 12, 34, 56)
+    assert record.ts == datetime(2021, 11, 11, 12, 34, 56, tzinfo=timezone.utc)
     assert record.description == "LEVEL Strip the headers, trace the source!"
     assert record.logfile == target_logfile_name
     assert record.username == user_details.user.name

--- a/tests/test_plugins_apps_remoteaccess_teamviewer.py
+++ b/tests/test_plugins_apps_remoteaccess_teamviewer.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from dissect.target.plugins.apps.remoteaccess.teamviewer import TeamviewerPlugin
 
@@ -18,7 +18,7 @@ def test_teamviewer_plugin_global_log(target_win_users, fs_win):
     assert len(records) == 1
 
     record = records[0]
-    assert record.ts == datetime(2021, 11, 11, 12, 34, 56)
+    assert record.ts == datetime(2021, 11, 11, 12, 34, 56, tzinfo=timezone.utc)
     assert record.description == "Strip the headers, trace the source!"
     assert record.logfile == target_logfile_name
     assert record.username is None
@@ -40,7 +40,7 @@ def test_teamviewer_plugin_user_log(target_win_users, fs_win):
     assert len(records) == 1
 
     record = records[0]
-    assert record.ts == datetime(2021, 11, 11, 12, 34, 56)
+    assert record.ts == datetime(2021, 11, 11, 12, 34, 56, tzinfo=timezone.utc)
     assert record.description == "Strip the headers, trace the source!"
     assert record.logfile == target_logfile_name
     assert record.username == user_details.user.name

--- a/tests/test_plugins_os_unix_log.py
+++ b/tests/test_plugins_os_unix_log.py
@@ -92,7 +92,7 @@ def test_atop_plugin(target_unix: Target, fs_unix: VirtualFilesystem) -> None:
 
     results = list(target_unix.atop())
     assert len(results) == 2219
-    assert str(results[0].ts) == "2022-11-11 19:50:44"
+    assert results[0].ts == datetime(2022, 11, 11, 19, 50, 44, tzinfo=timezone.utc)
     assert results[0].process == "systemd"
     assert results[0].cmdline == "/sbin/init"
     assert results[0].tgid == 1

--- a/tests/test_plugins_os_windows_tasks.py
+++ b/tests/test_plugins_os_windows_tasks.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from flow.record import GroupedRecord
@@ -30,7 +30,7 @@ def assert_xml_task_properties(xml_task):
         == "D:(A;;0x111FFFFF;;;SY)(A;;0x111FFFFF;;;BA)(A;;0x111FFFFF;;;S-1-5-80-3028837079-3186095147-955107200-3701964851-1150726376)(A;;FRFX;;;AU)"  # noqa: E501
     )
     assert xml_task.source is None
-    assert str(xml_task.date) == "2014-11-05 00:00:00"
+    assert xml_task.date == datetime(2014, 11, 5, 0, 0, 0, tzinfo=timezone.utc)
     assert xml_task.last_run_date is None
     assert xml_task.author == "$(@%SystemRoot%\\system32\\mapstoasttask.dll,-600)"
     assert xml_task.version is None
@@ -76,7 +76,7 @@ def assert_at_task_properties(at_task):
     assert at_task.security_descriptor is None
     assert str(at_task.task_path) == "sysvol\\windows\\tasks\\AtTask.job"
     assert at_task.date is None
-    assert at_task.last_run_date == datetime.strptime("2023-05-21 10:44:25.794000", "%Y-%m-%d %H:%M:%S.%f")
+    assert at_task.last_run_date == datetime(2023, 5, 21, 10, 44, 25, 794000, tzinfo=timezone.utc)
     assert at_task.author == "user1"
     assert at_task.version == "1"
     assert at_task.description == "At job task for testing purposes"


### PR DESCRIPTION
The version specifier for flow.record is changed to include a third version part to prevent future breakage as flow.record versions with a different second version part are not necessary compatible.

(DIS-2209)