### PR TITLE
Get scheduled task display name with filename 

### DIFF
--- a/dissect/target/plugins/os/windows/task_helpers/tasks_xml.py
+++ b/dissect/target/plugins/os/windows/task_helpers/tasks_xml.py
@@ -100,9 +100,7 @@ class XmlTask:
         self.user_id = self.get_element("Principals/Principal/UserId")
         self.logon_type = self.get_element("Principals/Principal/LogonType")
         self.group_id = self.get_element("Principals/Principal/GroupId")
-        self.display_name = self.get_element("Principals/Principal/DisplayName")
-        if self.display_name == None:
-            self.display_name = str(task_path)[str(task_path).rfind("/")+1:]
+        self.display_name = self.get_element("Principals/Principal/DisplayName") or task_path.name
         self.run_level = self.get_element("Principals/Principal/RunLevel")
         self.process_token_sid_type = self.get_element("Principals/Principal/ProcessTokenSidType")
         self.required_privileges = self.get_element("Principals/Principal/RequiredPrivileges")

--- a/dissect/target/plugins/os/windows/task_helpers/tasks_xml.py
+++ b/dissect/target/plugins/os/windows/task_helpers/tasks_xml.py
@@ -101,6 +101,8 @@ class XmlTask:
         self.logon_type = self.get_element("Principals/Principal/LogonType")
         self.group_id = self.get_element("Principals/Principal/GroupId")
         self.display_name = self.get_element("Principals/Principal/DisplayName")
+        if self.display_name == None:
+            self.display_name = str(task_path)[str(task_path).rfind("/")+1:]
         self.run_level = self.get_element("Principals/Principal/RunLevel")
         self.process_token_sid_type = self.get_element("Principals/Principal/ProcessTokenSidType")
         self.required_privileges = self.get_element("Principals/Principal/RequiredPrivileges")

--- a/tests/test_plugins_os_windows_tasks.py
+++ b/tests/test_plugins_os_windows_tasks.py
@@ -40,7 +40,7 @@ def assert_xml_task_properties(xml_task):
     assert xml_task.user_id is None
     assert xml_task.logon_type is None
     assert xml_task.group_id == "S-1-5-4"
-    assert xml_task.display_name is None
+    assert xml_task.display_name is "test_xml.xml"
     assert xml_task.run_level is None
     assert xml_task.process_token_sid_type is None
     assert xml_task.required_privileges is None

--- a/tests/test_plugins_os_windows_tasks.py
+++ b/tests/test_plugins_os_windows_tasks.py
@@ -40,7 +40,7 @@ def assert_xml_task_properties(xml_task):
     assert xml_task.user_id is None
     assert xml_task.logon_type is None
     assert xml_task.group_id == "S-1-5-4"
-    assert xml_task.display_name is "test_xml.xml"
+    assert xml_task.display_name == "test_xml.xml"
     assert xml_task.run_level is None
     assert xml_task.process_token_sid_type is None
     assert xml_task.required_privileges is None


### PR DESCRIPTION
If Principals/Principal/DisplayName is empty, use the filename as the display_name.

I noticed that the field "Principals/Principal/DisplayName" is not used a lot, resulting in the Display Name being null for most of the records.

Instead, let's use the filename as Display Name (Like in the Task Scheduler GUI) 