### PR TITLE
Replaced hyphen in key

### DIFF
--- a/dissect/target/plugins/os/unix/linux/services.py
+++ b/dissect/target/plugins/os/unix/linux/services.py
@@ -62,7 +62,8 @@ class ServicesPlugin(Plugin):
                     for segment, configuration in parsed_file.items():
                         for key, value in configuration.items():
                             _value = value or None
-                            _key = f"{segment}_{key.replace("-","_")}"
+                            _key = f"{segment}_{key}"
+                            _key = _key.replace("-","_")
                             types.append(("string", _key))
                             config.update({_key: _value})
                 except FileNotFoundError:

--- a/dissect/target/plugins/os/unix/linux/services.py
+++ b/dissect/target/plugins/os/unix/linux/services.py
@@ -62,7 +62,7 @@ class ServicesPlugin(Plugin):
                     for segment, configuration in parsed_file.items():
                         for key, value in configuration.items():
                             _value = value or None
-                            _key = f"{segment}_{key}"
+                            _key = f"{segment}_{key.replace("-","_")}"
                             types.append(("string", _key))
                             config.update({_key: _value})
                 except FileNotFoundError:

--- a/dissect/target/plugins/os/unix/linux/services.py
+++ b/dissect/target/plugins/os/unix/linux/services.py
@@ -63,7 +63,7 @@ class ServicesPlugin(Plugin):
                         for key, value in configuration.items():
                             _value = value or None
                             _key = f"{segment}_{key}"
-                            _key = _key.replace("-","_")
+                            _key = _key.replace("-", "_")
                             types.append(("string", _key))
                             config.update({_key: _value})
                 except FileNotFoundError:


### PR DESCRIPTION
Previously discussed in issues.
Having a service installed on an image, that has a hyphen in the key makes target.services() raises a RecordDescriptorError exception.

By adding a simple replace of the hyphen to underscore, it runs without issues.