### PR TITLE
Fix boolean parsing in OpenVPNPlugin

### DIFF
--- a/dissect/target/plugins/apps/vpn/openvpn.py
+++ b/dissect/target/plugins/apps/vpn/openvpn.py
@@ -167,7 +167,7 @@ def _parse_config(content: str) -> dict[str, Union[str, list[str]]]:
     lines = content.splitlines()
     res = {}
     boolean_fields = OpenVPNServer.getfields("boolean") + OpenVPNClient.getfields("boolean")
-    boolean_field_names = (field.name for field in boolean_fields)
+    boolean_field_names = set(field.name for field in boolean_fields)
 
     for line in lines:
         # As per man (8) openvpn, lines starting with ; or # are comments

--- a/dissect/target/plugins/apps/vpn/openvpn.py
+++ b/dissect/target/plugins/apps/vpn/openvpn.py
@@ -167,17 +167,19 @@ def _parse_config(content: str) -> dict[str, Union[str, list[str]]]:
     lines = content.splitlines()
     res = {}
     boolean_fields = OpenVPNServer.getfields("boolean") + OpenVPNClient.getfields("boolean")
+    boolean_field_names = (field.name for field in boolean_fields)
 
     for line in lines:
         # As per man (8) openvpn, lines starting with ; or # are comments
         if line and not line.startswith((";", "#")):
             key, *value = line.split(" ", 1)
-            if any(key == boolean_field.name for boolean_field in boolean_fields):
-                value = value[0] if value else True
-            else:
-                value = value[0] if value else ""
-                # This removes all text after the first comment
-                value = CONFIG_COMMENT_SPLIT_REGEX.split(value, 1)[0].strip()
+            value = value[0] if value else ""
+            # This removes all text after the first comment
+            value = CONFIG_COMMENT_SPLIT_REGEX.split(value, 1)[0].strip()
+
+            if key in boolean_field_names and value == "":
+                value = True
+
             if old_value := res.get(key):
                 if not isinstance(old_value, list):
                     old_value = [old_value]

--- a/dissect/target/plugins/apps/vpn/openvpn.py
+++ b/dissect/target/plugins/apps/vpn/openvpn.py
@@ -155,7 +155,7 @@ class OpenVPNPlugin(Plugin):
                     server=config.get("server"),
                     ifconfig_pool_persist=config.get("ifconfig-pool-persist"),
                     pushed_options=pushed_options,
-                    client_to_client=config.get("client-to-client", False),
+                    client_to_client=(False if config.get("client-to-client", False) == "" else config.get("client-to-client", False)),
                     duplicate_cn=config.get("duplicate-cn", False),
                     source=config_path,
                     _target=self.target,


### PR DESCRIPTION
Resolved an issue in the OpenVPNPlugin where the 'client-to-client' configuration option was incorrectly processed. Previously, the code attempted to use the value directly from the configuration, which led to errors when this value was an empty string. This fix ensures that an empty string for 'client-to-client' defaults to False, aligning with the expected boolean behavior of this configuration parameter.