### PR TITLE
Add support for birth timestamps in extfs / walkfs

### DIFF
--- a/dissect/target/filesystems/extfs.py
+++ b/dissect/target/filesystems/extfs.py
@@ -125,6 +125,10 @@ class ExtFilesystemEntry(FilesystemEntry):
             ]
         )
 
+        # Set birthtime if available
+        if self.entry.crtime:
+            st_info.st_birthtime = self.entry.crtime.timestamp()
+
         # Set the nanosecond resolution separately
         st_info.st_atime_ns = self.entry.atime_ns
         st_info.st_mtime_ns = self.entry.mtime_ns

--- a/dissect/target/plugins/filesystem/walkfs.py
+++ b/dissect/target/plugins/filesystem/walkfs.py
@@ -48,6 +48,7 @@ class WalkFSPlugin(Plugin):
 
 def generate_record(target: Target, path: TargetPath) -> FilesystemRecord:
     stat = path.lstat()
+    btime = from_unix(stat.st_birthtime) if stat.st_birthtime else None
     entry = path.get()
     if isinstance(entry, RootFilesystemEntry):
         fs_types = [sub_entry.fs.__type__ for sub_entry in entry.entries]
@@ -57,6 +58,7 @@ def generate_record(target: Target, path: TargetPath) -> FilesystemRecord:
         atime=from_unix(stat.st_atime),
         mtime=from_unix(stat.st_mtime),
         ctime=from_unix(stat.st_ctime),
+        btime=btime,
         ino=stat.st_ino,
         path=path,
         size=stat.st_size,


### PR DESCRIPTION
The walkfs plugin would always report btime=None, which is a shame since ext4 does support birth timestamps (called crtime in ext lingo).

dissect.extfs already supported crtime, so a simple fix suffices.