### PR TITLE
Pin pytest to a version <8.0.0 for now

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ requires = virtualenv>=20.16.6
 [testenv]
 extras = yara
 deps =
-    pytest
+    pytest<8.0.0
     pytest-cov
     coverage
 commands =


### PR DESCRIPTION
Some tests seem to be dependent on the order they are executed and will fail with pytest 8.0.0's new test collection order.

(DIS-2970)