### PR TITLE
Add Tab URL's and MIME type to download record

### DIFF
--- a/dissect/target/plugins/browsers/browser.py
+++ b/dissect/target/plugins/browsers/browser.py
@@ -9,7 +9,10 @@ GENERIC_DOWNLOAD_RECORD_FIELDS = [
     ("varint", "id"),
     ("path", "path"),
     ("uri", "url"),
+    ("uri", "tab_url"),
+    ("uri", "tab_referrer_url"),
     ("filesize", "size"),
+    ("string", "mime_type"),
     ("varint", "state"),
     ("path", "source"),
 ]

--- a/dissect/target/plugins/browsers/browser.py
+++ b/dissect/target/plugins/browsers/browser.py
@@ -9,10 +9,7 @@ GENERIC_DOWNLOAD_RECORD_FIELDS = [
     ("varint", "id"),
     ("path", "path"),
     ("uri", "url"),
-    ("uri", "tab_url"),
-    ("uri", "tab_referrer_url"),
     ("filesize", "size"),
-    ("string", "mime_type"),
     ("varint", "state"),
     ("path", "source"),
 ]

--- a/dissect/target/plugins/browsers/chrome.py
+++ b/dissect/target/plugins/browsers/chrome.py
@@ -7,7 +7,10 @@ from dissect.target.plugins.browsers.browser import (
     GENERIC_HISTORY_RECORD_FIELDS,
     BrowserPlugin,
 )
-from dissect.target.plugins.browsers.chromium import ChromiumMixin
+from dissect.target.plugins.browsers.chromium import (
+    CHROMIUM_DOWNLOAD_RECORD_FIELDS,
+    ChromiumMixin,
+)
 
 
 class ChromePlugin(ChromiumMixin, BrowserPlugin):
@@ -27,7 +30,7 @@ class ChromePlugin(ChromiumMixin, BrowserPlugin):
         "Library/Application Support/Google/Chrome/Default",
     ]
     BrowserDownloadRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
-        "browser/chrome/download", GENERIC_DOWNLOAD_RECORD_FIELDS
+        "browser/chrome/download", GENERIC_DOWNLOAD_RECORD_FIELDS + CHROMIUM_DOWNLOAD_RECORD_FIELDS
     )
     BrowserExtensionRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
         "browser/chrome/extension", GENERIC_EXTENSION_RECORD_FIELDS

--- a/dissect/target/plugins/browsers/chromium.py
+++ b/dissect/target/plugins/browsers/chromium.py
@@ -22,13 +22,19 @@ from dissect.target.plugins.browsers.browser import (
 )
 from dissect.target.plugins.general.users import UserDetails
 
+CHROMIUM_DOWNLOAD_RECORD_FIELDS = [
+    ("uri", "tab_url"),
+    ("uri", "tab_referrer_url"),
+    ("string", "mime_type"),
+]
+
 
 class ChromiumMixin:
     """Mixin class with methods for Chromium-based browsers."""
 
     DIRS = []
     BrowserDownloadRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
-        "browser/chromium/download", GENERIC_DOWNLOAD_RECORD_FIELDS
+        "browser/chromium/download", GENERIC_DOWNLOAD_RECORD_FIELDS + CHROMIUM_DOWNLOAD_RECORD_FIELDS
     )
     BrowserExtensionRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
         "browser/chromium/extension", GENERIC_EXTENSION_RECORD_FIELDS

--- a/dissect/target/plugins/browsers/chromium.py
+++ b/dissect/target/plugins/browsers/chromium.py
@@ -117,7 +117,10 @@ class ChromiumMixin:
                 id (string): Record ID.
                 path (string): Download path.
                 url (uri): Download URL.
+                tab_url (string): Tab URL.
+                tab_referrer_url (string): Referrer URL.
                 size (varint): Download file size.
+                mime_type (string): MIME type.
                 state (varint): Download state number.
                 source: (path): The source file of the download record.
         Raises:
@@ -151,9 +154,12 @@ class ChromiumMixin:
                         ts_end=webkittimestamp(row.end_time) if row.end_time else None,
                         browser=browser_name,
                         id=row.get("id"),
+                        tab_url=try_idna(row.get("tab_url")),
+                        tab_referrer_url=try_idna(row.get("tab_referrer_url")),
                         path=download_path,
                         url=url,
                         size=row.get("total_bytes"),
+                        mime_type=row.get("mime_type"),
                         state=row.get("state"),
                         source=db_file,
                         _target=self.target,

--- a/dissect/target/plugins/browsers/edge.py
+++ b/dissect/target/plugins/browsers/edge.py
@@ -7,7 +7,10 @@ from dissect.target.plugins.browsers.browser import (
     GENERIC_HISTORY_RECORD_FIELDS,
     BrowserPlugin,
 )
-from dissect.target.plugins.browsers.chromium import ChromiumMixin
+from dissect.target.plugins.browsers.chromium import (
+    CHROMIUM_DOWNLOAD_RECORD_FIELDS,
+    ChromiumMixin,
+)
 
 
 class EdgePlugin(ChromiumMixin, BrowserPlugin):
@@ -25,7 +28,7 @@ class EdgePlugin(ChromiumMixin, BrowserPlugin):
         "Library/Application Support/Microsoft Edge/Default",
     ]
     BrowserDownloadRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
-        "browser/edge/download", GENERIC_DOWNLOAD_RECORD_FIELDS
+        "browser/edge/download", GENERIC_DOWNLOAD_RECORD_FIELDS + CHROMIUM_DOWNLOAD_RECORD_FIELDS
     )
     BrowserExtensionRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
         "browser/edge/extension", GENERIC_EXTENSION_RECORD_FIELDS


### PR DESCRIPTION
In some cases the download URL isn't a valid link but a GUID `blob:null/<GUID>`, while the other tab URL related fields contain useful information about the origin of the downloaded file.