### PR TITLE
Make source field value a posix path

### DIFF
--- a/dissect/target/plugins/os/unix/bsd/osx/user.py
+++ b/dissect/target/plugins/os/unix/bsd/osx/user.py
@@ -1,6 +1,8 @@
 import plistlib
 from typing import Iterator
 
+from flow.record.fieldtypes import posix_path
+
 from dissect.target.exceptions import UnsupportedPluginError
 from dissect.target.helpers.descriptor_extensions import UserRecordDescriptorExtension
 from dissect.target.helpers.record import create_extended_descriptor
@@ -47,7 +49,7 @@ class UserPlugin(Plugin):
                         password_last_time=account_policy.get("passwordLastSetTime"),
                         failed_login_count=account_policy.get("failedLoginCount"),
                         failed_login_time=account_policy.get("failedLoginTimestamp"),
-                        source=user_details.user.source,
+                        source=posix_path(user_details.user.source),
                         _user=user_details.user,
                         _target=self.target,
                     )


### PR DESCRIPTION
Fixes test `test_plugins_os_windows_powershell` within `test_plugins_apps_shell_powershell` on Windows.