### PR TITLE
Add Brave browser plugin

### DIFF
--- a/dissect/target/plugins/apps/browser/brave.py
+++ b/dissect/target/plugins/apps/browser/brave.py
@@ -1,0 +1,69 @@
+from typing import Iterator
+
+from dissect.target.helpers.descriptor_extensions import UserRecordDescriptorExtension
+from dissect.target.helpers.record import create_extended_descriptor
+from dissect.target.plugin import export
+from dissect.target.plugins.apps.browser.browser import (
+    GENERIC_COOKIE_FIELDS,
+    GENERIC_DOWNLOAD_RECORD_FIELDS,
+    GENERIC_EXTENSION_RECORD_FIELDS,
+    GENERIC_HISTORY_RECORD_FIELDS,
+    BrowserPlugin,
+)
+from dissect.target.plugins.apps.browser.chromium import (
+    CHROMIUM_DOWNLOAD_RECORD_FIELDS,
+    ChromiumMixin,
+)
+
+
+class BravePlugin(ChromiumMixin, BrowserPlugin):
+    """Brave browser plugin."""
+
+    __namespace__ = "brave"
+
+    DIRS = [
+        # Windows
+        "AppData/Local/BraveSoftware/Brave-Browser/User Data/Default",
+        "AppData/Roaming/BraveSoftware/Brave-Browser/User Data/Default",
+        # Linux
+        ".config/BraveSoftware/Default",
+        # Macos
+        "Library/Application Support/BraveSoftware/Default",
+    ]
+
+    BrowserHistoryRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
+        "browser/brave/history", GENERIC_HISTORY_RECORD_FIELDS
+    )
+
+    BrowserCookieRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
+        "browser/brave/cookie",
+        GENERIC_COOKIE_FIELDS,
+    )
+
+    BrowserDownloadRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
+        "browser/brave/download", GENERIC_DOWNLOAD_RECORD_FIELDS + CHROMIUM_DOWNLOAD_RECORD_FIELDS
+    )
+
+    BrowserExtensionRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
+        "browser/brave/extension", GENERIC_EXTENSION_RECORD_FIELDS
+    )
+
+    @export(record=BrowserHistoryRecord)
+    def history(self) -> Iterator[BrowserHistoryRecord]:
+        """Return browser history records for Brave."""
+        yield from super().history("brave")
+
+    @export(record=BrowserCookieRecord)
+    def cookies(self) -> Iterator[BrowserCookieRecord]:
+        """Return browser cookie records for Brave."""
+        yield from super().cookies("brave")
+
+    @export(record=BrowserDownloadRecord)
+    def downloads(self) -> Iterator[BrowserDownloadRecord]:
+        """Return browser download records for Brave."""
+        yield from super().downloads("brave")
+
+    @export(record=BrowserExtensionRecord)
+    def extensions(self) -> Iterator[BrowserExtensionRecord]:
+        """Return browser extension records for Brave."""
+        yield from super().extensions("brave")

--- a/dissect/target/plugins/apps/browser/brave.py
+++ b/dissect/target/plugins/apps/browser/brave.py
@@ -36,8 +36,7 @@ class BravePlugin(ChromiumMixin, BrowserPlugin):
     )
 
     BrowserCookieRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
-        "browser/brave/cookie",
-        GENERIC_COOKIE_FIELDS,
+        "browser/brave/cookie", GENERIC_COOKIE_FIELDS
     )
 
     BrowserDownloadRecord = create_extended_descriptor([UserRecordDescriptorExtension])(

--- a/dissect/target/plugins/apps/browser/chromium.py
+++ b/dissect/target/plugins/apps/browser/chromium.py
@@ -70,12 +70,12 @@ class ChromiumMixin:
                 users_dirs.append((user_details.user, cur_dir))
         return users_dirs
 
-    def _iter_db(self, filename: str, *subfolders: Optional[list[str]]) -> Iterator[SQLite3]:
+    def _iter_db(self, filename: str, subdirs: Optional[list[str]] = None) -> Iterator[SQLite3]:
         """Generate a connection to a sqlite database file.
 
         Args:
             filename: The filename as string of the database where the data is stored.
-            subfolders (optional): Subfolder(s) to also try for every configured directory.
+            subdirs: Subdirectories to also try for every configured directory.
 
         Yields:
             opened db_file (SQLite3)
@@ -86,8 +86,8 @@ class ChromiumMixin:
         """
 
         dirs = self.DIRS
-        if subfolders:
-            dirs = dirs + [join(dir, subdir) for dir, subdir in itertools.product(self.DIRS, subfolders)]
+        if subdirs:
+            dirs.extend([join(dir, subdir) for dir, subdir in itertools.product(self.DIRS, subdirs)])
 
         for user, cur_dir in self._build_userdirs(dirs):
             db_file = cur_dir.joinpath(filename)
@@ -204,7 +204,7 @@ class ChromiumMixin:
                 is_http_only (bool): Cookie http only flag.
                 same_site (bool): Cookie same site flag.
         """
-        for user, db_file, db in self._iter_db("Cookies", "Network"):
+        for user, db_file, db in self._iter_db("Cookies", subdirs=["Network"]):
             try:
                 for cookie in db.table("cookies").rows():
                     yield self.BrowserCookieRecord(

--- a/tests/plugins/apps/browser/test_brave.py
+++ b/tests/plugins/apps/browser/test_brave.py
@@ -1,0 +1,47 @@
+from typing import Iterator
+
+import pytest
+
+from dissect.target import Target
+from dissect.target.filesystem import VirtualFilesystem
+from dissect.target.plugins.apps.browser import brave
+from tests._utils import absolute_path
+
+
+@pytest.fixture
+def target_brave(target_win_users: Target, fs_win: VirtualFilesystem) -> Iterator[Target]:
+    base_path = "Users\\John\\AppData\\Local\\BraveSoftware\\Brave-Browser\\User Data\\Default"
+    files = [
+        ("History", "_data/plugins/apps/browser/chrome/History.sqlite"),
+        ("Preferences", "_data/plugins/apps/browser/chrome/windows/Preferences"),
+        ("Secure Preferences", "_data/plugins/apps/browser/chrome/windows/Secure Preferences"),
+        ("Network\\Cookies", "_data/plugins/apps/browser/chromium/Cookies.sqlite"),
+    ]
+
+    for filename, test_path in files:
+        fs_win.map_file("\\".join([base_path, filename]), absolute_path(test_path))
+
+    target_win_users.add_plugin(brave.BravePlugin)
+
+    yield target_win_users
+
+
+def test_brave_history(target_brave: Target) -> None:
+    records = list(target_brave.brave.history())
+    assert len(records) == 5
+
+
+def test_brave_downloads(target_brave: Target) -> None:
+    records = list(target_brave.brave.downloads())
+    assert len(records) == 1
+
+
+def test_brave_extensions(target_brave: Target) -> None:
+    records = list(target_brave.brave.extensions())
+    assert len(records) == 8
+
+
+def test_brave_cookies(target_brave: Target) -> None:
+    records = list(target_brave.brave.cookies())
+    assert len(records) == 5
+    assert all(record.host == ".tweakers.net" for record in records)


### PR DESCRIPTION
This PR adds a `BrowserPlugin` for Brave. 

While working on this PR we found that cookies are stored in the `Network` subfolder in newer versions of Chromium-based browsers.  We therefore made a small addition to `_iter_db` to support checking additional subfolders, which can then be used in the `cookies` method. 