### PR TITLE
Fix MRUList assumption

### DIFF
--- a/dissect/target/plugins/os/windows/regf/mru.py
+++ b/dissect/target/plugins/os/windows/regf/mru.py
@@ -332,7 +332,7 @@ def parse_mru_key(target, key, record):
         if value.name == "MRUList":
             continue
 
-        entry_index = mrulist.index(value.name)
+        entry_index = mrulist.index(value.name) if mrulist else None
         entry_value = value.value
 
         yield record(

--- a/dissect/target/plugins/os/windows/regf/mru.py
+++ b/dissect/target/plugins/os/windows/regf/mru.py
@@ -322,7 +322,11 @@ class MRUPlugin(Plugin):
 
 def parse_mru_key(target, key, record):
     user = target.registry.get_user(key)
-    mrulist = key.value("MRUList").value
+
+    try:
+        mrulist = key.value("MRUList").value
+    except RegistryError:
+        mrulist = None
 
     for value in key.values():
         if value.name == "MRUList":


### PR DESCRIPTION
An MRU key does not always have a `MRUList` key/value pair. This assumption is now fixed.