### PR TITLE
Refactor TargetPath and add support for Python 3.12

### DIFF
--- a/dissect/target/filesystem.py
+++ b/dissect/target/filesystem.py
@@ -1240,12 +1240,22 @@ class VirtualFilesystem(Filesystem):
             directory.add(entry_name, entry)
 
     def link(self, src: str, dst: str) -> None:
-        """Hard link a FilesystemEntry to another location."""
+        """Hard link a FilesystemEntry to another location.
+
+        Args:
+            src: The path to the target of the link.
+            dst: The path to the link.
+        """
         self.map_file_entry(dst, self.get(src))
 
     def symlink(self, src: str, dst: str) -> None:
-        """Create a symlink to another location."""
-        src = fsutil.normalize(src, alt_separator=self.alt_separator).strip("/")
+        """Create a symlink to another location.
+
+        Args:
+            src: The path to the target of the symlink.
+            dst: The path to the symlink.
+        """
+        src = fsutil.normalize(src, alt_separator=self.alt_separator).rstrip("/")
         dst = fsutil.normalize(dst, alt_separator=self.alt_separator).strip("/")
         self.map_file_entry(dst, VirtualSymlink(self, dst, src))
 

--- a/dissect/target/helpers/compat/path_310.py
+++ b/dissect/target/helpers/compat/path_310.py
@@ -1,0 +1,506 @@
+"""A pathlib.Path compatible implementation for dissect.target.
+
+This allows for the majority of the pathlib.Path API to "just work" on dissect.target filesystems.
+
+Most of this consists of subclassed internal classes with dissect.target specific patches,
+but sometimes the change to a function is small, so the entire internal function is copied
+and only a small part changed. To ease updating this code, the order of functions, comments
+and code style is kept largely the same as the original pathlib.py.
+
+Yes, we know, this is playing with fire and it can break on new CPython releases.
+
+The implementation is split up in multiple files, one for each CPython version.
+You're currently looking at the CPython 3.10 implementation.
+
+Commit hash we're in sync with: b382bf5
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from pathlib import Path, PurePath, _Accessor, _PosixFlavour
+from stat import S_ISBLK, S_ISCHR, S_ISFIFO, S_ISSOCK
+from typing import IO, TYPE_CHECKING, Any, Callable, Iterator, Optional
+
+from dissect.target import filesystem
+from dissect.target.exceptions import FilesystemError, SymlinkRecursionError
+from dissect.target.helpers.compat.path_common import (
+    _DissectPathParents,
+    io_open,
+    isjunction,
+    realpath,
+    scandir,
+)
+from dissect.target.helpers.polypath import normalize
+
+if TYPE_CHECKING:
+    from dissect.target.filesystem import Filesystem, FilesystemEntry
+    from dissect.target.helpers.compat.path_common import _DissectScandirIterator
+    from dissect.target.helpers.fsutil import stat_result
+
+
+class _DissectFlavour(_PosixFlavour):
+    is_supported = True
+
+    __variant_instances = {}
+
+    def __new__(cls, case_sensitive: bool = False, alt_separator: str = ""):
+        idx = (case_sensitive, alt_separator)
+        instance = cls.__variant_instances.get(idx, None)
+        if instance is None:
+            instance = _PosixFlavour.__new__(cls)
+            cls.__variant_instances[idx] = instance
+
+        return instance
+
+    def __init__(self, case_sensitive: bool = False, alt_separator: str = ""):
+        super().__init__()
+        self.altsep = alt_separator
+        self.case_sensitive = case_sensitive
+
+    def casefold(self, s: str) -> str:
+        return s if self.case_sensitive else s.lower()
+
+    def casefold_parts(self, parts: list[str]) -> list[str]:
+        return parts if self.case_sensitive else [p.lower() for p in parts]
+
+    def compile_pattern(self, pattern: str) -> Callable[..., Any]:
+        return re.compile(fnmatch.translate(pattern), 0 if self.case_sensitive else re.IGNORECASE).fullmatch
+
+
+class _DissectAccessor(_Accessor):
+    @staticmethod
+    def stat(path: TargetPath, *, follow_symlinks: bool = True) -> stat_result:
+        if follow_symlinks:
+            return path.get().stat()
+        else:
+            return path.get().lstat()
+
+    @staticmethod
+    def open(
+        path: TargetPath,
+        mode: str = "rb",
+        buffering: int = 0,
+        encoding: Optional[str] = None,
+        errors: Optional[str] = None,
+        newline: Optional[str] = None,
+    ) -> IO:
+        """Open file and return a stream.
+
+        Supports a subset of features of the real pathlib.open/io.open.
+
+        Note: in contrast to regular Python, the mode is binary by default. Text mode
+        has to be explicitly specified. Buffering is also disabled by default.
+        """
+        return io_open(path, mode, buffering, encoding, errors, newline)
+
+    @staticmethod
+    def listdir(path: TargetPath) -> Iterator[str]:
+        return path.get().listdir()
+
+    @staticmethod
+    def scandir(path: TargetPath) -> _DissectScandirIterator:
+        return scandir(path)
+
+    @staticmethod
+    def chmod(path: TargetPath, mode: int, *, follow_symlinks: bool = True) -> None:
+        raise NotImplementedError("TargetPath.chmod() is unsupported")
+
+    @staticmethod
+    def lchmod(path: TargetPath, mode: int) -> None:
+        raise NotImplementedError("TargetPath.lchmod() is unsupported")
+
+    @staticmethod
+    def mkdir(path: TargetPath, mode: int = 0o777, parents: bool = False, exist_ok: bool = False) -> None:
+        raise NotImplementedError("TargetPath.mkdir() is unsupported")
+
+    @staticmethod
+    def unlink(path: TargetPath, missing_ok: bool = False) -> None:
+        raise NotImplementedError("TargetPath.unlink() is unsupported")
+
+    @staticmethod
+    def link(src: str, dst: TargetPath) -> None:
+        raise NotImplementedError("TargetPath.link() is unsupported")
+
+    @staticmethod
+    def rmdir(path: TargetPath) -> None:
+        raise NotImplementedError("TargetPath.rmdir() is unsupported")
+
+    @staticmethod
+    def rename(path: TargetPath, target: str) -> str:
+        raise NotImplementedError("TargetPath.rename() is unsupported")
+
+    @staticmethod
+    def replace(path: TargetPath, target: str) -> str:
+        raise NotImplementedError("TargetPath.replace() is unsupported")
+
+    @staticmethod
+    def symlink(path: TargetPath, target: str, target_is_directory: bool = False) -> None:
+        raise NotImplementedError("TargetPath.symlink() is unsupported")
+
+    @staticmethod
+    def touch(path: TargetPath, mode: int = 0o666, exist_ok: bool = True) -> None:
+        raise NotImplementedError("TargetPath.touch() is unsupported")
+
+    @staticmethod
+    def readlink(path: TargetPath) -> str:
+        return path.get().readlink()
+
+    @staticmethod
+    def owner(path: TargetPath) -> str:
+        raise NotImplementedError("TargetPath.owner() is unsupported")
+
+    @staticmethod
+    def group(path: TargetPath) -> str:
+        raise NotImplementedError("TargetPath.group() is unsupported")
+
+    @staticmethod
+    def getcwd() -> str:
+        raise NotImplementedError("TargetPath.getcwd() is unsupported")
+
+    @staticmethod
+    def expanduser(path: str) -> str:
+        raise NotImplementedError("TargetPath.expanduser() is unsupported")
+
+    realpath = staticmethod(realpath)
+
+    # NOTE: Forward compatibility with CPython >= 3.12
+    isjunction = staticmethod(isjunction)
+
+
+_dissect_accessor = _DissectAccessor()
+
+
+class PureDissectPath(PurePath):
+    _fs: Filesystem
+    _flavour = _DissectFlavour(case_sensitive=False)
+
+    def __reduce__(self) -> tuple:
+        raise TypeError("TargetPath pickling is currently not supported")
+
+    @classmethod
+    def _from_parts(cls, args: list) -> TargetPath:
+        fs = args[0]
+
+        if not isinstance(fs, filesystem.Filesystem):
+            raise TypeError(
+                "invalid PureDissectPath initialization: missing filesystem, "
+                "got %r (this might be a bug, please report)" % args
+            )
+
+        alt_separator = fs.alt_separator
+        path_args = []
+        for arg in args[1:]:
+            if isinstance(arg, str):
+                arg = normalize(arg, alt_separator=alt_separator)
+            path_args.append(arg)
+
+        self = super()._from_parts(path_args)
+        self._fs = fs
+
+        self._flavour = _DissectFlavour(alt_separator=fs.alt_separator, case_sensitive=fs.case_sensitive)
+
+        return self
+
+    def _make_child(self, args: list) -> TargetPath:
+        child = super()._make_child(args)
+        child._fs = self._fs
+        child._flavour = self._flavour
+        return child
+
+    def with_name(self, name: str) -> TargetPath:
+        result = super().with_name(name)
+        result._fs = self._fs
+        result._flavour = self._flavour
+        return result
+
+    def with_stem(self, stem: str) -> TargetPath:
+        result = super().with_stem(stem)
+        result._fs = self._fs
+        result._flavour = self._flavour
+        return result
+
+    def with_suffix(self, suffix: str) -> TargetPath:
+        result = super().with_suffix(suffix)
+        result._fs = self._fs
+        result._flavour = self._flavour
+        return result
+
+    def relative_to(self, *other) -> TargetPath:
+        result = super().relative_to(*other)
+        result._fs = self._fs
+        result._flavour = self._flavour
+        return result
+
+    def __rtruediv__(self, key: str) -> TargetPath:
+        try:
+            return self._from_parts([self._fs, key] + self._parts)
+        except TypeError:
+            return NotImplemented
+
+    @property
+    def parent(self) -> TargetPath:
+        result = super().parent
+        result._fs = self._fs
+        result._flavour = self._flavour
+        return result
+
+    @property
+    def parents(self) -> _DissectPathParents:
+        return _DissectPathParents(self)
+
+
+class TargetPath(Path, PureDissectPath):
+    _accessor = _dissect_accessor
+    __slots__ = ("_entry",)
+
+    def _make_child_relpath(self, part: str) -> TargetPath:
+        child = super()._make_child_relpath(part)
+        child._fs = self._fs
+        child._flavour = self._flavour
+        return child
+
+    def get(self) -> FilesystemEntry:
+        try:
+            return self._entry
+        except AttributeError:
+            self._entry = self._fs.get(str(self))
+            return self._entry
+
+    @classmethod
+    def cwd(cls) -> TargetPath:
+        """Return a new path pointing to the current working directory
+        (as returned by os.getcwd()).
+        """
+        raise NotImplementedError("TargetPath.cwd() is unsupported")
+
+    @classmethod
+    def home(cls) -> TargetPath:
+        """Return a new path pointing to the user's home directory (as
+        returned by os.path.expanduser('~')).
+        """
+        raise NotImplementedError("TargetPath.home() is unsupported")
+
+    def iterdir(self) -> Iterator[TargetPath]:
+        """Iterate over the files in this directory.  Does not yield any
+        result for the special paths '.' and '..'.
+        """
+        for entry in self._accessor.scandir(self):
+            if entry.name in {".", ".."}:
+                # Yielding a path object for these makes little sense
+                continue
+            child_path = self._make_child_relpath(entry.name)
+            child_path._entry = entry
+            yield child_path
+
+    # NOTE: Forward compatibility with CPython >= 3.12
+    def walk(
+        self, top_down: bool = True, on_error: Callable[[Exception], None] = None, follow_symlinks: bool = False
+    ) -> Iterator[tuple[TargetPath, list[str], list[str]]]:
+        """Walk the directory tree from this directory, similar to os.walk()."""
+        paths = [self]
+
+        while paths:
+            path = paths.pop()
+            if isinstance(path, tuple):
+                yield path
+                continue
+
+            # We may not have read permission for self, in which case we can't
+            # get a list of the files the directory contains. os.walk()
+            # always suppressed the exception in that instance, rather than
+            # blow up for a minor reason when (say) a thousand readable
+            # directories are still left to visit. That logic is copied here.
+            try:
+                scandir_it = self._accessor.scandir(path)
+            except OSError as error:
+                if on_error is not None:
+                    on_error(error)
+                continue
+
+            with scandir_it:
+                dirnames = []
+                filenames = []
+                for entry in scandir_it:
+                    try:
+                        is_dir = entry.is_dir(follow_symlinks=follow_symlinks)
+                    except OSError:
+                        # Carried over from os.path.isdir().
+                        is_dir = False
+
+                    if is_dir:
+                        dirnames.append(entry.name)
+                    else:
+                        filenames.append(entry.name)
+
+            if top_down:
+                yield path, dirnames, filenames
+            else:
+                paths.append((path, dirnames, filenames))
+
+            paths += [path._make_child_relpath(d) for d in reversed(dirnames)]
+
+    def absolute(self) -> TargetPath:
+        """Return an absolute version of this path.  This function works
+        even if the path doesn't point to anything.
+
+        No normalization is done, i.e. all '.' and '..' will be kept along.
+        Use resolve() to get the canonical path to a file.
+        """
+        raise NotImplementedError("TargetPath.absolute() is unsupported in Dissect")
+
+    # NOTE: We changed some of the error handling here to deal with our own exception types
+    def resolve(self, strict: bool = False) -> TargetPath:
+        """
+        Make the path absolute, resolving all symlinks on the way and also
+        normalizing it (for example turning slashes into backslashes under
+        Windows).
+        """
+
+        s = self._accessor.realpath(self, strict=strict)
+        p = self._from_parts((self._fs, s))
+
+        # In non-strict mode, realpath() doesn't raise on symlink loops.
+        # Ensure we get an exception by calling stat()
+        if not strict:
+            try:
+                p.stat()
+            except FilesystemError as e:
+                if isinstance(e, SymlinkRecursionError):
+                    raise
+        return p
+
+    def stat(self, *, follow_symlinks: bool = True) -> stat_result:
+        """
+        Return the result of the stat() system call on this path, like
+        os.stat() does.
+        """
+        return self._accessor.stat(self, follow_symlinks=follow_symlinks)
+
+    def open(
+        self,
+        mode: str = "rb",
+        buffering: int = 0,
+        encoding: Optional[str] = None,
+        errors: Optional[str] = None,
+        newline: Optional[str] = None,
+    ) -> IO:
+        """Open file and return a stream.
+
+        Supports a subset of features of the real pathlib.open/io.open.
+
+        Note: in contrast to regular Python, the mode is binary by default. Text mode
+        has to be explicitly specified. Buffering is also disabled by default.
+        """
+        return self._accessor.open(self, mode, buffering, encoding, errors, newline)
+
+    def write_bytes(self, data: bytes) -> int:
+        """
+        Open the file in bytes mode, write to it, and close the file.
+        """
+        raise NotImplementedError("TargetPath.write_bytes() is unsupported")
+
+    def write_text(
+        self, data: str, encoding: Optional[str] = None, errors: Optional[str] = None, newline: Optional[str] = None
+    ) -> int:
+        """
+        Open the file in text mode, write to it, and close the file.
+        """
+        raise NotImplementedError("TargetPath.write_text() is unsupported")
+
+    def readlink(self) -> TargetPath:
+        """
+        Return the path to which the symbolic link points.
+        """
+        path = self._accessor.readlink(self)
+        obj = self._from_parts((self._fs, path))
+        return obj
+
+    def exists(self) -> bool:
+        """
+        Whether this path exists.
+        """
+        try:
+            # .exists() must resolve possible symlinks
+            self.get().stat()
+            return True
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_dir(self) -> bool:
+        """
+        Whether this path is a directory.
+        """
+        try:
+            return self.get().is_dir()
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_file(self) -> bool:
+        """
+        Whether this path is a regular file (also True for symlinks pointing
+        to regular files).
+        """
+        try:
+            return self.get().is_file()
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_symlink(self) -> bool:
+        """
+        Whether this path is a symbolic link.
+        """
+        try:
+            return self.get().is_symlink()
+        except (FilesystemError, ValueError):
+            return False
+
+    # NOTE: Forward compatibility with CPython >= 3.12
+    def is_junction(self) -> bool:
+        """
+        Whether this path is a junction.
+        """
+        return self._accessor.isjunction(self)
+
+    def is_block_device(self) -> bool:
+        """
+        Whether this path is a block device.
+        """
+        try:
+            return S_ISBLK(self.stat().st_mode)
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_char_device(self) -> bool:
+        """
+        Whether this path is a character device.
+        """
+        try:
+            return S_ISCHR(self.stat().st_mode)
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_fifo(self) -> bool:
+        """
+        Whether this path is a FIFO.
+        """
+        try:
+            return S_ISFIFO(self.stat().st_mode)
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_socket(self) -> bool:
+        """
+        Whether this path is a socket.
+        """
+        try:
+            return S_ISSOCK(self.stat().st_mode)
+        except (FilesystemError, ValueError):
+            return False
+
+    def expanduser(self) -> TargetPath:
+        """Return a new path with expanded ~ and ~user constructs
+        (as returned by os.path.expanduser)
+        """
+        raise NotImplementedError("TargetPath.expanduser() is unsupported")

--- a/dissect/target/helpers/compat/path_311.py
+++ b/dissect/target/helpers/compat/path_311.py
@@ -1,0 +1,539 @@
+"""A pathlib.Path compatible implementation for dissect.target.
+
+This allows for the majority of the pathlib.Path API to "just work" on dissect.target filesystems.
+
+Most of this consists of subclassed internal classes with dissect.target specific patches,
+but sometimes the change to a function is small, so the entire internal function is copied
+and only a small part changed. To ease updating this code, the order of functions, comments
+and code style is kept largely the same as the original pathlib.py.
+
+Yes, we know, this is playing with fire and it can break on new CPython releases.
+
+The implementation is split up in multiple files, one for each CPython version.
+You're currently looking at the CPython 3.11 implementation.
+
+Commit hash we're in sync with: 846a23d
+
+Notes:
+    - CPython 3.11 ditched the _Accessor class, so we override the methods that should use it
+"""
+from __future__ import annotations
+
+import fnmatch
+import re
+from pathlib import Path, PurePath, _PosixFlavour
+from stat import S_ISBLK, S_ISCHR, S_ISFIFO, S_ISSOCK
+from typing import IO, TYPE_CHECKING, Any, Callable, Iterator, Optional
+
+from dissect.target import filesystem
+from dissect.target.exceptions import (
+    FileNotFoundError,
+    FilesystemError,
+    NotADirectoryError,
+    NotASymlinkError,
+    SymlinkRecursionError,
+)
+from dissect.target.helpers.compat.path_common import (
+    _DissectPathParents,
+    io_open,
+    isjunction,
+    realpath,
+    scandir,
+)
+from dissect.target.helpers.polypath import normalize
+
+if TYPE_CHECKING:
+    from dissect.target.filesystem import Filesystem, FilesystemEntry
+    from dissect.target.helpers.compat.path_common import _DissectScandirIterator
+    from dissect.target.helpers.fsutil import stat_result
+
+
+class _DissectFlavour(_PosixFlavour):
+    is_supported = True
+
+    __variant_instances = {}
+
+    def __new__(cls, case_sensitive: bool = False, alt_separator: str = ""):
+        idx = (case_sensitive, alt_separator)
+        instance = cls.__variant_instances.get(idx, None)
+        if instance is None:
+            instance = _PosixFlavour.__new__(cls)
+            cls.__variant_instances[idx] = instance
+
+        return instance
+
+    def __init__(self, case_sensitive: bool = False, alt_separator: str = ""):
+        super().__init__()
+        self.altsep = alt_separator
+        self.case_sensitive = case_sensitive
+
+    def casefold(self, s: str) -> str:
+        return s if self.case_sensitive else s.lower()
+
+    def casefold_parts(self, parts: list[str]) -> list[str]:
+        return parts if self.case_sensitive else [p.lower() for p in parts]
+
+    def compile_pattern(self, pattern: str) -> Callable[..., Any]:
+        return re.compile(fnmatch.translate(pattern), 0 if self.case_sensitive else re.IGNORECASE).fullmatch
+
+    def is_reserved(self, parts: list[str]) -> bool:
+        return False
+
+
+class PureDissectPath(PurePath):
+    _fs: Filesystem
+    _flavour = _DissectFlavour(case_sensitive=False)
+
+    def __reduce__(self) -> tuple:
+        raise TypeError("TargetPath pickling is currently not supported")
+
+    @classmethod
+    def _from_parts(cls, args: list) -> TargetPath:
+        fs = args[0]
+
+        if not isinstance(fs, filesystem.Filesystem):
+            raise TypeError(
+                "invalid PureDissectPath initialization: missing filesystem, "
+                "got %r (this might be a bug, please report)" % args
+            )
+
+        alt_separator = fs.alt_separator
+        path_args = []
+        for arg in args[1:]:
+            if isinstance(arg, str):
+                arg = normalize(arg, alt_separator=alt_separator)
+            path_args.append(arg)
+
+        self = super()._from_parts(path_args)
+        self._fs = fs
+
+        self._flavour = _DissectFlavour(alt_separator=fs.alt_separator, case_sensitive=fs.case_sensitive)
+
+        return self
+
+    def _make_child(self, args: list) -> TargetPath:
+        child = super()._make_child(args)
+        child._fs = self._fs
+        child._flavour = self._flavour
+        return child
+
+    def with_name(self, name: str) -> TargetPath:
+        result = super().with_name(name)
+        result._fs = self._fs
+        result._flavour = self._flavour
+        return result
+
+    def with_stem(self, stem: str) -> TargetPath:
+        result = super().with_stem(stem)
+        result._fs = self._fs
+        result._flavour = self._flavour
+        return result
+
+    def with_suffix(self, suffix: str) -> TargetPath:
+        result = super().with_suffix(suffix)
+        result._fs = self._fs
+        result._flavour = self._flavour
+        return result
+
+    def relative_to(self, *other) -> TargetPath:
+        result = super().relative_to(*other)
+        result._fs = self._fs
+        result._flavour = self._flavour
+        return result
+
+    def __rtruediv__(self, key: str) -> TargetPath:
+        try:
+            return self._from_parts([self._fs, key] + self._parts)
+        except TypeError:
+            return NotImplemented
+
+    @property
+    def parent(self) -> TargetPath:
+        result = super().parent
+        result._fs = self._fs
+        result._flavour = self._flavour
+        return result
+
+    @property
+    def parents(self) -> _DissectPathParents:
+        return _DissectPathParents(self)
+
+
+class TargetPath(Path, PureDissectPath):
+    __slots__ = ("_entry",)
+
+    def _make_child_relpath(self, part: str) -> TargetPath:
+        child = super()._make_child_relpath(part)
+        child._fs = self._fs
+        child._flavour = self._flavour
+        return child
+
+    def get(self) -> FilesystemEntry:
+        try:
+            return self._entry
+        except AttributeError:
+            self._entry = self._fs.get(str(self))
+            return self._entry
+
+    @classmethod
+    def cwd(cls) -> TargetPath:
+        """Return a new path pointing to the current working directory
+        (as returned by os.getcwd()).
+        """
+        raise NotImplementedError("TargetPath.cwd() is unsupported")
+
+    @classmethod
+    def home(cls) -> TargetPath:
+        """Return a new path pointing to the user's home directory (as
+        returned by os.path.expanduser('~')).
+        """
+        raise NotImplementedError("TargetPath.home() is unsupported")
+
+    def iterdir(self) -> Iterator[TargetPath]:
+        """Iterate over the files in this directory.  Does not yield any
+        result for the special paths '.' and '..'.
+        """
+        for entry in scandir(self):
+            if entry.name in {".", ".."}:
+                # Yielding a path object for these makes little sense
+                continue
+            child_path = self._make_child_relpath(entry.name)
+            child_path._entry = entry
+            yield child_path
+
+    def _scandir(self) -> _DissectScandirIterator:
+        return scandir(self)
+
+    # NOTE: Forward compatibility with CPython >= 3.12
+    def walk(
+        self, top_down: bool = True, on_error: Callable[[Exception], None] = None, follow_symlinks: bool = False
+    ) -> Iterator[tuple[TargetPath, list[str], list[str]]]:
+        """Walk the directory tree from this directory, similar to os.walk()."""
+        paths = [self]
+
+        while paths:
+            path = paths.pop()
+            if isinstance(path, tuple):
+                yield path
+                continue
+
+            # We may not have read permission for self, in which case we can't
+            # get a list of the files the directory contains. os.walk()
+            # always suppressed the exception in that instance, rather than
+            # blow up for a minor reason when (say) a thousand readable
+            # directories are still left to visit. That logic is copied here.
+            try:
+                scandir_it = path._scandir()
+            except OSError as error:
+                if on_error is not None:
+                    on_error(error)
+                continue
+
+            with scandir_it:
+                dirnames = []
+                filenames = []
+                for entry in scandir_it:
+                    try:
+                        is_dir = entry.is_dir(follow_symlinks=follow_symlinks)
+                    except OSError:
+                        # Carried over from os.path.isdir().
+                        is_dir = False
+
+                    if is_dir:
+                        dirnames.append(entry.name)
+                    else:
+                        filenames.append(entry.name)
+
+            if top_down:
+                yield path, dirnames, filenames
+            else:
+                paths.append((path, dirnames, filenames))
+
+            paths += [path._make_child_relpath(d) for d in reversed(dirnames)]
+
+    def absolute(self) -> TargetPath:
+        """Return an absolute version of this path.  This function works
+        even if the path doesn't point to anything.
+
+        No normalization is done, i.e. all '.' and '..' will be kept along.
+        Use resolve() to get the canonical path to a file.
+        """
+        raise NotImplementedError("TargetPath.absolute() is unsupported in Dissect")
+
+    # NOTE: We changed some of the error handling here to deal with our own exception types
+    def resolve(self, strict: bool = False) -> TargetPath:
+        """
+        Make the path absolute, resolving all symlinks on the way and also
+        normalizing it.
+        """
+
+        s = realpath(self, strict=strict)
+        p = self._from_parts((self._fs, s))
+
+        # In non-strict mode, realpath() doesn't raise on symlink loops.
+        # Ensure we get an exception by calling stat()
+        if not strict:
+            try:
+                p.stat()
+            except FilesystemError as e:
+                if isinstance(e, SymlinkRecursionError):
+                    raise
+        return p
+
+    def stat(self, *, follow_symlinks: bool = True) -> stat_result:
+        """
+        Return the result of the stat() system call on this path, like
+        os.stat() does.
+        """
+        if follow_symlinks:
+            return self.get().stat()
+        else:
+            return self.get().lstat()
+
+    def owner(self) -> str:
+        """
+        Return the login name of the file owner.
+        """
+        raise NotImplementedError("TargetPath.owner() is unsupported")
+
+    def group(self) -> str:
+        """
+        Return the group name of the file gid.
+        """
+        raise NotImplementedError("TargetPath.group() is unsupported")
+
+    def open(
+        self,
+        mode: str = "rb",
+        buffering: int = 0,
+        encoding: Optional[str] = None,
+        errors: Optional[str] = None,
+        newline: Optional[str] = None,
+    ) -> IO:
+        """Open file and return a stream.
+
+        Supports a subset of features of the real pathlib.open/io.open.
+
+        Note: in contrast to regular Python, the mode is binary by default. Text mode
+        has to be explicitly specified. Buffering is also disabled by default.
+        """
+        return io_open(self, mode, buffering, encoding, errors, newline)
+
+    def write_bytes(self, data: bytes) -> int:
+        """
+        Open the file in bytes mode, write to it, and close the file.
+        """
+        raise NotImplementedError("TargetPath.write_bytes() is unsupported")
+
+    def write_text(
+        self, data: str, encoding: Optional[str] = None, errors: Optional[str] = None, newline: Optional[str] = None
+    ) -> int:
+        """
+        Open the file in text mode, write to it, and close the file.
+        """
+        raise NotImplementedError("TargetPath.write_text() is unsupported")
+
+    def readlink(self) -> TargetPath:
+        """
+        Return the path to which the symbolic link points.
+        """
+        return self._from_parts((self._fs, self.get().readlink()))
+
+    def touch(self, mode: int = 0o666, exist_ok: bool = True) -> None:
+        """
+        Create this file with the given access mode, if it doesn't exist.
+        """
+        raise NotImplementedError("TargetPath.touch() is unsupported")
+
+    def mkdir(self, mode: int = 0o777, parents: bool = False, exist_ok: bool = False) -> None:
+        """
+        Create a new directory at this given path.
+        """
+        raise NotImplementedError("TargetPath.mkdir() is unsupported")
+
+    def chmod(self, mode: int, *, follow_symlinks: bool = True) -> None:
+        """
+        Change the permissions of the path, like os.chmod().
+        """
+        raise NotImplementedError("TargetPath.chmod() is unsupported")
+
+    def lchmod(self, mode: int) -> None:
+        """
+        Like chmod(), except if the path points to a symlink, the symlink's
+        permissions are changed, rather than its target's.
+        """
+        raise NotImplementedError("TargetPath.lchmod() is unsupported")
+
+    def unlink(self, missing_ok: bool = False) -> None:
+        """
+        Remove this file or link.
+        If the path is a directory, use rmdir() instead.
+        """
+        raise NotImplementedError("TargetPath.unlink() is unsupported")
+
+    def rmdir(self) -> None:
+        """
+        Remove this directory.  The directory must be empty.
+        """
+        raise NotImplementedError("TargetPath.rmdir() is unsupported")
+
+    def rename(self, target: str) -> TargetPath:
+        """
+        Rename this path to the target path.
+
+        The target path may be absolute or relative. Relative paths are
+        interpreted relative to the current working directory, *not* the
+        directory of the Path object.
+
+        Returns the new Path instance pointing to the target path.
+        """
+        raise NotImplementedError("TargetPath.rename() is unsupported")
+
+    def replace(self, target: str) -> TargetPath:
+        """
+        Rename this path to the target path, overwriting if that path exists.
+
+        The target path may be absolute or relative. Relative paths are
+        interpreted relative to the current working directory, *not* the
+        directory of the Path object.
+
+        Returns the new Path instance pointing to the target path.
+        """
+        raise NotImplementedError("TargetPath.replace() is unsupported")
+
+    def symlink_to(self, target: str, target_is_directory: bool = False) -> None:
+        """
+        Make this path a symlink pointing to the target path.
+        Note the order of arguments (link, target) is the reverse of os.symlink.
+        """
+        raise NotImplementedError("TargetPath.symlink_to() is unsupported")
+
+    def hardlink_to(self, target: str) -> None:
+        """
+        Make this path a hard link pointing to the same file as *target*.
+
+        Note the order of arguments (self, target) is the reverse of os.link's.
+        """
+        raise NotImplementedError("TargetPath.hardlink_to() is unsupported")
+
+    def link_to(self, target: str) -> None:
+        """
+        Make the target path a hard link pointing to this path.
+
+        Note this function does not make this path a hard link to *target*,
+        despite the implication of the function and argument names. The order
+        of arguments (target, link) is the reverse of Path.symlink_to, but
+        matches that of os.link.
+
+        Deprecated since Python 3.10 and scheduled for removal in Python 3.12.
+        Use `hardlink_to()` instead.
+        """
+        raise NotImplementedError("TargetPath.link_to() is unsupported")
+
+    def exists(self) -> bool:
+        """
+        Whether this path exists.
+        """
+        try:
+            # .exists() must resolve possible symlinks
+            self.get().stat()
+            return True
+        except (FileNotFoundError, NotADirectoryError, NotASymlinkError, SymlinkRecursionError, ValueError):
+            return False
+
+    def is_dir(self) -> bool:
+        """
+        Whether this path is a directory.
+        """
+        try:
+            return self.get().is_dir()
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_file(self) -> bool:
+        """
+        Whether this path is a regular file (also True for symlinks pointing
+        to regular files).
+        """
+        try:
+            return self.get().is_file()
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_mount(self) -> bool:
+        """
+        Check if this path is a POSIX mount point
+        """
+        # Need to exist and be a dir
+        if not self.exists() or not self.is_dir():
+            return False
+
+        try:
+            parent_dev = self.parent.stat().st_dev
+        except FilesystemError:
+            return False
+
+        dev = self.stat().st_dev
+        if dev != parent_dev:
+            return True
+        ino = self.stat().st_ino
+        parent_ino = self.parent.stat().st_ino
+        return ino == parent_ino
+
+    def is_symlink(self) -> bool:
+        """
+        Whether this path is a symbolic link.
+        """
+        try:
+            return self.get().is_symlink()
+        except (FilesystemError, ValueError):
+            return False
+
+    # NOTE: Forward compatibility with CPython >= 3.12
+    def is_junction(self) -> bool:
+        """
+        Whether this path is a junction.
+        """
+        return isjunction(self)
+
+    def is_block_device(self) -> bool:
+        """
+        Whether this path is a block device.
+        """
+        try:
+            return S_ISBLK(self.stat().st_mode)
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_char_device(self) -> bool:
+        """
+        Whether this path is a character device.
+        """
+        try:
+            return S_ISCHR(self.stat().st_mode)
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_fifo(self) -> bool:
+        """
+        Whether this path is a FIFO.
+        """
+        try:
+            return S_ISFIFO(self.stat().st_mode)
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_socket(self) -> bool:
+        """
+        Whether this path is a socket.
+        """
+        try:
+            return S_ISSOCK(self.stat().st_mode)
+        except (FilesystemError, ValueError):
+            return False
+
+    def expanduser(self) -> TargetPath:
+        """Return a new path with expanded ~ and ~user constructs
+        (as returned by os.path.expanduser)
+        """
+        raise NotImplementedError("TargetPath.expanduser() is unsupported")

--- a/dissect/target/helpers/compat/path_312.py
+++ b/dissect/target/helpers/compat/path_312.py
@@ -1,0 +1,443 @@
+"""A pathlib.Path compatible implementation for dissect.target.
+
+This allows for the majority of the pathlib.Path API to "just work" on dissect.target filesystems.
+
+Most of this consists of subclassed internal classes with dissect.target specific patches,
+but sometimes the change to a function is small, so the entire internal function is copied
+and only a small part changed. To ease updating this code, the order of functions, comments
+and code style is kept largely the same as the original pathlib.py.
+
+Yes, we know, this is playing with fire and it can break on new CPython releases.
+
+The implementation is split up in multiple files, one for each CPython version.
+You're currently looking at the CPython 3.12 implementation.
+
+Commit hash we're in sync with:
+
+Notes:
+    - CPython 3.12 changed a lot in preparation of proper subclassing, so our patches differ
+      a lot from previous versions
+    - Flavours don't really exist anymore, but since we kind of "multi-flavour" we need to emulate it
+"""
+
+from __future__ import annotations
+
+import posixpath
+import sys
+from pathlib import Path, PurePath
+from stat import S_ISBLK, S_ISCHR, S_ISFIFO, S_ISSOCK
+from typing import IO, TYPE_CHECKING, Iterator, Optional
+
+from dissect.target import filesystem
+from dissect.target.exceptions import FilesystemError, SymlinkRecursionError
+from dissect.target.helpers import polypath
+from dissect.target.helpers.compat.path_common import (
+    io_open,
+    isjunction,
+    realpath,
+    scandir,
+)
+
+if TYPE_CHECKING:
+    from dissect.target.filesystem import Filesystem, FilesystemEntry
+    from dissect.target.helpers.compat.path_common import _DissectScandirIterator
+    from dissect.target.helpers.fsutil import stat_result
+
+
+class _DissectFlavour:
+    sep = "/"
+    altsep = ""
+    case_sensitive = False
+
+    __variant_instances = {}
+
+    def __new__(cls, case_sensitive: bool = False, alt_separator: str = ""):
+        idx = (case_sensitive, alt_separator)
+        instance = cls.__variant_instances.get(idx, None)
+        if instance is None:
+            instance = object.__new__(cls)
+            cls.__variant_instances[idx] = instance
+
+        return instance
+
+    def __init__(self, case_sensitive: bool = False, alt_separator: str = ""):
+        self.altsep = alt_separator
+        self.case_sensitive = case_sensitive
+
+    def normcase(self, s: str) -> str:
+        return s if self.case_sensitive else s.lower()
+
+    splitdrive = staticmethod(posixpath.splitdrive)
+
+    def splitroot(self, part: str) -> tuple[str, str]:
+        return polypath.splitroot(part, alt_separator=self.altsep)
+
+    def join(self, *args) -> str:
+        return polypath.join(*args, alt_separator=self.altsep)
+
+    # NOTE: Fallback implementation from older versions of pathlib.py
+    def ismount(self, path: TargetPath) -> bool:
+        # Need to exist and be a dir
+        if not path.exists() or not path.is_dir():
+            return False
+
+        try:
+            parent_dev = path.parent.stat().st_dev
+        except FilesystemError:
+            return False
+
+        dev = path.stat().st_dev
+        if dev != parent_dev:
+            return True
+        ino = path.stat().st_ino
+        parent_ino = path.parent.stat().st_ino
+        return ino == parent_ino
+
+    isjunction = staticmethod(isjunction)
+
+    samestat = staticmethod(posixpath.samestat)
+
+    def isabs(self, path: str) -> bool:
+        return polypath.isabs(path, alt_separator=self.altsep)
+
+    realpath = staticmethod(realpath)
+
+
+class PureDissectPath(PurePath):
+    _fs: Filesystem
+    _flavour = _DissectFlavour(case_sensitive=False)
+
+    def __reduce__(self) -> tuple:
+        raise TypeError("TargetPath pickling is currently not supported")
+
+    def __init__(self, fs: Filesystem, *pathsegments):
+        if not isinstance(fs, filesystem.Filesystem):
+            raise TypeError(
+                "invalid PureDissectPath initialization: missing filesystem, "
+                "got %r (this might be a bug, please report)" % pathsegments
+            )
+
+        alt_separator = fs.alt_separator
+        path_args = []
+        for arg in pathsegments:
+            if isinstance(arg, str):
+                arg = polypath.normalize(arg, alt_separator=alt_separator)
+            path_args.append(arg)
+
+        super().__init__(*path_args)
+        self._fs = fs
+        self._flavour = _DissectFlavour(alt_separator=fs.alt_separator, case_sensitive=fs.case_sensitive)
+
+    def with_segments(self, *pathsegments) -> TargetPath:
+        return type(self)(self._fs, *pathsegments)
+
+    # NOTE: This is copied from pathlib.py but turned into an instance method so we get access to the correct flavour
+    def _parse_path(self, path: str) -> tuple[str, str, list[str]]:
+        if not path:
+            return "", "", []
+        sep = self._flavour.sep
+        altsep = self._flavour.altsep
+        if altsep:
+            path = path.replace(altsep, sep)
+        drv, root, rel = self._flavour.splitroot(path)
+        if not root and drv.startswith(sep) and not drv.endswith(sep):
+            drv_parts = drv.split(sep)
+            if len(drv_parts) == 4 and drv_parts[2] not in "?.":
+                # e.g. //server/share
+                root = sep
+            elif len(drv_parts) == 6:
+                # e.g. //?/unc/server/share
+                root = sep
+        parsed = [sys.intern(str(x)) for x in rel.split(sep) if x and x != "."]
+        return drv, root, parsed
+
+    def is_reserved(self) -> bool:
+        """Return True if the path contains one of the special names reserved
+        by the system, if any."""
+        return False
+
+
+class TargetPath(Path, PureDissectPath):
+    __slots__ = ("_entry",)
+
+    def get(self) -> FilesystemEntry:
+        try:
+            return self._entry
+        except AttributeError:
+            self._entry = self._fs.get(str(self))
+            return self._entry
+
+    def stat(self, *, follow_symlinks: bool = True) -> stat_result:
+        """
+        Return the result of the stat() system call on this path, like
+        os.stat() does.
+        """
+        if follow_symlinks:
+            return self.get().stat()
+        else:
+            return self.get().lstat()
+
+    def exists(self, *, follow_symlinks: bool = True) -> bool:
+        """
+        Whether this path exists.
+
+        This method normally follows symlinks; to check whether a symlink exists,
+        add the argument follow_symlinks=False.
+        """
+        try:
+            # .exists() must resolve possible symlinks
+            self.stat(follow_symlinks=follow_symlinks)
+            return True
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_dir(self) -> bool:
+        """
+        Whether this path is a directory.
+        """
+        try:
+            return self.get().is_dir()
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_file(self) -> bool:
+        """
+        Whether this path is a regular file (also True for symlinks pointing
+        to regular files).
+        """
+        try:
+            return self.get().is_file()
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_symlink(self) -> bool:
+        """
+        Whether this path is a symbolic link.
+        """
+        try:
+            return self.get().is_symlink()
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_block_device(self) -> bool:
+        """
+        Whether this path is a block device.
+        """
+        try:
+            return S_ISBLK(self.stat().st_mode)
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_char_device(self) -> bool:
+        """
+        Whether this path is a character device.
+        """
+        try:
+            return S_ISCHR(self.stat().st_mode)
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_fifo(self) -> bool:
+        """
+        Whether this path is a FIFO.
+        """
+        try:
+            return S_ISFIFO(self.stat().st_mode)
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_socket(self) -> bool:
+        """
+        Whether this path is a socket.
+        """
+        try:
+            return S_ISSOCK(self.stat().st_mode)
+        except (FilesystemError, ValueError):
+            return False
+
+    def open(
+        self,
+        mode: str = "rb",
+        buffering: int = 0,
+        encoding: Optional[str] = None,
+        errors: Optional[str] = None,
+        newline: Optional[str] = None,
+    ) -> IO:
+        """Open file and return a stream.
+
+        Supports a subset of features of the real pathlib.open/io.open.
+
+        Note: in contrast to regular Python, the mode is binary by default. Text mode
+        has to be explicitly specified. Buffering is also disabled by default.
+        """
+        return io_open(self, mode, buffering, encoding, errors, newline)
+
+    def write_bytes(self, data: bytes) -> int:
+        """
+        Open the file in bytes mode, write to it, and close the file.
+        """
+        raise NotImplementedError("TargetPath.write_bytes() is unsupported")
+
+    def write_text(
+        self, data: str, encoding: Optional[str] = None, errors: Optional[str] = None, newline: Optional[str] = None
+    ) -> int:
+        """
+        Open the file in text mode, write to it, and close the file.
+        """
+        raise NotImplementedError("TargetPath.write_text() is unsupported")
+
+    def iterdir(self) -> Iterator[TargetPath]:
+        """Iterate over the files in this directory.  Does not yield any
+        result for the special paths '.' and '..'.
+        """
+        for entry in scandir(self):
+            if entry.name in {".", ".."}:
+                # Yielding a path object for these makes little sense
+                continue
+            child_path = self._make_child_relpath(entry.name)
+            child_path._entry = entry
+            yield child_path
+
+    def _scandir(self) -> _DissectScandirIterator:
+        return scandir(self)
+
+    @classmethod
+    def cwd(cls) -> TargetPath:
+        """Return a new path pointing to the current working directory."""
+        raise NotImplementedError("TargetPath.cwd() is unsupported")
+
+    @classmethod
+    def home(cls) -> TargetPath:
+        """Return a new path pointing to the user's home directory (as
+        returned by os.path.expanduser('~')).
+        """
+        raise NotImplementedError("TargetPath.home() is unsupported")
+
+    def absolute(self) -> TargetPath:
+        """Return an absolute version of this path by prepending the current
+        working directory. No normalization or symlink resolution is performed.
+
+        Use resolve() to get the canonical path to a file.
+        """
+        raise NotImplementedError("TargetPath.absolute() is unsupported in Dissect")
+
+    # NOTE: We changed some of the error handling here to deal with our own exception types
+    def resolve(self, strict: bool = False) -> TargetPath:
+        """
+        Make the path absolute, resolving all symlinks on the way and also
+        normalizing it.
+        """
+
+        s = self._flavour.realpath(self, strict=strict)
+        p = self.with_segments(s)
+
+        # In non-strict mode, realpath() doesn't raise on symlink loops.
+        # Ensure we get an exception by calling stat()
+        if not strict:
+            try:
+                p.stat()
+            except FilesystemError as e:
+                if isinstance(e, SymlinkRecursionError):
+                    raise
+        return p
+
+    def owner(self) -> str:
+        """
+        Return the login name of the file owner.
+        """
+        raise NotImplementedError("TargetPath.owner() is unsupported")
+
+    def group(self) -> str:
+        """
+        Return the group name of the file gid.
+        """
+        raise NotImplementedError("TargetPath.group() is unsupported")
+
+    def readlink(self) -> TargetPath:
+        """
+        Return the path to which the symbolic link points.
+        """
+        return self.with_segments(self.get().readlink())
+
+    def touch(self, mode: int = 0o666, exist_ok: bool = True) -> None:
+        """
+        Create this file with the given access mode, if it doesn't exist.
+        """
+        raise NotImplementedError("TargetPath.touch() is unsupported")
+
+    def mkdir(self, mode: int = 0o777, parents: bool = False, exist_ok: bool = False) -> None:
+        """
+        Create a new directory at this given path.
+        """
+        raise NotImplementedError("TargetPath.mkdir() is unsupported")
+
+    def chmod(self, mode: int, *, follow_symlinks: bool = True) -> None:
+        """
+        Change the permissions of the path, like os.chmod().
+        """
+        raise NotImplementedError("TargetPath.chmod() is unsupported")
+
+    def lchmod(self, mode: int) -> None:
+        """
+        Like chmod(), except if the path points to a symlink, the symlink's
+        permissions are changed, rather than its target's.
+        """
+        raise NotImplementedError("TargetPath.lchmod() is unsupported")
+
+    def unlink(self, missing_ok: bool = False) -> None:
+        """
+        Remove this file or link.
+        If the path is a directory, use rmdir() instead.
+        """
+        raise NotImplementedError("TargetPath.unlink() is unsupported")
+
+    def rmdir(self) -> None:
+        """
+        Remove this directory.  The directory must be empty.
+        """
+        raise NotImplementedError("TargetPath.rmdir() is unsupported")
+
+    def rename(self, target: str) -> TargetPath:
+        """
+        Rename this path to the target path.
+
+        The target path may be absolute or relative. Relative paths are
+        interpreted relative to the current working directory, *not* the
+        directory of the Path object.
+
+        Returns the new Path instance pointing to the target path.
+        """
+        raise NotImplementedError("TargetPath.rename() is unsupported")
+
+    def replace(self, target: str) -> TargetPath:
+        """
+        Rename this path to the target path, overwriting if that path exists.
+
+        The target path may be absolute or relative. Relative paths are
+        interpreted relative to the current working directory, *not* the
+        directory of the Path object.
+
+        Returns the new Path instance pointing to the target path.
+        """
+        raise NotImplementedError("TargetPath.replace() is unsupported")
+
+    def symlink_to(self, target: str, target_is_directory: bool = False) -> None:
+        """
+        Make this path a symlink pointing to the target path.
+        Note the order of arguments (link, target) is the reverse of os.symlink.
+        """
+        raise NotImplementedError("TargetPath.symlink_to() is unsupported")
+
+    def hardlink_to(self, target: str) -> None:
+        """
+        Make this path a hard link pointing to the same file as *target*.
+
+        Note the order of arguments (self, target) is the reverse of os.link's.
+        """
+        raise NotImplementedError("TargetPath.hardlink_to() is unsupported")
+
+    def expanduser(self) -> TargetPath:
+        """Return a new path with expanded ~ and ~user constructs
+        (as returned by os.path.expanduser)
+        """
+        raise NotImplementedError("TargetPath.expanduser() is unsupported")

--- a/dissect/target/helpers/compat/path_39.py
+++ b/dissect/target/helpers/compat/path_39.py
@@ -1,0 +1,545 @@
+"""A pathlib.Path compatible implementation for dissect.target.
+
+This allows for the majority of the pathlib.Path API to "just work" on dissect.target filesystems.
+
+Most of this consists of subclassed internal classes with dissect.target specific patches,
+but sometimes the change to a function is small, so the entire internal function is copied
+and only a small part changed. To ease updating this code, the order of functions, comments
+and code style is kept exactly the same as the original pathlib.py.
+
+Yes, we know, this is playing with fire and it can break on new CPython releases.
+
+The implementation is split up in multiple files, one for each CPython version.
+You're currently looking at the CPython 3.9 implementation.
+
+Commit hash we're in sync with: debb751
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from pathlib import Path, PurePath, _Accessor, _PosixFlavour
+from stat import S_ISBLK, S_ISCHR, S_ISFIFO, S_ISSOCK
+from typing import IO, TYPE_CHECKING, Any, BinaryIO, Callable, Iterator, Optional
+
+from dissect.target import filesystem
+from dissect.target.exceptions import (
+    FilesystemError,
+    NotASymlinkError,
+    SymlinkRecursionError,
+)
+from dissect.target.helpers.compat.path_common import (
+    _DissectPathParents,
+    io_open,
+    isjunction,
+    scandir,
+)
+from dissect.target.helpers.polypath import normalize, normpath
+
+if TYPE_CHECKING:
+    from dissect.target.filesystem import Filesystem, FilesystemEntry
+    from dissect.target.helpers.compat.path_common import _DissectScandirIterator
+    from dissect.target.helpers.fsutil import stat_result
+
+
+class _DissectFlavour(_PosixFlavour):
+    is_supported = True
+
+    __variant_instances = {}
+
+    def __new__(cls, case_sensitive: bool = False, alt_separator: str = ""):
+        idx = (case_sensitive, alt_separator)
+        instance = cls.__variant_instances.get(idx, None)
+        if instance is None:
+            instance = _PosixFlavour.__new__(cls)
+            cls.__variant_instances[idx] = instance
+
+        return instance
+
+    def __init__(self, case_sensitive: bool = False, alt_separator: str = ""):
+        super().__init__()
+        self.altsep = alt_separator
+        self.case_sensitive = case_sensitive
+
+    def casefold(self, s: str) -> str:
+        return s if self.case_sensitive else s.lower()
+
+    def casefold_parts(self, parts: list[str]) -> list[str]:
+        return parts if self.case_sensitive else [p.lower() for p in parts]
+
+    def compile_pattern(self, pattern: str) -> Callable[..., Any]:
+        return re.compile(fnmatch.translate(pattern), 0 if self.case_sensitive else re.IGNORECASE).fullmatch
+
+    def resolve(self, path: str, strict: bool = False) -> str:
+        sep = self.sep
+        accessor = path._accessor
+        seen = {}
+
+        def _resolve(fs, path, rest):
+            if rest.startswith(sep):
+                path = ""
+
+            for name in rest.split(sep):
+                if not name or name == ".":
+                    # current dir
+                    continue
+                if name == "..":
+                    # parent dir
+                    path, _, _ = path.rpartition(sep)
+                    continue
+                if path.endswith(sep):
+                    newpath = path + name
+                else:
+                    newpath = path + sep + name
+                if newpath in seen:
+                    # Already seen this path
+                    path = seen[newpath]
+                    if path is not None:
+                        # use cached value
+                        continue
+                    # The symlink is not resolved, so we must have a symlink loop.
+                    raise SymlinkRecursionError(newpath)
+                # Resolve the symbolic link
+                try:
+                    target = accessor.readlink(fs.path(newpath))
+                except FilesystemError as e:
+                    if not isinstance(e, NotASymlinkError) and strict:
+                        raise
+                    # Not a symlink, or non-strict mode. We just leave the path
+                    # untouched.
+                    path = newpath
+                else:
+                    seen[newpath] = None  # not resolved symlink
+                    path = _resolve(fs, path, target)
+                    seen[newpath] = path  # resolved symlink
+
+            return path
+
+        # NOTE: according to POSIX, getcwd() cannot contain path components
+        # which are symlinks.
+        return _resolve(path._fs, "", str(path)) or sep
+
+    def gethomedir(self, username: str) -> str:
+        raise NotImplementedError("gethomedir() is unsupported")
+
+
+class _DissectAccessor(_Accessor):
+    # Forward compatibility with CPython >= 3.10
+    @staticmethod
+    def stat(path: TargetPath, *, follow_symlinks: bool = True) -> stat_result:
+        if follow_symlinks:
+            return path.get().stat()
+        else:
+            return path.get().lstat()
+
+    @staticmethod
+    def lstat(path: TargetPath) -> stat_result:
+        return path.get().lstat()
+
+    @staticmethod
+    def open(path: TargetPath, flags: int, mode: int = 0o777) -> BinaryIO:
+        return path.get().open()
+
+    @staticmethod
+    def listdir(path: TargetPath) -> list[str]:
+        return path.get().listdir()
+
+    @staticmethod
+    def scandir(path: TargetPath) -> _DissectScandirIterator:
+        return scandir(path)
+
+    @staticmethod
+    def chmod(path: TargetPath, mode: int, *, follow_symlinks: bool = True) -> None:
+        raise NotImplementedError("TargetPath.chmod() is unsupported")
+
+    @staticmethod
+    def lchmod(path: TargetPath, mode: int) -> None:
+        raise NotImplementedError("TargetPath.lchmod() is unsupported")
+
+    @staticmethod
+    def mkdir(path: TargetPath, mode: int = 0o777, parents: bool = False, exist_ok: bool = False) -> None:
+        raise NotImplementedError("TargetPath.mkdir() is unsupported")
+
+    @staticmethod
+    def unlink(path: TargetPath, missing_ok: bool = False) -> None:
+        raise NotImplementedError("TargetPath.unlink() is unsupported")
+
+    @staticmethod
+    def link_to(src: str, dst: TargetPath) -> None:
+        raise NotImplementedError("TargetPath.link_to() is unsupported")
+
+    @staticmethod
+    def rmdir(path: TargetPath) -> None:
+        raise NotImplementedError("TargetPath.rmdir() is unsupported")
+
+    @staticmethod
+    def rename(path: TargetPath, target: str) -> str:
+        raise NotImplementedError("TargetPath.rename() is unsupported")
+
+    @staticmethod
+    def replace(path: TargetPath, target: str) -> str:
+        raise NotImplementedError("TargetPath.replace() is unsupported")
+
+    @staticmethod
+    def symlink(path: TargetPath, target: str, target_is_directory: bool = False) -> None:
+        raise NotImplementedError("TargetPath.symlink() is unsupported")
+
+    @staticmethod
+    def utime(
+        path: TargetPath, times: tuple[float, float], *, ns: tuple[int, int] = None, follow_symlinks: bool = True
+    ) -> None:
+        raise NotImplementedError("TargetPath.utime() is unsupported")
+
+    @staticmethod
+    def readlink(path: TargetPath) -> str:
+        return path.get().readlink()
+
+    @staticmethod
+    def owner(path: TargetPath) -> str:
+        raise NotImplementedError("TargetPath.owner() is unsupported")
+
+    @staticmethod
+    def group(path: TargetPath) -> str:
+        raise NotImplementedError("TargetPath.group() is unsupported")
+
+    # NOTE: Forward compatibility with CPython >= 3.12
+    isjunction = staticmethod(isjunction)
+
+
+_dissect_accessor = _DissectAccessor()
+
+
+class PureDissectPath(PurePath):
+    _fs: Filesystem
+    _flavour = _DissectFlavour(case_sensitive=False)
+
+    def __reduce__(self) -> tuple:
+        raise TypeError("TargetPath pickling is currently not supported")
+
+    @classmethod
+    def _from_parts(cls, args: list, init: bool = True) -> TargetPath:
+        fs = args[0]
+
+        if not isinstance(fs, filesystem.Filesystem):
+            raise TypeError(
+                "invalid PureDissectPath initialization: missing filesystem, "
+                "got %r (this might be a bug, please report)" % args
+            )
+
+        alt_separator = fs.alt_separator
+        path_args = []
+        for arg in args[1:]:
+            if isinstance(arg, str):
+                arg = normalize(arg, alt_separator=alt_separator)
+            path_args.append(arg)
+
+        self = super()._from_parts(path_args, init=init)
+        self._fs = fs
+
+        self._flavour = _DissectFlavour(alt_separator=fs.alt_separator, case_sensitive=fs.case_sensitive)
+
+        return self
+
+    def _make_child(self, args: list) -> TargetPath:
+        child = super()._make_child(args)
+        child._fs = self._fs
+        child._flavour = self._flavour
+        return child
+
+    def with_name(self, name: str) -> TargetPath:
+        result = super().with_name(name)
+        result._fs = self._fs
+        result._flavour = self._flavour
+        return result
+
+    def with_stem(self, stem: str) -> TargetPath:
+        result = super().with_stem(stem)
+        result._fs = self._fs
+        result._flavour = self._flavour
+        return result
+
+    def with_suffix(self, suffix: str) -> TargetPath:
+        result = super().with_suffix(suffix)
+        result._fs = self._fs
+        result._flavour = self._flavour
+        return result
+
+    def relative_to(self, *other) -> TargetPath:
+        result = super().relative_to(*other)
+        result._fs = self._fs
+        result._flavour = self._flavour
+        return result
+
+    def __rtruediv__(self, key: str) -> TargetPath:
+        try:
+            return self._from_parts([self._fs, key] + self._parts)
+        except TypeError:
+            return NotImplemented
+
+    @property
+    def parent(self) -> TargetPath:
+        result = super().parent
+        result._fs = self._fs
+        result._flavour = self._flavour
+        return result
+
+    @property
+    def parents(self) -> _DissectPathParents:
+        return _DissectPathParents(self)
+
+
+class TargetPath(Path, PureDissectPath):
+    __slots__ = ("_entry",)
+
+    def _init(self, template: Optional[Path] = None) -> None:
+        self._accessor = _dissect_accessor
+
+    def _make_child_relpath(self, part: str) -> TargetPath:
+        child = super()._make_child_relpath(part)
+        child._fs = self._fs
+        child._flavour = self._flavour
+        return child
+
+    def get(self) -> FilesystemEntry:
+        try:
+            return self._entry
+        except AttributeError:
+            self._entry = self._fs.get(str(self))
+            return self._entry
+
+    @classmethod
+    def cwd(cls) -> TargetPath:
+        """Return a new path pointing to the current working directory
+        (as returned by os.getcwd()).
+        """
+        raise NotImplementedError("TargetPath.cwd() is unsupported")
+
+    @classmethod
+    def home(cls) -> TargetPath:
+        """Return a new path pointing to the user's home directory (as
+        returned by os.path.expanduser('~')).
+        """
+        raise NotImplementedError("TargetPath.home() is unsupported")
+
+    def iterdir(self) -> Iterator[TargetPath]:
+        """Iterate over the files in this directory.  Does not yield any
+        result for the special paths '.' and '..'.
+        """
+        for entry in self._accessor.scandir(self):
+            if entry.name in {".", ".."}:
+                # Yielding a path object for these makes little sense
+                continue
+            child_path = self._make_child_relpath(entry.name)
+            child_path._entry = entry
+            yield child_path
+
+    # NOTE: Forward compatibility with CPython >= 3.12
+    def walk(
+        self, top_down: bool = True, on_error: Callable[[Exception], None] = None, follow_symlinks: bool = False
+    ) -> Iterator[tuple[TargetPath, list[str], list[str]]]:
+        """Walk the directory tree from this directory, similar to os.walk()."""
+        paths = [self]
+
+        while paths:
+            path = paths.pop()
+            if isinstance(path, tuple):
+                yield path
+                continue
+
+            # We may not have read permission for self, in which case we can't
+            # get a list of the files the directory contains. os.walk()
+            # always suppressed the exception in that instance, rather than
+            # blow up for a minor reason when (say) a thousand readable
+            # directories are still left to visit. That logic is copied here.
+            try:
+                scandir_it = self._accessor.scandir(path)
+            except OSError as error:
+                if on_error is not None:
+                    on_error(error)
+                continue
+
+            with scandir_it:
+                dirnames = []
+                filenames = []
+                for entry in scandir_it:
+                    try:
+                        is_dir = entry.is_dir(follow_symlinks=follow_symlinks)
+                    except OSError:
+                        # Carried over from os.path.isdir().
+                        is_dir = False
+
+                    if is_dir:
+                        dirnames.append(entry.name)
+                    else:
+                        filenames.append(entry.name)
+
+            if top_down:
+                yield path, dirnames, filenames
+            else:
+                paths.append((path, dirnames, filenames))
+
+            paths += [path._make_child_relpath(d) for d in reversed(dirnames)]
+
+    def absolute(self) -> TargetPath:
+        """Return an absolute version of this path.  This function works
+        even if the path doesn't point to anything.
+
+        No normalization is done, i.e. all '.' and '..' will be kept along.
+        Use resolve() to get the canonical path to a file.
+        """
+        raise NotImplementedError("TargetPath.absolute() is unsupported in Dissect")
+
+    def resolve(self, strict: bool = False) -> TargetPath:
+        """
+        Make the path absolute, resolving all symlinks on the way and also
+        normalizing it (for example turning slashes into backslashes under
+        Windows).
+        """
+        s = self._flavour.resolve(self, strict=strict)
+        if s is None:
+            # No symlink resolution => for consistency, raise an error if
+            # the path doesn't exist or is forbidden
+            self.stat()
+            s = str(self.absolute())
+        # Now we have no symlinks in the path, it's safe to normalize it.
+        normed = normpath(s, self._flavour.altsep)
+        obj = self._from_parts((self._fs, normed), init=False)
+        obj._init(template=self)
+        return obj
+
+    # Forward compatibility with CPython >= 3.10
+    def stat(self, *, follow_symlinks: bool = True) -> stat_result:
+        """
+        Return the result of the stat() system call on this path, like
+        os.stat() does.
+        """
+        return self._accessor.stat(self, follow_symlinks=follow_symlinks)
+
+    # Forward compatibility with CPython >= 3.10
+    def open(
+        self,
+        mode: str = "rb",
+        buffering: int = 0,
+        encoding: Optional[str] = None,
+        errors: Optional[str] = None,
+        newline: Optional[str] = None,
+    ) -> IO:
+        """Open file and return a stream.
+
+        Supports a subset of features of the real pathlib.open/io.open.
+
+        Note: in contrast to regular Python, the mode is binary by default. Text mode
+        has to be explicitly specified. Buffering is also disabled by default.
+        """
+        return io_open(self, mode, buffering, encoding, errors, newline)
+
+    def write_bytes(self, data: bytes) -> int:
+        """
+        Open the file in bytes mode, write to it, and close the file.
+        """
+        raise NotImplementedError("TargetPath.write_bytes() is unsupported")
+
+    def write_text(
+        self, data: str, encoding: Optional[str] = None, errors: Optional[str] = None, newline: Optional[str] = None
+    ) -> int:
+        """
+        Open the file in text mode, write to it, and close the file.
+        """
+        raise NotImplementedError("TargetPath.write_text() is unsupported")
+
+    def readlink(self) -> TargetPath:
+        """
+        Return the path to which the symbolic link points.
+        """
+        path = self._accessor.readlink(self)
+        obj = self._from_parts((self._fs, path), init=False)
+        return obj
+
+    def exists(self) -> bool:
+        """
+        Whether this path exists.
+        """
+        try:
+            # .exists() must resolve possible symlinks
+            self.get().stat()
+            return True
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_dir(self) -> bool:
+        """
+        Whether this path is a directory.
+        """
+        try:
+            return self.get().is_dir()
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_file(self) -> bool:
+        """
+        Whether this path is a regular file (also True for symlinks pointing
+        to regular files).
+        """
+        try:
+            return self.get().is_file()
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_symlink(self) -> bool:
+        """
+        Whether this path is a symbolic link.
+        """
+        try:
+            return self.get().is_symlink()
+        except (FilesystemError, ValueError):
+            return False
+
+    # NOTE: Forward compatibility with CPython >= 3.12
+    def is_junction(self) -> bool:
+        """
+        Whether this path is a junction.
+        """
+        return self._accessor.isjunction(self)
+
+    def is_block_device(self) -> bool:
+        """
+        Whether this path is a block device.
+        """
+        try:
+            return S_ISBLK(self.stat().st_mode)
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_char_device(self) -> bool:
+        """
+        Whether this path is a character device.
+        """
+        try:
+            return S_ISCHR(self.stat().st_mode)
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_fifo(self) -> bool:
+        """
+        Whether this path is a FIFO.
+        """
+        try:
+            return S_ISFIFO(self.stat().st_mode)
+        except (FilesystemError, ValueError):
+            return False
+
+    def is_socket(self) -> bool:
+        """
+        Whether this path is a socket.
+        """
+        try:
+            return S_ISSOCK(self.stat().st_mode)
+        except (FilesystemError, ValueError):
+            return False
+
+    def expanduser(self) -> TargetPath:
+        """Return a new path with expanded ~ and ~user constructs
+        (as returned by os.path.expanduser)
+        """
+        raise NotImplementedError("TargetPath.expanduser() is unsupported")

--- a/dissect/target/helpers/compat/path_common.py
+++ b/dissect/target/helpers/compat/path_common.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import io
+import posixpath
+import stat
+from typing import IO, TYPE_CHECKING, Iterator, Literal, Optional
+
+if TYPE_CHECKING:
+    from dissect.target.helpers.fsutil import TargetPath
+    from dissect.target.filesystem import Filesystem, FilesystemEntry
+
+from dissect.target.exceptions import FilesystemError, SymlinkRecursionError
+from dissect.target.helpers.polypath import abspath, normalize
+
+try:
+    # Up until CPython 3.12, pathlib._PathParents requires subclassing to inject the filesystem and flavour
+    # into each parent path component. Since CPython 3.12, this is no longer necessary.
+    # In CPython 3.13, _PathParents was moved to a different file, so this will result in an import error.
+    # Since we no longer need it in CPython 3.13, we can just ignore the error.
+    from pathlib import _PathParents
+
+    class _DissectPathParents(_PathParents):
+        __slots__ = ("_fs", "_flavour")
+
+        def __init__(self, path: TargetPath):
+            super().__init__(path)
+            self._fs = path._fs
+            self._flavour = path._flavour
+
+        def __getitem__(self, idx: int) -> TargetPath:
+            result = super().__getitem__(idx)
+            result._fs = self._fs
+            result._flavour = self._flavour
+            return result
+
+except ImportError:
+    pass
+
+
+class _DissectScandirIterator:
+    """This class implements a ScandirIterator for dissect's scandir()
+
+    The _DissectScandirIterator provides a context manager, so scandir can be called as:
+
+    ```
+    with scandir(path) as it:
+        for entry in it
+            print(entry.name)
+    ```
+
+    similar to os.scandir() behaviour since Python 3.6.
+    """
+
+    def __init__(self, iterator: Iterator[FilesystemEntry]):
+        self._iterator = iterator
+
+    def __del__(self) -> None:
+        self.close()
+
+    def __enter__(self) -> Iterator[FilesystemEntry]:
+        return self._iterator
+
+    def __exit__(self, *args, **kwargs) -> Literal[False]:
+        return False
+
+    def __iter__(self) -> Iterator[FilesystemEntry]:
+        return self._iterator
+
+    def __next__(self, *args) -> FilesystemEntry:
+        return next(self._iterator, *args)
+
+    def close(self):
+        # close() is not defined in the various filesystem implementations. The
+        # python ScandirIterator does define the interface however.
+        pass
+
+
+def scandir(path: TargetPath) -> _DissectScandirIterator:
+    return _DissectScandirIterator(path.get().scandir())
+
+
+def realpath(path: TargetPath, *, strict: bool = False) -> str:
+    """Return the canonical path of the specified filename, eliminating any symbolic links encountered in the path."""
+    filename = str(path)
+    path, _ = _joinrealpath(path._fs, filename[:0], filename, strict, {})
+    return abspath(path)
+
+
+def isjunction(path: TargetPath) -> bool:
+    """Return True if the path is a junction."""
+    try:
+        from dissect.target.filesystems.ntfs import NtfsFilesystemEntry
+    except ImportError:
+        return False
+
+    entry = path.get()
+    # Python's ntpath isjunction() only checks for mount point reparse tags
+    return isinstance(entry, NtfsFilesystemEntry) and entry.dereference().is_mount_point()
+
+
+# Join two paths, normalizing and eliminating any symbolic links
+# encountered in the second path.
+# NOTE: This is a copy of posixpath._joinrealpath with some small tweaks
+def _joinrealpath(fs: Filesystem, path: str, rest: str, strict: bool, seen: dict[str, str]) -> tuple[str, bool]:
+    if posixpath.isabs(rest):
+        rest = rest[1:]
+        path = "/"
+
+    while rest:
+        name, _, rest = rest.partition("/")
+        if not name or name == ".":
+            # current dir
+            continue
+        if name == "..":
+            # parent dir
+            if path:
+                path, name = posixpath.split(path)
+                if name == "..":
+                    path = posixpath.join(path, "..", "..")
+            else:
+                path = ".."
+            continue
+        newpath = posixpath.join(path, name)
+        try:
+            st = fs.get(newpath).lstat()
+        except FilesystemError:
+            if strict:
+                raise
+            is_link = False
+        else:
+            is_link = stat.S_ISLNK(st.st_mode)
+        if not is_link:
+            path = newpath
+            continue
+        # Resolve the symbolic link
+        if newpath in seen:
+            # Already seen this path
+            path = seen[newpath]
+            if path is not None:
+                # use cached value
+                continue
+            # The symlink is not resolved, so we must have a symlink loop.
+            if strict:
+                # Raise OSError(errno.ELOOP)
+                raise SymlinkRecursionError(newpath)
+            else:
+                # Return already resolved part + rest of the path unchanged.
+                return posixpath.join(newpath, rest), False
+        seen[newpath] = None  # not resolved symlink
+        path, ok = _joinrealpath(fs, path, normalize(fs.readlink(newpath)), strict, seen)
+        if not ok:
+            return posixpath.join(path, rest), False
+        seen[newpath] = path  # resolved symlink
+
+    return path, True
+
+
+def io_open(
+    path: TargetPath,
+    mode: str = "rb",
+    buffering: int = 0,
+    encoding: Optional[str] = None,
+    errors: Optional[str] = None,
+    newline: Optional[str] = None,
+) -> IO:
+    """Open file and return a stream.
+
+    Supports a subset of features of the real pathlib.open/io.open.
+
+    Note: in contrast to regular Python, the mode is binary by default. Text mode
+    has to be explicitly specified. Buffering is also disabled by default.
+    """
+    modes = set(mode)
+    if modes - set("rbt") or len(mode) > len(modes):
+        raise ValueError("invalid mode: %r" % mode)
+
+    reading = "r" in modes
+    binary = "b" in modes
+    text = "t" in modes or "b" not in modes
+
+    if "b" not in mode:
+        encoding = encoding or "UTF-8"
+        # CPython >= 3.10
+        if hasattr(io, "text_encoding"):
+            # Vermin linting needs to be skipped for this line as this is
+            # guarded by an explicit check for availability.
+            # novermin
+            encoding = io.text_encoding(encoding)
+
+    if not reading:
+        raise ValueError("must be reading mode")
+    if text and binary:
+        raise ValueError("can't have text and binary mode at once")
+    if binary and encoding is not None:
+        raise ValueError("binary mode doesn't take an encoding argument")
+    if binary and errors is not None:
+        raise ValueError("binary mode doesn't take an errors argument")
+    if binary and newline is not None:
+        raise ValueError("binary mode doesn't take a newline argument")
+
+    raw = path.get().open()
+    result = raw
+
+    line_buffering = False
+    if buffering == 1 or buffering < 0 and raw.isatty():
+        buffering = -1
+        line_buffering = True
+    if buffering < 0 or text and buffering == 0:
+        buffering = io.DEFAULT_BUFFER_SIZE
+    if buffering == 0:
+        if binary:
+            return result
+        raise ValueError("can't have unbuffered text I/O")
+
+    buffer = io.BufferedReader(raw, buffering)
+    result = buffer
+    if binary:
+        return result
+
+    result = io.TextIOWrapper(buffer, encoding, errors, newline, line_buffering)
+    result.mode = mode
+
+    return result

--- a/dissect/target/helpers/polypath.py
+++ b/dissect/target/helpers/polypath.py
@@ -1,0 +1,73 @@
+"""Filesystem path manipulation functions.
+
+Similar to posixpath and ntpath, but with support for alternative separators.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import re
+
+re_normalize_path = re.compile(r"[/]+")
+re_normalize_sbs_path = re.compile(r"[\\/]+")
+
+
+def normalize(path: str, alt_separator: str = "") -> str:
+    if alt_separator == "\\":
+        return re_normalize_sbs_path.sub("/", path)
+    else:
+        return re_normalize_path.sub("/", path)
+
+
+def isabs(path: str, alt_separator: str = "") -> bool:
+    return posixpath.isabs(normalize(path, alt_separator=alt_separator))
+
+
+def join(*args, alt_separator: str = "") -> str:
+    return posixpath.join(*[normalize(part, alt_separator=alt_separator) for part in args])
+
+
+def split(path: str, alt_separator: str = "") -> str:
+    return posixpath.split(normalize(path, alt_separator=alt_separator))
+
+
+splitext = posixpath.splitext
+
+
+splitdrive = posixpath.splitdrive
+
+
+def splitroot(path: str, alt_separator: str = "") -> tuple[str, str]:
+    return posixpath.splitroot(normalize(path, alt_separator=alt_separator))
+
+
+def basename(path: str, alt_separator: str = "") -> str:
+    return posixpath.basename(normalize(path, alt_separator=alt_separator))
+
+
+def dirname(path: str, alt_separator: str = "") -> str:
+    return posixpath.dirname(normalize(path, alt_separator=alt_separator))
+
+
+def normpath(path: str, alt_separator: str = "") -> str:
+    return posixpath.normpath(normalize(path, alt_separator=alt_separator))
+
+
+def abspath(path: str, cwd: str = "", alt_separator: str = "") -> str:
+    cwd = cwd or "/"
+    cwd = normalize(cwd, alt_separator=alt_separator)
+    path = normalize(path, alt_separator=alt_separator)
+    if not isabs(path):
+        path = join(cwd, path)
+    return posixpath.normpath(path)
+
+
+def relpath(path: str, start: str, alt_separator: str = "") -> str:
+    return posixpath.relpath(
+        normalize(path, alt_separator=alt_separator),
+        normalize(start, alt_separator=alt_separator),
+    )
+
+
+def commonpath(paths: list[str], alt_separator: str = "") -> str:
+    return posixpath.commonpath([normalize(path, alt_separator=alt_separator) for path in paths])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "dissect.regf>=3.3.dev,<4.0.dev",
     "dissect.util>=3.0.dev,<4.0.dev",
     "dissect.volume>=3.0.dev,<4.0.dev",
-    "flow.record~=3.13.0",
+    "flow.record~=3.14.0",
     "structlog",
 ]
 dynamic = ["version"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,8 @@
-import os
 import pathlib
 import tempfile
 import textwrap
 from io import BytesIO
-from typing import Any, Callable, Iterator, Optional
+from typing import Callable, Iterator, Optional
 
 import pytest
 
@@ -432,49 +431,3 @@ def target_osx_users(target_osx: Target, fs_osx: VirtualFilesystem) -> Iterator[
     fs_osx.map_file("/var/db/dslocal/nodes/Default/users/_test.plist", test)
 
     yield target_osx
-
-
-@pytest.fixture
-def xattrs() -> dict[str, str]:
-    return {"some_key": b"some_value"}
-
-
-@pytest.fixture
-def listxattr_spec(xattrs: dict[str, str]) -> dict[str, Any]:
-    # listxattr() is only available on Linux
-    attr_names = list(xattrs.keys())
-
-    if hasattr(os, "listxattr"):
-        spec = {
-            "create": False,
-            "autospec": True,
-            "return_value": attr_names,
-        }
-    else:
-        spec = {
-            "create": True,
-            "return_value": attr_names,
-        }
-
-    return spec
-
-
-@pytest.fixture
-def getxattr_spec(xattrs: dict[str, str]) -> dict[str, Any]:
-    # getxattr() is only available on Linux
-    attr_name = list(xattrs.keys())[0]
-    attr_value = xattrs.get(attr_name)
-
-    if hasattr(os, "getxattr"):
-        spec = {
-            "create": False,
-            "autospec": True,
-            "return_value": attr_value,
-        }
-    else:
-        spec = {
-            "create": True,
-            "return_value": attr_value,
-        }
-
-    return spec

--- a/tests/helpers/test_fsutil.py
+++ b/tests/helpers/test_fsutil.py
@@ -2,15 +2,26 @@ import bz2
 import gzip
 import io
 import os
+import sys
 import tempfile
 from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Iterator
 from unittest.mock import Mock, patch
 
 import pytest
 
+from dissect.target.exceptions import (
+    FileNotFoundError,
+    NotADirectoryError,
+    NotASymlinkError,
+    SymlinkRecursionError,
+)
 from dissect.target.filesystem import VirtualFile, VirtualFilesystem
 from dissect.target.filesystems.dir import DirectoryFilesystem
+from dissect.target.filesystems.ntfs import NtfsFilesystemEntry
 from dissect.target.helpers import fsutil
+from dissect.target.target import Target
 
 
 @pytest.mark.parametrize(
@@ -23,7 +34,7 @@ from dissect.target.helpers import fsutil
         ("/some///long\\\\dir/so\\//me\\file", "\\", "/some/long/dir/so/me/file"),
     ],
 )
-def test_helpers_fsutil_normalize(path, alt_separator, result):
+def test_normalize(path: str, alt_separator: str, result: str) -> None:
     assert fsutil.normalize(path, alt_separator=alt_separator) == result
 
 
@@ -37,7 +48,7 @@ def test_helpers_fsutil_normalize(path, alt_separator, result):
         (("/some///long\\\\dir", "so\\//me\\file"), "\\", "/some/long/dir/so/me/file"),
     ],
 )
-def test_helpers_fsutil_join(args, alt_separator, result):
+def test_join(args: str, alt_separator: str, result: str) -> None:
     assert fsutil.join(*args, alt_separator=alt_separator) == result
 
 
@@ -51,7 +62,7 @@ def test_helpers_fsutil_join(args, alt_separator, result):
         ("/some///long\\\\dir/so\\//me\\file", "\\", "/some/long/dir/so/me"),
     ],
 )
-def test_helpers_fsutil_dirname(path, alt_separator, result):
+def test_dirname(path: str, alt_separator: str, result: str) -> None:
     assert fsutil.dirname(path, alt_separator=alt_separator) == result
 
 
@@ -65,7 +76,7 @@ def test_helpers_fsutil_dirname(path, alt_separator, result):
         ("/some///long\\\\dir/so\\//me\\file", "\\", "file"),
     ],
 )
-def test_helpers_fsutil_basename(path, alt_separator, result):
+def test_basename(path: str, alt_separator: str, result: str) -> None:
     assert fsutil.basename(path, alt_separator=alt_separator) == result
 
 
@@ -83,7 +94,7 @@ def test_helpers_fsutil_basename(path, alt_separator, result):
         ("/some///long\\\\dir/so\\//me\\file", "\\", ("/some/long/dir/so/me", "file")),
     ],
 )
-def test_helpers_fsutil_split(path, alt_separator, result):
+def test_split(path: str, alt_separator: str, result: str) -> None:
     assert fsutil.split(path, alt_separator=alt_separator) == result
 
 
@@ -98,7 +109,7 @@ def test_helpers_fsutil_split(path, alt_separator, result):
         ("\\some/dir", "\\", True),
     ],
 )
-def test_helpers_fsutil_isabs(path, alt_separator, result):
+def test_isabs(path: str, alt_separator: str, result: str) -> None:
     assert fsutil.isabs(path, alt_separator=alt_separator) == result
 
 
@@ -112,7 +123,7 @@ def test_helpers_fsutil_isabs(path, alt_separator, result):
         ("/some///long\\..\\dir/so\\.//me\\file", "\\", "/some/dir/so/me/file"),
     ],
 )
-def test_helpers_fsutil_normpath(path, alt_separator, result):
+def test_normpath(path: str, alt_separator: str, result: str) -> None:
     assert fsutil.normpath(path, alt_separator=alt_separator) == result
 
 
@@ -134,7 +145,7 @@ def test_helpers_fsutil_normpath(path, alt_separator, result):
         ("some\\dir", "/my\\cwd/", "\\", "/my/cwd/some/dir"),
     ],
 )
-def test_helpers_fsutil_abspath(path, cwd, alt_separator, result):
+def test_abspath(path: str, cwd: str, alt_separator: str, result: str) -> None:
     assert fsutil.abspath(path, cwd=cwd, alt_separator=alt_separator) == result
 
 
@@ -150,11 +161,11 @@ def test_helpers_fsutil_abspath(path, cwd, alt_separator, result):
         ("/some///long\\\\dir/so\\//me\\file", "/some/long\\\\dir", "\\", "so/me/file"),
     ],
 )
-def test_helpers_fsutil_relpath(path, start, alt_separator, result):
+def test_relpath(path: str, start: str, alt_separator: str, result: str) -> None:
     assert fsutil.relpath(path, start, alt_separator=alt_separator) == result
 
 
-def test_helpers_fsutil_generate_addr():
+def test_generate_addr() -> None:
     slash_path = "/some/dir/some/file"
     slash_vfs = VirtualFilesystem(alt_separator="")
     slash_target_path = fsutil.TargetPath(slash_vfs, slash_path)
@@ -176,7 +187,7 @@ def test_helpers_fsutil_generate_addr():
     assert fsutil.generate_addr(slash_path, "") != fsutil.generate_addr(backslash_path, "")
 
 
-def test_stat_result():
+def test_stat_result() -> None:
     with pytest.raises(TypeError):
         fsutil.stat_result([0])
 
@@ -210,6 +221,378 @@ def test_stat_result():
     assert st == my_stat
 
 
+@pytest.fixture
+def path_fs() -> Iterator[VirtualFilesystem]:
+    vfs = VirtualFilesystem()
+
+    vfs.makedirs("/some/dir")
+    vfs.symlink("/some/dir/file.txt", "/some/symlink.txt")
+    vfs.symlink("nonexistent", "/some/dir/link.txt")
+    vfs.map_file_fh("/some/file.txt", io.BytesIO(b"content"))
+    vfs.map_file_fh("/some/dir/file.txt", io.BytesIO(b""))
+
+    yield vfs
+
+
+def test_target_path_drive(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/file.txt").drive == ""
+
+
+def test_target_path_root(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/file.txt").root == "/"
+
+
+def test_target_path_anchor(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/file.txt").anchor == "/"
+
+
+def test_target_path_parent(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/dir/file.txt").parent == path_fs.path("/some/dir")
+
+
+def test_target_path_parents(path_fs: VirtualFilesystem) -> None:
+    path = path_fs.path("/some/dir/file.txt")
+    parents = list(path.parents)
+    assert parents == [path_fs.path("/some/dir"), path_fs.path("/some"), path_fs.path("/")]
+    assert [p.exists() for p in parents]
+    assert all([p._fs == path_fs for p in parents])
+
+
+def test_target_path_name(path_fs: VirtualFilesystem) -> None:
+    path = path_fs.path("/some/file.txt")
+    assert path.name == "file.txt"
+
+
+def test_target_path_suffix(path_fs: VirtualFilesystem) -> None:
+    path = path_fs.path("/some/file.txt")
+    assert path.suffix == ".txt"
+
+
+def test_target_path_suffixes(path_fs: VirtualFilesystem) -> None:
+    path = path_fs.path("/some/file.tar.gz")
+    assert path.suffixes == [".tar", ".gz"]
+
+
+def test_target_path_stem(path_fs: VirtualFilesystem) -> None:
+    path = path_fs.path("/some/file.txt")
+    assert path.stem == "file"
+
+
+def test_target_path_as_posix(path_fs: VirtualFilesystem) -> None:
+    path = path_fs.path("/some/file.txt")
+    assert path.as_posix() == "/some/file.txt"
+
+    path_fs.alt_separator = "\\"
+    path = path_fs.path("\\some\\file.txt")
+    assert path.exists()
+    assert path.as_posix() == "/some/file.txt"
+
+
+def test_target_path_as_uri(path_fs: VirtualFilesystem) -> None:
+    path = path_fs.path("/some/file.txt")
+    assert path.as_uri() == "file:///some/file.txt"
+
+    path_fs.alt_separator = "\\"
+    path = path_fs.path("\\some\\file.txt")
+    assert path.as_uri() == "file:///some/file.txt"
+
+
+def test_target_path_is_absolute(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/file.txt").is_absolute()
+    assert not path_fs.path("some/file.txt").is_absolute()
+
+
+def test_target_path_is_relative_to(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/dir/file.txt").is_relative_to("/some/dir")
+    assert not path_fs.path("/some/dir/file.txt").is_relative_to("/some/other")
+
+
+def test_target_path_is_reserved(path_fs: VirtualFilesystem) -> None:
+    # We currently do not have any reserved names for TargetPath
+    assert not path_fs.path("CON").is_reserved()
+    assert not path_fs.path("foo").is_reserved()
+
+
+def test_target_path_join(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some").joinpath("file.txt") == path_fs.path("/some/file.txt")
+    assert path_fs.path("/some") / "file.txt" == path_fs.path("/some/file.txt")
+
+
+def test_target_path_match(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/file.txt").match("*.txt")
+    assert not path_fs.path("/some/file.txt").match("*.csv")
+
+
+def test_target_path_relative_to(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/dir/file.txt").relative_to("/some") == path_fs.path("dir/file.txt")
+
+
+def test_target_path_with_name(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/file.txt").with_name("new_file.txt") == path_fs.path("/some/new_file.txt")
+
+
+def test_target_path_with_stem(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/file.txt").with_stem("new_file") == path_fs.path("/some/new_file.txt")
+
+
+def test_target_path_with_suffix(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/file.txt").with_suffix(".csv") == path_fs.path("/some/file.csv")
+
+
+def test_target_path_stat(path_fs: VirtualFilesystem) -> None:
+    stat_result = path_fs.path("/some/file.txt").stat()
+    assert stat_result.st_mode == 0o100000
+    assert stat_result.st_dev == id(path_fs)
+    assert stat_result.st_nlink == 1
+
+    stat_result = path_fs.path("/some").stat()
+    assert stat_result.st_mode == 0o40000
+    assert stat_result.st_dev == id(path_fs)
+    assert stat_result.st_nlink == 1
+
+    assert path_fs.path("/some/symlink.txt").stat() == path_fs.path("/some/dir/file.txt").stat()
+
+
+def test_target_path_lstat(path_fs: VirtualFilesystem) -> None:
+    stat_result = path_fs.path("/some/symlink.txt").lstat()
+    assert stat_result != path_fs.path("/some/dir/file.txt").lstat()
+    assert stat_result.st_mode == 0o120000
+
+
+def test_target_path_exists(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/file.txt").exists()
+    assert not path_fs.path("/some/other.txt").exists()
+
+
+def test_target_path_glob(path_fs: VirtualFilesystem) -> None:
+    assert list(path_fs.path("/some").glob("*.txt")) == [
+        path_fs.path("/some/symlink.txt"),
+        path_fs.path("/some/file.txt"),
+    ]
+    assert list(path_fs.path("/some").glob("*.csv")) == []
+
+
+def test_target_path_rglob(path_fs: VirtualFilesystem) -> None:
+    assert list(path_fs.path("/some").rglob("*.txt")) == [
+        path_fs.path("/some/symlink.txt"),
+        path_fs.path("/some/file.txt"),
+        path_fs.path("/some/dir/link.txt"),
+        path_fs.path("/some/dir/file.txt"),
+    ]
+    assert list(path_fs.path("/some").rglob("*.csv")) == []
+
+
+def test_target_path_is_dir(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/dir").is_dir()
+    assert not path_fs.path("/some/file.txt").is_dir()
+
+
+def test_target_path_is_file(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/file.txt").is_file()
+    assert not path_fs.path("/some/dir").is_file()
+
+
+def test_target_path_is_mount(path_fs: VirtualFilesystem) -> None:
+    assert not path_fs.path("/some").is_mount()
+
+    mnt_vfs = VirtualFilesystem()
+    mnt_vfs.makedirs("/foo")
+    path_fs.mount("/mnt", mnt_vfs)
+
+    assert path_fs.path("/mnt").is_mount()
+
+
+def test_target_path_is_symlink(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/symlink.txt").is_symlink()
+    assert not path_fs.path("/some/file.txt").is_symlink()
+    assert not path_fs.path("/some/dir").is_symlink()
+
+
+def test_target_path_is_junction(path_fs: VirtualFilesystem) -> None:
+    assert not path_fs.path("/some").is_junction()
+
+    mock_entry = Mock(spec=NtfsFilesystemEntry)
+    mock_entry.dereference.return_value.is_mount_point.return_value = True
+
+    path_fs.map_file_entry("/junction", mock_entry)
+    assert path_fs.path("/junction").is_junction()
+
+
+def test_target_path_is_socket(path_fs: VirtualFilesystem) -> None:
+    assert not path_fs.path("/some/file.txt").is_socket()
+
+
+def test_target_path_is_fifo(path_fs: VirtualFilesystem) -> None:
+    assert not path_fs.path("/some/file.txt").is_fifo()
+
+
+def test_target_path_is_block_device(path_fs: VirtualFilesystem) -> None:
+    assert not path_fs.path("/some/file.txt").is_block_device()
+
+
+def test_target_path_is_char_device(path_fs: VirtualFilesystem) -> None:
+    assert not path_fs.path("/some/file.txt").is_char_device()
+
+
+def test_target_path_iterdir(path_fs: VirtualFilesystem) -> None:
+    assert list(path_fs.path("/some").iterdir()) == [
+        path_fs.path("/some/dir"),
+        path_fs.path("/some/symlink.txt"),
+        path_fs.path("/some/file.txt"),
+    ]
+
+
+def test_target_path_walk(path_fs: VirtualFilesystem) -> None:
+    assert list(path_fs.path("/some").walk()) == [
+        (path_fs.path("/some"), ["dir"], ["symlink.txt", "file.txt"]),
+        (path_fs.path("/some/dir"), [], ["link.txt", "file.txt"]),
+    ]
+
+
+def test_target_path_open(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/file.txt").open("rb").read() == b"content"
+    assert path_fs.path("/some/file.txt").open("r").read() == "content"
+
+
+def test_target_path_read_bytes(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/file.txt").read_bytes() == b"content"
+
+
+def test_target_path_read_text(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/file.txt").read_text() == "content"
+
+
+def test_target_path_readlink(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/symlink.txt").readlink() == path_fs.path("/some/dir/file.txt")
+
+
+def test_target_path_resolve(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/symlink.txt").resolve() == path_fs.path("/some/dir/file.txt")
+    assert path_fs.path("/some/symlink.txt").resolve(strict=True) == path_fs.path("/some/dir/file.txt")
+    assert path_fs.path("/some/foo").resolve() == path_fs.path("/some/foo")
+
+    with pytest.raises(FileNotFoundError):
+        assert path_fs.path("/some/foo").resolve(strict=True)
+
+    with pytest.raises(FileNotFoundError):
+        path_fs.path("/some/dir/link.txt").resolve(strict=True)
+
+    with pytest.raises(NotADirectoryError):
+        path_fs.path("/some/file.txt/other").resolve(strict=True)
+
+
+def test_target_path_samefile(path_fs: VirtualFilesystem) -> None:
+    assert path_fs.path("/some/symlink.txt").samefile(path_fs.path("/some/dir/file.txt"))
+    assert not path_fs.path("/some/symlink.txt").samefile(path_fs.path("/some/file.txt"))
+
+
+def test_target_path_errors(path_fs: VirtualFilesystem) -> None:
+    # TargetPath sometimes emulates OSErrors to play nicely with pathlib, but other times
+    # we raise our own FilesystemError variants. Ensure that all user-facing errors are our own.
+    path_fs.symlink("symlink1", "symlink2")
+    path_fs.symlink("symlink2", "symlink1")
+
+    with pytest.raises(SymlinkRecursionError) as e:
+        path_fs.path("symlink1/symlink2/symlink1").resolve()
+
+    # This should raise from the final stat() call
+    if sys.version_info >= (3, 10):
+        assert [tb.name for tb in e.traceback[1:3]] == [
+            "resolve",
+            "stat",
+        ]
+    else:
+        # In 3.9 there's no difference between these two
+        assert [tb.name for tb in e.traceback[1:3]] == [
+            "resolve",
+            "resolve",
+        ]
+
+    with pytest.raises(SymlinkRecursionError) as e:
+        path_fs.path("symlink1/symlink2/symlink1").resolve(strict=True)
+
+    # This should raise from the inner realpath() call
+    if sys.version_info >= (3, 10):
+        assert [tb.frame.code.name for tb in e.traceback[1:3]] == [
+            "resolve",
+            "realpath",
+        ]
+    else:
+        # In 3.9 there's no difference between these two
+        assert [tb.frame.code.name for tb in e.traceback[1:3]] == [
+            "resolve",
+            "resolve",
+        ]
+
+    with pytest.raises(NotASymlinkError):
+        path_fs.path("some/file.txt").readlink()
+
+    with pytest.raises(NotADirectoryError):
+        path_fs.path("some/file.txt/dir").stat()
+
+
+def test_target_path_not_implemented(path_fs: VirtualFilesystem) -> None:
+    # TargetPath can't do some things, such as write actions or stuff related to a "current" user or path
+    # Ensure all those methods properly error
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().cwd()
+
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().home()
+
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().expanduser()
+
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().absolute()
+
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().owner()
+
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().group()
+
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().chmod(0o777)
+
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().lchmod(0o777)
+
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().rename("foo")
+
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().replace("foo")
+
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().symlink_to("foo")
+
+    if sys.version_info >= (3, 10):
+        with pytest.raises(NotImplementedError):
+            assert path_fs.path().hardlink_to("foo")
+    else:
+        with pytest.raises(NotImplementedError):
+            assert path_fs.path().link_to("foo")
+
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().mkdir()
+
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().rmdir()
+
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().touch()
+
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().unlink()
+
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().write_bytes(b"foo")
+
+    with pytest.raises(NotImplementedError):
+        assert path_fs.path().write_text("foo")
+
+
 @pytest.mark.parametrize(
     ("path, alt_separator, result"),
     [
@@ -222,7 +605,7 @@ def test_stat_result():
         ("\\some\\dir/some\\file", "\\", ("/", "some", "dir", "some", "file")),
     ],
 )
-def test_helpers_fsutil_pure_dissect_path__from_parts(path, alt_separator, result):
+def test_pure_dissect_path__from_parts(path: str, alt_separator: str, result: tuple[str]) -> None:
     vfs = VirtualFilesystem(alt_separator=alt_separator)
     pure_dissect_path = fsutil.PureDissectPath(vfs, path)
 
@@ -237,7 +620,7 @@ def test_helpers_fsutil_pure_dissect_path__from_parts(path, alt_separator, resul
     ("case_sensitive"),
     [True, False],
 )
-def test_helpers_fsutil_pure_dissect_path__from_parts_flavour(alt_separator, case_sensitive):
+def test_pure_dissect_path__from_parts_flavour(alt_separator: str, case_sensitive: bool) -> None:
     vfs = VirtualFilesystem(alt_separator=alt_separator, case_sensitive=case_sensitive)
     pure_dissect_path = fsutil.PureDissectPath(vfs, "/some/dir")
 
@@ -245,7 +628,7 @@ def test_helpers_fsutil_pure_dissect_path__from_parts_flavour(alt_separator, cas
     assert pure_dissect_path._flavour.case_sensitive == case_sensitive
 
 
-def test_helpers_fsutil_pure_dissect_path__from_parts_no_fs_exception():
+def test_pure_dissect_path__from_parts_no_fs_exception() -> None:
     with pytest.raises(TypeError):
         fsutil.PureDissectPath(Mock(), "/some/dir")
 
@@ -260,13 +643,13 @@ def test_helpers_fsutil_pure_dissect_path__from_parts_no_fs_exception():
         ("comp_bz2", bz2.compress, b"bz2\ncontent"),
     ],
 )
-def test_helpers_fsutil_open_decompress(file_name, compressor, content):
+def test_open_decompress(file_name: str, compressor: Callable, content: bytes) -> None:
     vfs = VirtualFilesystem()
     vfs.map_file_fh(file_name, io.BytesIO(compressor(content)))
     assert fsutil.open_decompress(vfs.path(file_name)).read() == content
 
 
-def test_helpers_fsutil_open_decompress_text_modes():
+def test_open_decompress_text_modes() -> None:
     vfs = VirtualFilesystem()
     vfs.map_file_fh("test", io.BytesIO(b"zomgbbq"))
 
@@ -289,7 +672,7 @@ def test_helpers_fsutil_open_decompress_text_modes():
     assert fh.errors == "backslashreplace"
 
 
-def test_helpers_fsutil_reverse_readlines():
+def test_reverse_readlines() -> None:
     vfs = VirtualFilesystem()
 
     expected_range_reverse = ["99"] + [f"{i}\n" for i in range(98, -1, -1)]
@@ -335,6 +718,52 @@ def test_helpers_fsutil_reverse_readlines():
     ]
 
 
+@pytest.fixture
+def xattrs() -> dict[str, bytes]:
+    return {"some_key": b"some_value"}
+
+
+@pytest.fixture
+def listxattr_spec(xattrs: dict[str, str]) -> dict[str, Any]:
+    # listxattr() is only available on Linux
+    attr_names = list(xattrs.keys())
+
+    if hasattr(os, "listxattr"):
+        spec = {
+            "create": False,
+            "autospec": True,
+            "return_value": attr_names,
+        }
+    else:
+        spec = {
+            "create": True,
+            "return_value": attr_names,
+        }
+
+    return spec
+
+
+@pytest.fixture
+def getxattr_spec(xattrs: dict[str, str]) -> dict[str, Any]:
+    # getxattr() is only available on Linux
+    attr_name = list(xattrs.keys())[0]
+    attr_value = xattrs.get(attr_name)
+
+    if hasattr(os, "getxattr"):
+        spec = {
+            "create": False,
+            "autospec": True,
+            "return_value": attr_value,
+        }
+    else:
+        spec = {
+            "create": True,
+            "return_value": attr_value,
+        }
+
+    return spec
+
+
 @pytest.mark.parametrize(
     "follow_symlinks",
     [
@@ -342,7 +771,9 @@ def test_helpers_fsutil_reverse_readlines():
         False,
     ],
 )
-def test_fs_attrs(xattrs, listxattr_spec, getxattr_spec, follow_symlinks):
+def test_fs_attrs(
+    xattrs: dict[str, bytes], listxattr_spec: dict[str, Any], getxattr_spec: dict[str, Any], follow_symlinks: bool
+) -> None:
     with patch("os.listxattr", **listxattr_spec) as listxattr:
         with patch("os.getxattr", **getxattr_spec) as getxattr:
             path = "/some/path"
@@ -354,7 +785,7 @@ def test_fs_attrs(xattrs, listxattr_spec, getxattr_spec, follow_symlinks):
 
 
 @contextmanager
-def no_listxattr():
+def no_listxattr() -> Iterator[None]:
     if not hasattr(os, "listxattr"):
         yield
         return
@@ -366,12 +797,12 @@ def no_listxattr():
         os.listxattr = listxattr
 
 
-def test_fs_attrs_no_os_listxattr():
+def test_fs_attrs_no_os_listxattr() -> None:
     with no_listxattr():
         assert fsutil.fs_attrs("/some/path") == {}
 
 
-def test_target_path_checks_dirfs(tmp_path, target_win):
+def test_target_path_checks_dirfs(tmp_path: Path, target_win: Target) -> None:
     with tempfile.NamedTemporaryFile(dir=tmp_path, delete=False) as tf:
         tf.write(b"dummy")
         tf.close()
@@ -385,7 +816,7 @@ def test_target_path_checks_dirfs(tmp_path, target_win):
         assert not target_win.fs.path(f"Z:\\{tmpfile_name}\\some").is_file()
 
 
-def test_target_path_checks_mapped_dir(tmp_path, target_win):
+def test_target_path_checks_mapped_dir(tmp_path: Path, target_win: Target) -> None:
     with tempfile.NamedTemporaryFile(dir=tmp_path, delete=False) as tf:
         tf.write(b"dummy")
         tf.close()
@@ -399,13 +830,13 @@ def test_target_path_checks_mapped_dir(tmp_path, target_win):
         assert not target_win.fs.path(f"C:\\test-dir\\{tmpfile_name}\\some").is_file()
 
 
-def test_target_path_checks_virtual():
+def test_target_path_checks_virtual() -> None:
     vfs = VirtualFilesystem()
     vfs.map_file_entry("file", VirtualFile(vfs, "file", None))
     assert not vfs.path("file/test").exists()
 
 
-def test_target_path_backslash_normalisation(target_win, fs_win, tmp_path):
+def test_target_path_backslash_normalisation(target_win: Target, fs_win: VirtualFilesystem, tmp_path: Path) -> None:
     with tempfile.NamedTemporaryFile(dir=tmp_path, delete=False) as tf:
         tf.write(b"dummy")
         tf.close()

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -659,12 +659,12 @@ def test_virtual_filesystem_link(vfs_path, link_path):
         ),
     ],
 )
-def test_virtual_filesystem_symlink(vfs_path, link_path):
+def test_virtual_filesystem_symlink(vfs_path: str, link_path: str) -> None:
     vfs = VirtualFilesystem()
 
     vfs.symlink(vfs_path, link_path)
 
-    vfs_path = fsutil.normalize(vfs_path, alt_separator=vfs.alt_separator).strip("/")
+    vfs_path = fsutil.normalize(vfs_path, alt_separator=vfs.alt_separator).rstrip("/")
     link_path = fsutil.normalize(link_path, alt_separator=vfs.alt_separator).strip("/")
     link_entry = vfs.get(link_path)
 
@@ -913,8 +913,8 @@ def rootfs(
     vfs2.map_file_entry("/shared_entry", vfs2_shared_entry)
 
     vfs1.map_file_entry("/path/to/some/file", VirtualFile(vfs1, "path/to/some/file", Mock()))
-    vfs1.symlink("/path/to/some/", "dirlink")
-    vfs1.symlink("/path/to/some/file", "filelink")
+    vfs1.symlink("path/to/some/", "dirlink")
+    vfs1.symlink("path/to/some/file", "filelink")
 
     target = Mock()
     rootfs = RootFilesystem(target)

--- a/tests/tools/test_utils.py
+++ b/tests/tools/test_utils.py
@@ -28,7 +28,7 @@ def test_persist_execution_report():
             assert full_path.suffix == ".json"
             assert "2000-01-01-000000" in full_path.name
 
-            mocked_json_dumps.called_once_with(report_data)
+            mocked_json_dumps.assert_called_once_with(report_data, sort_keys=True, indent=4)
 
             mocked_write_text.assert_called_once_with(test_output)
 


### PR DESCRIPTION
This refactors TargetPath into a structure that's hopefully a little easier to maintain for future Python versions. TargetPath implementations are now split into different files, one for each Python version. Each file has specific changes needed to make it work. Each new release of Python still requires a new patch though.

I've also fixed some small filesystem and other test related bugs I ran into to get this all working.

As I'm writing this, I'm also starting to wonder at what point it might be a better idea to just... subclass `pathlib.Path` but literally override everything. I'm sure that has it's own set of challenges though.

Depends on https://github.com/fox-it/flow.record/pull/91