### PR TITLE
Add FortiOS rootfs.gz decrypt functionality

### DIFF
--- a/dissect/target/plugins/os/unix/linux/fortios/generic.py
+++ b/dissect/target/plugins/os/unix/linux/fortios/generic.py
@@ -16,13 +16,15 @@ class GenericPlugin(Plugin):
     @export(property=True)
     def install_date(self) -> Optional[datetime]:
         """Return the likely install date of FortiOS."""
-        if (init_log := self.target.fs.path("/data/etc/cloudinit.log")).exists():
-            return ts.from_unix(init_log.stat().st_mtime)
+        files = ["/data/etc/cloudinit.log", "/data/.vm_provisioned", "/data/etc/ssh/ssh_host_dsa_key"]
+        for file in files:
+            if (fp := self.target.fs.path(file)).exists():
+                return ts.from_unix(fp.stat().st_mtime)
 
     @export(property=True)
     def activity(self) -> Optional[datetime]:
         """Return last seen activity based on filesystem timestamps."""
-        log_dirs = ["/var/log/log/root", "/var/log/root"]
+        log_dirs = ["/var/log/log/root", "/var/log/root", "/data"]
         for log_dir in log_dirs:
             if (var_log := self.target.fs.path(log_dir)).exists():
                 return calculate_last_activity(var_log)

--- a/dissect/target/plugins/os/unix/linux/fortios/locale.py
+++ b/dissect/target/plugins/os/unix/linux/fortios/locale.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from dissect.target.exceptions import UnsupportedPluginError
 from dissect.target.plugin import Plugin, export
 
@@ -8,13 +10,16 @@ class LocalePlugin(Plugin):
             raise UnsupportedPluginError("FortiOS specific plugin loaded on non-FortiOS target")
 
     @export(property=True)
-    def timezone(self) -> str:
+    def timezone(self) -> Optional[str]:
         """Return configured UI/system timezone."""
-        timezone_num = self.target._os._config["global-config"]["system"]["global"]["timezone"][0]
-        return translate_timezone(timezone_num)
+        try:
+            timezone_num = self.target._os._config["global-config"]["system"]["global"]["timezone"][0]
+            return translate_timezone(timezone_num)
+        except KeyError:
+            pass
 
     @export(property=True)
-    def language(self) -> str:
+    def language(self) -> Optional[str]:
         """Return configured UI language."""
         LANG_MAP = {
             "english": "en_US",
@@ -26,8 +31,11 @@ class LocalePlugin(Plugin):
             "simch": "zh_CN",
             "korean": "ko_KR",
         }
-        lang_str = self.target._os._config["global-config"]["system"]["global"].get("language", ["english"])[0]
-        return LANG_MAP.get(lang_str, lang_str)
+        try:
+            lang_str = self.target._os._config["global-config"]["system"]["global"].get("language", ["english"])[0]
+            return LANG_MAP.get(lang_str, lang_str)
+        except KeyError:
+            pass
 
 
 def translate_timezone(timezone_num: str) -> str:


### PR DESCRIPTION
This PR adds rudimentary support for decrypting `rootfs.gz` files on FortiOS 7.4.1 and up.