### PR TITLE
Fix permission issues when tests are run on windows

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,18 +34,20 @@ if not pathlib.Path(data_dir).is_dir():
     )
 
 
-def make_mock_target():
-    with tempfile.NamedTemporaryFile(prefix="MockTarget-") as tmp_file:
+def make_mock_target(tmp_path):
+    with tempfile.NamedTemporaryFile(dir=tmp_path, prefix="MockTarget-", delete=False) as tmp_file:
+        tmp_file.close()
+
         target = Target()
         target.path = pathlib.Path(tmp_file.name)
         yield target
 
 
 @pytest.fixture
-def make_mock_targets(request):
+def make_mock_targets(request, tmp_path):
     def _make_targets(size):
         for _ in range(size):
-            yield from make_mock_target()
+            yield from make_mock_target(tmp_path)
 
     return _make_targets
 
@@ -186,22 +188,22 @@ def hive_hku():
 
 
 @pytest.fixture
-def target_bare():
+def target_bare(tmp_path):
     # A target without any associated OSPlugin
-    yield from make_mock_target()
+    yield from make_mock_target(tmp_path)
 
 
 @pytest.fixture
-def target_default():
-    mock_target = next(make_mock_target())
+def target_default(tmp_path):
+    mock_target = next(make_mock_target(tmp_path))
     mock_target._os_plugin = default.DefaultPlugin
     mock_target.apply()
     yield mock_target
 
 
 @pytest.fixture
-def target_win(hive_hklm, fs_win):
-    mock_target = next(make_mock_target())
+def target_win(tmp_path, hive_hklm, fs_win):
+    mock_target = next(make_mock_target(tmp_path))
     mock_target._os_plugin = WindowsPlugin
 
     mock_target.add_plugin(registry.RegistryPlugin, check_compatible=False)
@@ -219,8 +221,8 @@ def target_win(hive_hklm, fs_win):
 
 
 @pytest.fixture
-def target_unix(fs_unix):
-    mock_target = next(make_mock_target())
+def target_unix(tmp_path, fs_unix):
+    mock_target = next(make_mock_target(tmp_path))
     mock_target._os_plugin = UnixPlugin
 
     mock_target.filesystems.add(fs_unix)
@@ -230,8 +232,8 @@ def target_unix(fs_unix):
 
 
 @pytest.fixture
-def target_linux(fs_linux):
-    mock_target = next(make_mock_target())
+def target_linux(tmp_path, fs_linux):
+    mock_target = next(make_mock_target(tmp_path))
     mock_target._os_plugin = LinuxPlugin
 
     mock_target.filesystems.add(fs_linux)
@@ -241,8 +243,8 @@ def target_linux(fs_linux):
 
 
 @pytest.fixture
-def target_osx(fs_osx):
-    mock_target = next(make_mock_target())
+def target_osx(tmp_path, fs_osx):
+    mock_target = next(make_mock_target(tmp_path))
     mock_target._os_plugin = MacPlugin
 
     mock_target.filesystems.add(fs_osx)
@@ -259,8 +261,8 @@ def target_osx(fs_osx):
 
 
 @pytest.fixture
-def target_citrix(fs_bsd):
-    mock_target = next(make_mock_target())
+def target_citrix(tmp_path, fs_bsd):
+    mock_target = next(make_mock_target(tmp_path))
     mock_target._os_plugin = CitrixBsdPlugin
 
     mock_target.filesystems.add(fs_bsd)
@@ -278,8 +280,8 @@ def target_citrix(fs_bsd):
 
 
 @pytest.fixture
-def target_android(fs_android: VirtualFilesystem) -> Target:
-    mock_target = next(make_mock_target())
+def target_android(tmp_path, fs_android: VirtualFilesystem) -> Target:
+    mock_target = next(make_mock_target(tmp_path))
     mock_target._os_plugin = AndroidPlugin
     mock_target.filesystems.add(fs_android)
     mock_target.apply()

--- a/tests/filesystems/test_config.py
+++ b/tests/filesystems/test_config.py
@@ -17,10 +17,11 @@ from tests._utils import absolute_path
 
 @pytest.fixture
 def etc_directory(tmp_path: Path, fs_unix: VirtualFilesystem) -> VirtualFilesystem:
-    tmp_path.joinpath("new/path").mkdir(parents=True, exist_ok=True)
-    tmp_path.joinpath("new/config").mkdir(parents=True, exist_ok=True)
-    tmp_path.joinpath("new/path/config").write_text(Path(absolute_path("_data/helpers/configutil/config")).read_text())
-    fs_unix.map_dir("/etc", tmp_path)
+    etc_path = tmp_path.joinpath("etc/")
+    etc_path.joinpath("new/path").mkdir(parents=True, exist_ok=True)
+    etc_path.joinpath("new/config").mkdir(parents=True, exist_ok=True)
+    etc_path.joinpath("new/path/config").write_text(Path(absolute_path("_data/helpers/configutil/config")).read_text())
+    fs_unix.map_dir("/etc", etc_path)
 
     return fs_unix
 

--- a/tests/filesystems/test_dir.py
+++ b/tests/filesystems/test_dir.py
@@ -1,5 +1,4 @@
 import pathlib
-import platform
 import tempfile
 from unittest.mock import Mock, patch
 
@@ -8,11 +7,10 @@ import pytest
 from dissect.target.filesystems.dir import DirectoryFilesystem, DirectoryFilesystemEntry
 
 
-@pytest.mark.skipif(platform.system() == "Windows", reason="Raises permission exception on Windows. Needs to be fixed.")
 def test_filesystem_dir_symlink_to_file(tmp_path):
-    with tempfile.NamedTemporaryFile(dir=tmp_path) as tf:
+    with tempfile.NamedTemporaryFile(dir=tmp_path, delete=False) as tf:
         tf.write(b"dummy")
-        tf.flush()
+        tf.close()
 
         tmpfile_path = pathlib.Path(tf.name)
         symlink_path = tmp_path.joinpath("symlink")

--- a/tests/helpers/test_fsutil.py
+++ b/tests/helpers/test_fsutil.py
@@ -374,9 +374,9 @@ def test_fs_attrs_no_os_listxattr():
 
 
 def test_target_path_checks_dirfs(tmp_path, target_win):
-    with tempfile.NamedTemporaryFile(dir=tmp_path) as tf:
+    with tempfile.NamedTemporaryFile(dir=tmp_path, delete=False) as tf:
         tf.write(b"dummy")
-        tf.flush()
+        tf.close()
         tmpfile_name = os.path.basename(tf.name)
 
         fs = DirectoryFilesystem(path=tmp_path)
@@ -388,9 +388,9 @@ def test_target_path_checks_dirfs(tmp_path, target_win):
 
 
 def test_target_path_checks_mapped_dir(tmp_path, target_win):
-    with tempfile.NamedTemporaryFile(dir=tmp_path) as tf:
+    with tempfile.NamedTemporaryFile(dir=tmp_path, delete=False) as tf:
         tf.write(b"dummy")
-        tf.flush()
+        tf.close()
         tmpfile_name = os.path.basename(tf.name)
 
         target_win.filesystems.entries[0].map_dir("test-dir", tmp_path)
@@ -408,9 +408,9 @@ def test_target_path_checks_virtual():
 
 
 def test_target_path_backslash_normalisation(target_win, fs_win, tmp_path):
-    with tempfile.NamedTemporaryFile(dir=tmp_path) as tf:
+    with tempfile.NamedTemporaryFile(dir=tmp_path, delete=False) as tf:
         tf.write(b"dummy")
-        tf.flush()
+        tf.close()
 
         fs_win.map_dir("windows/system32/", tmp_path)
         fs_win.map_file("windows/system32/somefile.txt", tf.name)

--- a/tests/plugins/apps/browser/test_browser.py
+++ b/tests/plugins/apps/browser/test_browser.py
@@ -17,7 +17,6 @@ def test_iexplore_plugin(target_win, fs_win, tmp_path, target_win_users):
     with tempfile.NamedTemporaryFile(dir=tmp_path, delete=False) as tf:
         with gzip.GzipFile(cache_archive, "rb") as f:
             tf.write(f.read())
-        tf.flush()
         tf.close()
 
         user = target_win_users.user_details.find(username="John")

--- a/tests/plugins/filesystem/test_yara.py
+++ b/tests/plugins/filesystem/test_yara.py
@@ -9,7 +9,7 @@ from dissect.target.filesystem import VirtualFilesystem
 yara = pytest.importorskip("dissect.target.plugins.filesystem.yara", reason="yara-python module unavailable")
 
 
-def test_yara_plugin(target_default):
+def test_yara_plugin(tmp_path, target_default):
     test_rule = """
     rule test_rule_name {
         strings:
@@ -25,9 +25,8 @@ def test_yara_plugin(target_default):
 
     target_default.filesystems.add(vfs)
 
-    with tempfile.NamedTemporaryFile("w+t", delete=False) as tmp_file:
+    with tempfile.NamedTemporaryFile(mode="w+t", dir=tmp_path, delete=False) as tmp_file:
         tmp_file.write(test_rule)
-        tmp_file.flush()
         tmp_file.close()
 
         target_default.add_plugin(yara.YaraPlugin)

--- a/tests/plugins/os/unix/test__os.py
+++ b/tests/plugins/os/unix/test__os.py
@@ -1,8 +1,5 @@
-import platform
 import tempfile
 from uuid import UUID
-
-import pytest
 
 from dissect.target.filesystem import VirtualFilesystem
 from dissect.target.plugins.os.unix._os import parse_fstab
@@ -40,11 +37,10 @@ UUID=F631-BECA                            /boot/efi    vfat    defaults,discard,
 """  # noqa
 
 
-@pytest.mark.skipif(platform.system() == "Windows", reason="Permission Error. Needs to be fixed.")
-def test_parse_fstab():
-    with tempfile.NamedTemporaryFile() as tf:
+def test_parse_fstab(tmp_path):
+    with tempfile.NamedTemporaryFile(dir=tmp_path, delete=False) as tf:
         tf.write(FSTAB_CONTENT.encode("ascii"))
-        tf.flush()
+        tf.close()
 
         fs = VirtualFilesystem()
         fs.map_file("/etc/fstab", tf.name)

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -462,11 +462,11 @@ def test_virtual_filesystem_mount(vfs):
     assert vfs.mount == vfs.map_fs
 
 
-def test_virtual_filesystem_map_dir():
+def test_virtual_filesystem_map_dir(tmp_path):
     vfs = VirtualFilesystem()
     vfs_path = "/map/point/"
     with (
-        TemporaryDirectory() as tmp_dir,
+        TemporaryDirectory(dir=tmp_path) as tmp_dir,
         TemporaryDirectory(dir=tmp_dir) as some_dir,
         TemporaryDirectory(dir=tmp_dir) as other_dir,
         TemporaryDirectory(dir=other_dir) as second_lvl_dir,

--- a/tests/tools/test_dump.py
+++ b/tests/tools/test_dump.py
@@ -57,7 +57,7 @@ def test_execute_pipeline(
     with patch("dissect.target.tools.dump.run.get_targets", new=mock_get_targets), patch(
         "dissect.target.tools.dump.run.log_progress", new=mock_log_progress
     ):
-        output_dir = tmp_path
+        output_dir = tmp_path / "output"
 
         serialization = utils.Serialization(serialization_name)
         compression = utils.Compression(compression_name)
@@ -148,7 +148,7 @@ def test_execute_pipeline_limited(limit, target_win_iis_amcache, tmp_path):
     with patch("dissect.target.tools.dump.run.get_targets", new=mock_get_targets), patch(
         "dissect.target.tools.dump.run.log_progress", new=mock_log_progress
     ):
-        output_dir = tmp_path
+        output_dir = tmp_path / "output"
 
         functions = ["iis.logs", "amcache.applications"]
 

--- a/tests/tools/test_shell.py
+++ b/tests/tools/test_shell.py
@@ -233,19 +233,22 @@ def test_target_cli_print_extensive_file_stat_fail(target_win, capsys):
     ],
 )
 def test_target_cli_save(target_win, tmp_path, folders, files, save, expected):
+    output_dir = tmp_path / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
     cli = TargetCli(target_win)
     for folder in folders.split("|"):
         target_win.fs.root.makedirs(folder)
     for _file in files.split("|"):
         target_win.fs.root.map_file_fh(_file, BytesIO(_file.encode("utf-8")))
-    args = argparse.Namespace(path=[save], out=tmp_path, verbose=False)
+    args = argparse.Namespace(path=[save], out=output_dir, verbose=False)
     cli.cmd_save(args, sys.stdout)
 
     def _map_function(path: Path) -> str:
-        relative_path = str(path.relative_to(tmp_path))
+        relative_path = str(path.relative_to(output_dir))
         return normalize(relative_path, alt_separator=target_win.fs.alt_separator)
 
-    path_map = map(lambda path: _map_function(path), tmp_path.rglob("*"))
+    path_map = map(lambda path: _map_function(path), output_dir.rglob("*"))
     tree = "|".join(sorted(path_map))
 
     assert tree == expected


### PR DESCRIPTION
On Windows, files can not be opened when already open. This gives issues when using temporary files. By not deleting a temporaryfile after it is closed and closing it after it is created, this is circumvented.

By moving all these files into pytest's tmp_path, the tmp_path mechanism will take care of removing these temporary files.