### PR TITLE
Fix TypeError in iexplore.downloads `down_path`

### DIFF
--- a/dissect/target/plugins/apps/browser/iexplore.py
+++ b/dissect/target/plugins/apps/browser/iexplore.py
@@ -212,7 +212,7 @@ class InternetExplorerPlugin(BrowserPlugin):
                     ts_end=ts_end,
                     browser="iexplore",
                     id=container_record.EntryId,
-                    path=self.target.fs.path(down_path),
+                    path=self.target.fs.path(down_path) if down_path else None,
                     url=down_url,
                     size=None,
                     state=None,


### PR DESCRIPTION
This PR fixes an error in the `iexplore.downloads` function.

When `container_record.ResponseHeaders` does not exist or fails to be decoded, the variable `down_path` stays set to `None`. When passing `None` to `self.target.fs.path` / `TargetPath` we get an ugly exception.

This is fixed by properly checking if `down_path` is truthy before calling `self.target.fs.path`.