### PR TITLE
Apply bug workaround in plocate plugin to all PyPy versions

### DIFF
--- a/dissect/target/plugins/os/unix/locate/plocate.py
+++ b/dissect/target/plugins/os/unix/locate/plocate.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import platform
-import sys
 from io import BytesIO
 from typing import BinaryIO, Iterable
 

--- a/dissect/target/plugins/os/unix/locate/plocate.py
+++ b/dissect/target/plugins/os/unix/locate/plocate.py
@@ -114,12 +114,12 @@ class PLocateFile:
         self.buf = RangeStream(self.fh, self.fh.tell(), self.compressed_length_bytes)
 
     def __iter__(self) -> Iterable[PLocateFile]:
-        # NOTE: This is a workaround for a PyPy 3.9 bug
+        # NOTE: This is a workaround for a PyPy bug
         # We don't know what breaks, but PyPy + zstandard = unhappy times
         # You just get random garbage data back instead of the decompressed data
         # This weird dance of using a decompressobj and unused data is the only way that seems to work
         # It's more expensive on memory, but at least it doesn't break
-        if platform.python_implementation() == "PyPy" and sys.version_info < (3, 10):
+        if platform.python_implementation() == "PyPy":
             obj = self.ctx.decompressobj()
             buf = self.buf.read()
 


### PR DESCRIPTION
Apply the workaround to the whole of PyPy instead of just PyPy 3.9. Since it seems to affect PyPy 3.10 as well.