### PR TITLE
Fix for logloader

### DIFF
--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -488,6 +488,10 @@ class Target:
         counter = 0
         path = "/$fs$/fs0"
 
+        # VirtualFilesystem does not have mounts.
+        if not hasattr(root_fs, "mounts"):
+            return
+
         for fs in self.filesystems:
             if fs not in root_fs.mounts.values():
                 # determine mount point


### PR DESCRIPTION
The patch below fixes the `LogLoader`. This should now work (again): 

```
target-query -f evtx log:///absolute/path/to/*.evtx