### PR TITLE
Fix file handle exhaustion for EWF files with many chunks

### DIFF
--- a/dissect/target/containers/ewf.py
+++ b/dissect/target/containers/ewf.py
@@ -19,7 +19,7 @@ class EwfContainer(Container):
         if hasattr(fhs[0], "read"):
             self.ewf = EWF(fhs)
         else:
-            self.ewf = EWF([path.open("rb") for path in find_files(fhs[0])])
+            self.ewf = EWF([path for path in find_files(fhs[0])])
 
         self._stream = self.ewf.open()
         super().__init__(fh, self.ewf.size, *args, **kwargs)

--- a/dissect/target/containers/ewf.py
+++ b/dissect/target/containers/ewf.py
@@ -19,7 +19,7 @@ class EwfContainer(Container):
         if hasattr(fhs[0], "read"):
             self.ewf = EWF(fhs)
         else:
-            self.ewf = EWF([path for path in find_files(fhs[0])])
+            self.ewf = EWF(find_files(fhs[0]))
 
         self._stream = self.ewf.open()
         super().__init__(fh, self.ewf.size, *args, **kwargs)


### PR DESCRIPTION
The EWF implementation in `dissect.evidence` does LRU, but that requires passing in the `Path` objects instead of file-like objects. The current code just tries to open _all_ the files at once. Passing the `Path` objects instead will allow us to properly utilize the internal LRU.