### PR TITLE
Revert back to yara-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ full = [
 yara = [
     # Grab the dependencies for dissect.target
     "dissect.target[full]",
-    "yara-python-wheel"
+    "yara-python"
 ]
 smb = [
     # Grab the dependencies for dissect.target


### PR DESCRIPTION
Yara-python now provides their own pre-compiled wheels, so revert back to the official dependency