### PR TITLE
Improve driveletter selection for windows disks

### DIFF
--- a/dissect/target/plugins/filesystem/ntfs/mft.py
+++ b/dissect/target/plugins/filesystem/ntfs/mft.py
@@ -123,6 +123,12 @@ class MftPlugin(Plugin):
 
         The Master File Table (MFT) contains primarily metadata about every file and folder on a NFTS filesystem.
 
+        If the filesystem is part of a virtual NTFS filesystem (a ``VirtualFilesystem`` with the MFT properties
+        added to it through a "fake" ``NtfsFilesystem``), the paths returned in the MFT records are based on the
+        mount point of the ``VirtualFilesystem``. This ensures that the proper original drive letter is used when
+        available.
+        When no drive letter can be determined, the path will show as e.g. ``\\$fs$\\fs0``.
+
         References:
             - https://docs.microsoft.com/en-us/windows/win32/fileio/master-file-table
         """
@@ -136,6 +142,10 @@ class MftPlugin(Plugin):
             if fs.__type__ != "ntfs":
                 continue
 
+            # If this filesystem is a "fake" NTFS filesystem, used to enhance a
+            # VirtualFilesystem, The driveletter (more accurate mount point)
+            # returned will be that of the VirtualFilesystem. This makes sure
+            # the paths returned in the records are actually reachable.
             drive_letter = get_drive_letter(self.target, fs)
             volume_uuid = get_volume_identifier(fs)
 

--- a/dissect/target/plugins/filesystem/ntfs/mft_timeline.py
+++ b/dissect/target/plugins/filesystem/ntfs/mft_timeline.py
@@ -105,6 +105,12 @@ class MftTimelinePlugin(Plugin):
 
         The Master File Table (MFT) contains metadata about every file and folder on a NFTS filesystem.
 
+        If the filesystem is part of a virtual NTFS filesystem (a ``VirtualFilesystem`` with the MFT properties
+        added to it through a "fake" ``NtfsFilesystem``), the paths returned in the MFT records are based on the
+        mount point of the ``VirtualFilesystem``. This ensures that the proper original drive letter is used when
+        available.
+        When no drive letter can be determined, the path will show as e.g. ``\\$fs$\\fs0``.
+
         References:
             - https://docs.microsoft.com/en-us/windows/win32/fileio/master-file-table
         """
@@ -112,6 +118,10 @@ class MftTimelinePlugin(Plugin):
             if fs.__type__ != "ntfs":
                 continue
 
+            # If this filesystem is a "fake" NTFS filesystem, used to enhance a
+            # VirtualFilesystem, The driveletter (more accurate mount point)
+            # returned will be that of the VirtualFilesystem. This makes sure
+            # the paths returned in the records are actually reachable.
             drive_letter = get_drive_letter(self.target, fs)
             extras = Extras(
                 serial=fs.ntfs.serial,

--- a/dissect/target/plugins/filesystem/ntfs/usnjrnl.py
+++ b/dissect/target/plugins/filesystem/ntfs/usnjrnl.py
@@ -34,6 +34,12 @@ class UsnjrnlPlugin(Plugin):
         The Update Sequence Number Journal (UsnJrnl) is a feature of an NTFS file system and contains information about
         filesystem activities. Each volume has its own UsnJrnl.
 
+        If the filesystem is part of a virtual NTFS filesystem (a ``VirtualFilesystem`` with the UsnJrnl
+        properties added to it through a "fake" ``NtfsFilesystem``), the paths returned in the UsnJrnl records
+        are based on the mount point of the ``VirtualFilesystem``. This ensures that the proper original drive
+        letter is used when available.
+        When no drive letter can be determined, the path will show as e.g. ``\\$fs$\\fs0``.
+
         References:
             - https://en.wikipedia.org/wiki/USN_Journal
             - https://velociraptor.velocidex.com/the-windows-usn-journal-f0c55c9010e
@@ -47,6 +53,10 @@ class UsnjrnlPlugin(Plugin):
             if not usnjrnl:
                 continue
 
+            # If this filesystem is a "fake" NTFS filesystem, used to enhance a
+            # VirtualFilesystem, The driveletter (more accurate mount point)
+            # returned will be that of the VirtualFilesystem. This makes sure
+            # the paths returned in the records are actually reachable.
             drive_letter = get_drive_letter(self.target, fs)
             for record in usnjrnl.records():
                 try:

--- a/tests/plugins/filesystem/ntfs/test_mft.py
+++ b/tests/plugins/filesystem/ntfs/test_mft.py
@@ -37,11 +37,26 @@ def load_mft_plugin(target_win):
     target_win.add_plugin(MftPlugin)
 
 
-def test_driveletter():
+@pytest.mark.parametrize(
+    "drive_letters, expected",
+    [
+        (("z:", "c:", "a:"), "a:\\"),
+        (("foo", "bar", "bla"), "bar\\"),
+        (("$fs$\\fs2", "$fs$\\fs1", "$fs$\\fs0"), "$fs$\\fs0\\"),
+        (("sysvol", "c:"), "c:\\"),
+        (("sysvol", "c:", "a:"), "a:\\"),
+        (("$fs$\\fs0", "sysvol", "c:"), "c:\\"),
+        (("$fs$\\fs0", "sysvol"), "sysvol\\"),
+        (("$fs$\\fs0",), "$fs$\\fs0\\"),
+    ],
+)
+def test_driveletter(drive_letters, expected):
     mocked_target = Mock()
-    mocked_cdisk = Mock()
-    mocked_target.fs.mounts = {"sysvol": mocked_cdisk, "c:": mocked_cdisk}
-    assert get_drive_letter(mocked_target, mocked_cdisk) == "c:\\"
+    mocked_disk = Mock()
+    num_drives = len(drive_letters)
+    mocked_target.fs.mounts = dict(zip(drive_letters, [mocked_disk] * num_drives))
+
+    assert get_drive_letter(mocked_target, mocked_disk) == expected
 
 
 def test_driveletter_unknown():


### PR DESCRIPTION
As of c97c344 filesystems are always mounted. In the case of "fake" NTFS filesystems, as used by e.g. the dir and tar loaders, this means such a filesystem can be present under up to three different mount points, e.g.: sysvol, C: and $fs$\fs0

When a plugin does not use the root filesystem but the bare ntfs filesystem to parse ntfs specific properties, e.g. the mft plugin, it extends paths with a "driveletter" (read: mountpoint) to construct a path that is reachable from the root filesystem.

The old setup always returned the last mount point a drive was mounted under. The new setup changes this to return the first mount point present in the following order:

1. the first mount point with a letter and colon, e.g. C:,
2. the first mount point not starting with $fs$, e.g. sysvol,
3. the first mount point starting with $fs$, e.g. $fs$\fs0.