### PR TITLE
Fix hostname plugin for RedHat systems

### DIFF
--- a/dissect/target/plugins/os/unix/_os.py
+++ b/dissect/target/plugins/os/unix/_os.py
@@ -133,6 +133,7 @@ class UnixPlugin(OSPlugin):
         return OperatingSystem.UNIX.value
 
     def _parse_rh_legacy(self, path):
+        hostname = None
         file_contents = path.open("rt").readlines()
         for line in file_contents:
             if not line.startswith("HOSTNAME"):
@@ -149,7 +150,6 @@ class UnixPlugin(OSPlugin):
         """
         redhat_legacy_path = "/etc/sysconfig/network"
         paths = paths or ["/etc/hostname", "/etc/HOSTNAME", redhat_legacy_path]
-        hostname_string = None
         hostname_dict = {"hostname": None, "domain": None}
 
         for path in paths:
@@ -166,9 +166,11 @@ class UnixPlugin(OSPlugin):
             if hostname_string and "." in hostname_string:
                 hostname_string = hostname_string.split(".", maxsplit=1)
                 hostname_dict = {"hostname": hostname_string[0], "domain": hostname_string[1]}
-            else:
+            elif hostname_string != "":
                 hostname_dict = {"hostname": hostname_string, "domain": None}
-            break
+            else:
+                hostname_dict = {"hostname": None, "domain": None}
+            break  # break whenever a valid hostname is found
         return hostname_dict
 
     def _parse_hosts_string(self, paths: Optional[list[str]] = None) -> dict[str, str]:

--- a/dissect/target/plugins/os/unix/_os.py
+++ b/dissect/target/plugins/os/unix/_os.py
@@ -147,8 +147,8 @@ class UnixPlugin(OSPlugin):
         Args:
             paths (list): list of paths
         """
-        REDHAT_LEGACY_PATH = self.target.fs.path("/etc/sysconfig/network")
-        paths = paths or ["/etc/hostname", "/etc/HOSTNAME", REDHAT_LEGACY_PATH]
+        redhat_legacy_path = "/etc/sysconfig/network"
+        paths = paths or ["/etc/hostname", "/etc/HOSTNAME", redhat_legacy_path]
         hostname_string = None
         hostname_dict = {"hostname": None, "domain": None}
 
@@ -158,7 +158,7 @@ class UnixPlugin(OSPlugin):
             if not path.exists():
                 continue
 
-            if path == REDHAT_LEGACY_PATH:
+            if path.as_posix() == redhat_legacy_path:
                 hostname_string = self._parse_rh_legacy(path)
             else:
                 hostname_string = path.open("rt").read().rstrip()

--- a/tests/plugins/os/unix/test__os.py
+++ b/tests/plugins/os/unix/test__os.py
@@ -1,7 +1,6 @@
 import tempfile
 from io import BytesIO
 from pathlib import Path
-from textwrap import dedent
 from uuid import UUID
 
 import pytest

--- a/tests/plugins/os/unix/test__os.py
+++ b/tests/plugins/os/unix/test__os.py
@@ -79,8 +79,8 @@ def test_parse_fstab(tmp_path):
     ],
 )
 def test__parse_hostname_string(
-    target_redhat: Target,
-    fs_redhat: VirtualFilesystem,
+    target_unix: Target,
+    fs_unix: VirtualFilesystem,
     path: Path,
     is_domain_joined: bool,
     expected_hostname: str,
@@ -102,9 +102,9 @@ def test__parse_hostname_string(
     else:
         hostname_file_content = hostname
 
-    fs_redhat.map_file_fh(path, BytesIO(hostname_file_content.encode("ascii")))
+    fs_unix.map_file_fh(path, BytesIO(hostname_file_content.encode("ascii")))
 
-    hostname_dict = target_redhat._os._parse_hostname_string()
+    hostname_dict = target_unix._os._parse_hostname_string()
 
     assert hostname_dict["hostname"] == expected_hostname
     assert hostname_dict["domain"] == expected_domain


### PR DESCRIPTION
Wrote as fix for ticket DIS-2796, where the hostname could not be found for Red Hat systems. The hostname for these files is instead of /etc/hostname found within /etc/sysconfig/network.