### PR TITLE
Fix performance regression due to TarFilesystem

### DIFF
--- a/dissect/target/filesystems/tar.py
+++ b/dissect/target/filesystems/tar.py
@@ -63,7 +63,7 @@ class TarFilesystem(Filesystem):
         fh = fsutil.open_decompress(fileobj=fh)
 
         fh.seek(257)
-        return fh.read(7) == b"ustar  "
+        return fh.read(8) in (tarfile.GNU_MAGIC, tarfile.POSIX_MAGIC)
 
     def get(self, path: str, relentry: Optional[FilesystemEntry] = None) -> FilesystemEntry:
         """Returns a TarFilesystemEntry object corresponding to the given path."""

--- a/dissect/target/filesystems/tar.py
+++ b/dissect/target/filesystems/tar.py
@@ -60,7 +60,10 @@ class TarFilesystem(Filesystem):
     @staticmethod
     def _detect(fh: BinaryIO) -> bool:
         """Detect a tar file on a given file-like object."""
-        return tarfile.is_tarfile(fh)
+        fh = fsutil.open_decompress(fileobj=fh)
+
+        fh.seek(257)
+        return fh.read(7) == b"ustar  "
 
     def get(self, path: str, relentry: Optional[FilesystemEntry] = None) -> FilesystemEntry:
         """Returns a TarFilesystemEntry object corresponding to the given path."""


### PR DESCRIPTION
Turns out that `tarfile.is_tarfile()` will read entire files (or partitions/disks, in our case...) to check if something is a tar file.