### PR TITLE
Fix handling of volumes at offset 0

### DIFF
--- a/dissect/target/volume.py
+++ b/dissect/target/volume.py
@@ -57,6 +57,8 @@ class VolumeSystem:
         serial: Serial number of the volume system, if any.
     """
 
+    # Due to lazy importing we generally can't use isinstance(), so we add a short identifying string to each class
+    # This has the added benefit of having a readily available "pretty name" for each implementation
     __type__: str = None
     """A short string identifying the type of volume system."""
 

--- a/dissect/target/volume.py
+++ b/dissect/target/volume.py
@@ -57,6 +57,9 @@ class VolumeSystem:
         serial: Serial number of the volume system, if any.
     """
 
+    __type__: str = None
+    """Defines the type of volume system."""
+
     def __init__(
         self, fh: Union[BinaryIO, list[BinaryIO]], dsk: Optional[Container] = None, serial: Optional[str] = None
     ):
@@ -64,6 +67,9 @@ class VolumeSystem:
         self.disk = dsk or fh  # Provide shorthand access to source disk
         self.serial = serial
         self._volumes_list: list[Volume] = None
+
+        if self.__type__ is None:
+            raise NotImplementedError(f"{self.__class__.__name__} must define __type__")
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} serial={self.serial}>"
@@ -124,20 +130,13 @@ class EncryptedVolumeSystem(VolumeSystem):
     It adds helper functions for interacting with the :attr:`~dissect.target.helpers.keychain.KEYCHAIN`,
     so that subclasses don't have to manually interact with it.
 
-    Subclasses must set the ``PROVIDER`` class attribute to a unique string, e.g. ``bitlocker``.
-
     Args:
         fh: The file-like object on which to open the encrypted volume system.
     """
 
-    PROVIDER: str = None
-
     def __init__(self, fh: BinaryIO, *args, **kwargs):
         super().__init__(fh, *args, **kwargs)
-
-        if not self.PROVIDER:
-            raise ValueError("Provider identifier is not set")
-        self.keys = keychain.get_keys_for_provider(self.PROVIDER) + keychain.get_keys_without_provider()
+        self.keys = keychain.get_keys_for_provider(self.__type__) + keychain.get_keys_without_provider()
 
     def get_keys_for_identifier(self, identifier: str) -> list[keychain.Key]:
         """Retrieves a list of keys that match a single ``identifier``.
@@ -399,7 +398,7 @@ def open_encrypted(volume: BinaryIO) -> Iterator[Volume]:
             log.debug("", exc_info=e)
         except Exception as e:
             log.error(
-                "Failed to open an encrypted volume %s with volume manager %s: %s", volume, manager_cls.PROVIDER, e
+                "Failed to open an encrypted volume %s with volume manager %s: %s", volume, manager_cls.__type__, e
             )
             log.debug("", exc_info=e)
     return None

--- a/dissect/target/volume.py
+++ b/dissect/target/volume.py
@@ -58,7 +58,7 @@ class VolumeSystem:
     """
 
     __type__: str = None
-    """Defines the type of volume system."""
+    """A short string identifying the type of volume system."""
 
     def __init__(
         self, fh: Union[BinaryIO, list[BinaryIO]], dsk: Optional[Container] = None, serial: Optional[str] = None

--- a/dissect/target/volumes/bde.py
+++ b/dissect/target/volumes/bde.py
@@ -17,7 +17,7 @@ class BitlockerVolumeSystemError(VolumeSystemError):
 
 
 class BitlockerVolumeSystem(EncryptedVolumeSystem):
-    PROVIDER = "bitlocker"
+    __type__ = "bitlocker"
 
     def __init__(self, fh: Union[BinaryIO, list[BinaryIO]], *args, **kwargs):
         super().__init__(fh, *args, **kwargs)

--- a/dissect/target/volumes/ddf.py
+++ b/dissect/target/volumes/ddf.py
@@ -8,6 +8,8 @@ from dissect.target.volume import LogicalVolumeSystem, Volume
 
 
 class DdfVolumeSystem(LogicalVolumeSystem):
+    __type__ = "ddf"
+
     def __init__(self, fh: Union[BinaryIO, list[BinaryIO]], *args, **kwargs):
         self.ddf = DDF(fh)
         super().__init__(fh, *args, **kwargs)

--- a/dissect/target/volumes/disk.py
+++ b/dissect/target/volumes/disk.py
@@ -6,6 +6,8 @@ from dissect.target.volume import Volume, VolumeSystem
 
 
 class DissectVolumeSystem(VolumeSystem):
+    __type__ = "disk"
+
     def __init__(self, fh: Union[BinaryIO, list[BinaryIO]], *args, **kwargs):
         self._disk = disk.Disk(fh)
         super().__init__(fh, serial=self._disk.serial, *args, **kwargs)

--- a/dissect/target/volumes/luks.py
+++ b/dissect/target/volumes/luks.py
@@ -17,7 +17,7 @@ class LUKSVolumeSystemError(VolumeSystemError):
 
 
 class LUKSVolumeSystem(EncryptedVolumeSystem):
-    PROVIDER = "luks"
+    __type__ = "luks"
 
     def __init__(self, fh: Union[BinaryIO, list[BinaryIO]], *args, **kwargs):
         super().__init__(fh, *args, **kwargs)

--- a/dissect/target/volumes/lvm.py
+++ b/dissect/target/volumes/lvm.py
@@ -22,6 +22,8 @@ KNOWN_SKIP_TYPES = (
 
 
 class LvmVolumeSystem(LogicalVolumeSystem):
+    __type__ = "lvm"
+
     def __init__(self, fh: Union[BinaryIO, list[BinaryIO]], *args, **kwargs):
         self.lvm = lvm.LVM2(fh)
         super().__init__(fh, *args, **kwargs)

--- a/dissect/target/volumes/md.py
+++ b/dissect/target/volumes/md.py
@@ -7,6 +7,8 @@ from dissect.target.volume import LogicalVolumeSystem, Volume
 
 
 class MdVolumeSystem(LogicalVolumeSystem):
+    __type__ = "md"
+
     def __init__(self, fh: Union[BinaryIO, list[BinaryIO]], *args, **kwargs):
         self.md = MD(fh)
         super().__init__(fh, *args, **kwargs)

--- a/dissect/target/volumes/vmfs.py
+++ b/dissect/target/volumes/vmfs.py
@@ -11,6 +11,8 @@ log = logging.getLogger(__name__)
 
 
 class VmfsVolumeSystem(LogicalVolumeSystem):
+    __type__ = "vmfs"
+
     def __init__(self, fh: Union[BinaryIO, list[BinaryIO]], *args, **kwargs):
         self.lvm = lvm.LVM(fh)
         super().__init__(fh, *args, **kwargs)

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -450,10 +450,14 @@ def test_empty_vs(target_bare: Target) -> None:
 
 def test_nested_vs(target_bare: Target) -> None:
     mock_base_volume = MagicMock()
+    mock_base_volume.offset = 0
+    mock_base_volume.vs = None
+    mock_base_volume.fs = None
     target_bare.volumes.add(mock_base_volume)
 
     mock_volume = MagicMock()
     mock_volume.offset = 0
+    mock_volume.vs.__type__ = "disk"
     mock_volume.fs = None
 
     mock_volume_system = MagicMock()
@@ -464,4 +468,31 @@ def test_nested_vs(target_bare: Target) -> None:
 
         target_bare.volumes.apply()
         filesystem_open.assert_called_once_with(mock_volume)
+        assert len(target_bare.volumes) == 2
+        assert len(target_bare.filesystems) == 1
+
+
+def test_vs_offset_0(target_bare: Target) -> None:
+    mock_disk = MagicMock()
+    mock_disk.vs = None
+    target_bare.disks.add(mock_disk)
+
+    mock_volume = MagicMock()
+    mock_volume.offset = 0
+    mock_volume.vs.__type__ = "disk"
+    mock_volume.fs = None
+
+    mock_volume_system = MagicMock()
+    mock_volume_system.volumes = [mock_volume]
+
+    with patch("dissect.target.volume.open") as volume_open, patch("dissect.target.filesystem.open") as filesystem_open:
+        volume_open.return_value = mock_volume_system
+
+        target_bare.disks.apply()
+        volume_open.assert_called_once_with(mock_disk)
+        assert len(target_bare.volumes) == 1
+
+        target_bare.volumes.apply()
+        filesystem_open.assert_called_once_with(mock_volume)
+        assert len(target_bare.volumes) == 1
         assert len(target_bare.filesystems) == 1

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -493,6 +493,8 @@ def test_vs_offset_0(target_bare: Target) -> None:
         assert len(target_bare.volumes) == 1
 
         target_bare.volumes.apply()
+        # volume.open must still only be called once
+        volume_open.assert_called_once_with(mock_disk)
         filesystem_open.assert_called_once_with(mock_volume)
         assert len(target_bare.volumes) == 1
         assert len(target_bare.filesystems) == 1

--- a/tests/volumes/test_bde.py
+++ b/tests/volumes/test_bde.py
@@ -39,7 +39,7 @@ def test_bde_volume_with_recovery_key(target_win, encrypted_volume):
         keychain.KeyType.RECOVERY_KEY,
         recovery_key,
         identifier=None,
-        provider=BitlockerVolumeSystem.PROVIDER,
+        provider=BitlockerVolumeSystem.__type__,
     )
 
     enc_vol = volume.Volume(encrypted_volume, 1, 0, None, None, None, disk=encrypted_volume)
@@ -67,7 +67,7 @@ def test_bde_volume_with_passphrase(target_win, encrypted_volume):
         keychain.KeyType.PASSPHRASE,
         passphrase,
         identifier=identifier,
-        provider=BitlockerVolumeSystem.PROVIDER,
+        provider=BitlockerVolumeSystem.__type__,
     )
 
     enc_vol = volume.Volume(encrypted_volume, 1, 0, None, None, None, disk=encrypted_volume)


### PR DESCRIPTION
As part of this fix I've introduced a `__type__` attribute to the `VolumeSystem` class. It's purpose is similar to `Filesystem.__fstype__` - being able to do some sort of type-check if you can't do a `isinstance()` check due to lazy importing.

In fact, I probably want to add it to `Container` too, and perhaps rename `Filesystem.__fstype__` to `Filesystem.__type__` - of course with the necessary deprecation warning and period.