### PR TITLE
Fix unix activity plugin

### DIFF
--- a/dissect/target/plugins/os/unix/generic.py
+++ b/dissect/target/plugins/os/unix/generic.py
@@ -20,6 +20,8 @@ class GenericPlugin(Plugin):
 
         last_seen = 0
         for f in var_log.iterdir():
+            if f.is_symlink() or not f.exists():
+                continue
             if f.stat().st_mtime > last_seen:
                 last_seen = f.stat().st_mtime
 

--- a/dissect/target/plugins/os/unix/generic.py
+++ b/dissect/target/plugins/os/unix/generic.py
@@ -20,7 +20,7 @@ class GenericPlugin(Plugin):
 
         last_seen = 0
         for f in var_log.iterdir():
-            if f.is_symlink() or not f.exists():
+            if not f.exists():
                 continue
             if f.stat().st_mtime > last_seen:
                 last_seen = f.stat().st_mtime

--- a/dissect/target/tools/info.py
+++ b/dissect/target/tools/info.py
@@ -86,7 +86,8 @@ def main():
                     print("-" * 70)
                 print_target_info(target)
         except Exception as e:
-            target.log.error("Exception in retrieving information for target: `%s`", target, exc_info=e)
+            target.log.error("Exception in retrieving information for target: `%s`. Use `-vv` for details.", target)
+            target.log.debug("", exc_info=e)
 
 
 def get_target_info(target: Target) -> dict[str, Union[str, list[str]]]:


### PR DESCRIPTION
When a target system contains (broken) symlinks in `/var/log, the activity plugin could break. This is now fixed by checking if a file is a symlink or if it exists at all.