### PR TITLE
Add xampp paths to ApachePlugin

### DIFF
--- a/dissect/target/plugins/apps/webserver/apache.py
+++ b/dissect/target/plugins/apps/webserver/apache.py
@@ -171,7 +171,14 @@ class ApachePlugin(WebserverPlugin):
 
     __namespace__ = "apache"
 
-    DEFAULT_LOG_DIRS = ["/var/log/apache2", "/var/log/apache", "/var/log/httpd", "/var/log"]
+    DEFAULT_LOG_DIRS = [
+        "/var/log/apache2",
+        "/var/log/apache",
+        "/var/log/httpd",
+        "/var/log",
+        "sysvol/xampp/apache/logs",
+        "/opt/lampp/logs",
+    ]
     ACCESS_LOG_NAMES = ["access.log", "access_log", "httpd-access.log"]
     ERROR_LOG_NAMES = ["error.log"]
     DEFAULT_CONFIG_PATHS = [

--- a/tests/plugins/apps/webserver/test_apache.py
+++ b/tests/plugins/apps/webserver/test_apache.py
@@ -74,6 +74,26 @@ def test_access_bz2(target_unix: Target, fs_unix: VirtualFilesystem) -> None:
     assert len(results) == 4
 
 
+def test_xampp_unix(target_unix: Target, fs_unix: VirtualFilesystem) -> None:
+    data_file = absolute_path("_data/plugins/apps/webserver/apache/access.log")
+    fs_unix.map_file("opt/lampp/logs/access.log", data_file)
+
+    target_unix.add_plugin(ApachePlugin)
+    results = list(target_unix.apache.access())
+
+    assert len(results) == 6
+
+
+def test_xampp_windows(target_win: Target, fs_win: VirtualFilesystem) -> None:
+    data_file = absolute_path("_data/plugins/apps/webserver/apache/access.log")
+    fs_win.map_file("xampp/apache/logs/access.log", data_file)
+
+    target_win.add_plugin(ApachePlugin)
+    results = list(target_win.apache.access())
+
+    assert len(results) == 6
+
+
 def test_all_access_log_formats(target_unix: Target, fs_unix: VirtualFilesystem) -> None:
     tz = timezone(timedelta(hours=1))
     data_file = absolute_path("_data/plugins/apps/webserver/apache/access.log")


### PR DESCRIPTION
This PR adds two paths to the ApachePlugin to account for installations of XAMPP on Windows and / or Linux.