### PR TITLE
Rename field digest to digests

### DIFF
--- a/dissect/target/plugins/filesystem/acquire_hash.py
+++ b/dissect/target/plugins/filesystem/acquire_hash.py
@@ -10,7 +10,7 @@ AcquireHashRecord = TargetRecordDescriptor(
     [
         ("path", "path"),
         ("filesize", "filesize"),
-        ("digest", "digest"),
+        ("digest", "digests"),
     ],
 )
 
@@ -39,6 +39,6 @@ class AcquireHashPlugin(Plugin):
                 yield AcquireHashRecord(
                     path=self.target.fs.path((row["path"])),
                     filesize=row["file-size"],
-                    digest=(row["md5"] or None, row["sha1"] or None, row["sha256"] or None),
+                    digests=(row["md5"] or None, row["sha1"] or None, row["sha256"] or None),
                     _target=self.target,
                 )

--- a/dissect/target/plugins/filesystem/yara.py
+++ b/dissect/target/plugins/filesystem/yara.py
@@ -13,7 +13,7 @@ YaraMatchRecord = TargetRecordDescriptor(
     "filesystem/yara/match",
     [
         ("path", "path"),
-        ("digest", "digest"),
+        ("digest", "digests"),
         ("string", "rule"),
         ("string[]", "tags"),
     ],
@@ -52,7 +52,7 @@ class YaraPlugin(Plugin):
                     for match in rules.match(data=path.read_bytes()):
                         yield YaraMatchRecord(
                             path=path,
-                            digest=path.get().hash(),
+                            digests=path.get().hash(),
                             rule=match.rule,
                             tags=match.tags,
                             _target=self.target,

--- a/dissect/target/plugins/os/windows/catroot.py
+++ b/dissect/target/plugins/os/windows/catroot.py
@@ -22,7 +22,7 @@ DIGEST_NEEDLES = {
 CatrootRecord = TargetRecordDescriptor(
     "windows/catroot",
     [
-        ("digest", "digest"),
+        ("digest", "digests"),
         ("string[]", "hints"),
         ("string", "catroot_name"),
         ("path", "source"),
@@ -98,7 +98,7 @@ class CatrootPlugin(Plugin):
         Yields CatrootRecords with the following fields:
             hostname (string): The target hostname.
             domain (string): The target domain.
-            digest (digest): The parsed digest.
+            digests (digest): The parsed digest.
             hints (string[]): File hints, if present.
             catroot_name (string): Catroot name.
             source (path): Source of the catroot record.
@@ -177,7 +177,7 @@ class CatrootPlugin(Plugin):
                 # TODO: find the correlation between the file hints and the digests in catroot files.
                 for file_digest in digests:
                     yield CatrootRecord(
-                        digest=file_digest,
+                        digests=file_digest,
                         hints=hints,
                         catroot_name=file.name,
                         source=file,
@@ -224,7 +224,7 @@ class CatrootPlugin(Plugin):
 
                         for catroot_name in catroot_names:
                             yield CatrootRecord(
-                                digest=file_digest,
+                                digests=file_digest,
                                 hints=None,
                                 catroot_name=catroot_name,
                                 source=ese_file,

--- a/tests/plugins/os/windows/test_catroot.py
+++ b/tests/plugins/os/windows/test_catroot.py
@@ -84,11 +84,11 @@ def test_catroot_files(
 
     sorted_file_hints = sorted(file_hints)
     # Make sure the order is constant by sorting on digest
-    for cat_hash, record in zip(sorted(hashes), sorted(records, key=lambda r: r.digest.sha256)):
+    for cat_hash, record in zip(sorted(hashes), sorted(records, key=lambda r: r.digests.sha256)):
         assert str(record.source) == "sysvol" + file_location
         assert record.catroot_name == filename
         assert sorted(record.hints) == sorted_file_hints
-        assert record.digest.sha256 == cat_hash
+        assert record.digests.sha256 == cat_hash
 
 
 def test_catroot_catdb(target_win: Target, fs_win: VirtualFilesystem) -> None:
@@ -109,10 +109,10 @@ def test_catroot_catdb(target_win: Target, fs_win: VirtualFilesystem) -> None:
     # Make sure the order is constant by sorting on digest
     for expected_digest, record in zip(
         sorted(hashes, key=lambda d: d.sha1 or d.sha256),
-        sorted(records, key=lambda r: r.digest.sha1 or r.digest.sha256),
+        sorted(records, key=lambda r: r.digests.sha1 or r.digests.sha256),
     ):
         assert record.catroot_name == "Containers-ApplicationGuard-Package~31bf3856ad364e35~amd64~~10.0.19041.1288.cat"
         assert record.source == "sysvol\\windows\\system32\\catroot2\\{ID}\\catdb"
         assert record.hints == []
         # No direct comparison available, but representation comparison suffices.
-        assert str(expected_digest) == str(record.digest)
+        assert str(expected_digest) == str(record.digests)


### PR DESCRIPTION
It helps when all fields that use the type `digest` are named `digests`, where possible. Depending on which search platform is used, e.g. Elasticsearch https://github.com/huntandhackett/ir-automation/blob/a005f5d2ea58a8beabe7c6ae0e25e0c0ae16ce85/logstash-dissect.conf#L54-L62, this field type must be stored as an object compared to the other field types that only contain one value (integer, string, etc.).