### PR TITLE
Add firefox extensions within firefox plugin

### DIFF
--- a/dissect/target/plugins/apps/browser/firefox.py
+++ b/dissect/target/plugins/apps/browser/firefox.py
@@ -44,7 +44,7 @@ try:
 except ImportError:
     HAS_CRYPTO = False
 
-FIREFOX_EXTENSION_RECORD_FIELDS = [("uri", "sourceURI"), ("string[]", "optionalPermissions")]
+FIREFOX_EXTENSION_RECORD_FIELDS = [("uri", "source_uri"), ("string[]", "optional_permissions")]
 
 log = logging.getLogger(__name__)
 
@@ -353,17 +353,17 @@ class FirefoxPlugin(BrowserPlugin):
                             ts_update=extension.get("updateDate", 0) // 1000,
                             browser="firefox",
                             id=extension.get("id"),
-                            name=extension.get("defaultLocale").get("name"),
+                            name=extension.get("defaultLocale", {}).get("name"),
                             short_name=None,
                             default_title=None,
-                            description=extension.get("defaultLocale").get("description"),
+                            description=extension.get("defaultLocale", {}).get("description"),
                             version=extension.get("version"),
                             ext_path=extension.get("path"),
                             from_webstore=None,
-                            permissions=extension.get("userPermissions").get("permissions"),
+                            permissions=extension.get("userPermissions", {}).get("permissions"),
                             manifest_version=extension.get("manifestVersion"),
-                            sourceURI=extension.get("sourceURI"),
-                            optionalPermissions=extension.get("optionalPermissions").get("permissions"),
+                            source_uri=extension.get("sourceURI"),
+                            optional_permissions=extension.get("optionalPermissions", {}).get("permissions"),
                             source=extension_file,
                             _target=self.target,
                             _user=user.user,

--- a/dissect/target/plugins/apps/browser/firefox.py
+++ b/dissect/target/plugins/apps/browser/firefox.py
@@ -316,24 +316,23 @@ class FirefoxPlugin(BrowserPlugin):
     def extensions(self) -> Iterator[BrowserExtensionRecord]:
         """Return browser extension records for Firefox.
 
-        Yields:
-            Records with the following fields:
-                ts_install (datetime): Extension install timestamp.
-                ts_update (datetime): Extension update timestamp.
-                browser (string): The browser from which the records are generated.
-                id (string): Extension unique identifier.
-                name (string): Name of the extension.
-                short_name (string): Short name of the extension.
-                default_title (string): Default title of the extension.
-                description (string): Description of the extension.
-                version (string): Version of the extension.
-                ext_path (path): Relative path of the extension.
-                from_webstore (boolean): Extension from webstore.
-                permissions (string[]): Permissions of the extension.
-                manifest (varint): Version of the extensions' manifest.
-                optionalPermissions (string[]): Optional permissions of the extension.
-                sourceURI (path): Source path from which the extension was downloaded.
-                source (path): The source file of the download record.
+        Yields BrowserExtensionRecord with the following fields::
+            ts_install (datetime): Extension install timestamp.
+            ts_update (datetime): Extension update timestamp.
+            browser (string): The browser from which the records are generated.
+            id (string): Extension unique identifier.
+            name (string): Name of the extension.
+            short_name (string): Short name of the extension.
+            default_title (string): Default title of the extension.
+            description (string): Description of the extension.
+            version (string): Version of the extension.
+            ext_path (path): Relative path of the extension.
+            from_webstore (boolean): Extension from webstore.
+            permissions (string[]): Permissions of the extension.
+            manifest (varint): Version of the extensions' manifest.
+            optional_permissions (string[]): Optional permissions of the extension.
+            source_uri (path): Source path from which the extension was downloaded.
+            source (path): The source file of the download record.
         """
         for user, _, profile_dir in self._iter_profiles():
             extension_file = profile_dir.joinpath("extensions.json")
@@ -348,29 +347,26 @@ class FirefoxPlugin(BrowserPlugin):
                 extensions = json.load(extension_file.open())
 
                 for extension in extensions.get("addons", []):
-                    try:
-                        yield self.BrowserExtensionRecord(
-                            ts_install=extension.get("installDate", 0) // 1000,
-                            ts_update=extension.get("updateDate", 0) // 1000,
-                            browser="firefox",
-                            id=extension.get("id"),
-                            name=extension.get("defaultLocale", {}).get("name"),
-                            short_name=None,
-                            default_title=None,
-                            description=extension.get("defaultLocale", {}).get("description"),
-                            version=extension.get("version"),
-                            ext_path=extension.get("path"),
-                            from_webstore=None,
-                            permissions=extension.get("userPermissions", {}).get("permissions"),
-                            manifest_version=extension.get("manifestVersion"),
-                            source_uri=extension.get("sourceURI"),
-                            optional_permissions=extension.get("optionalPermissions", {}).get("permissions"),
-                            source=extension_file,
-                            _target=self.target,
-                            _user=user.user,
-                        )
-                    except (AttributeError, KeyError) as e:
-                        self.target.log.info("No browser extensions found in: %s", extension_file, exc_info=e)
+                    yield self.BrowserExtensionRecord(
+                        ts_install=extension.get("installDate", 0) // 1000,
+                        ts_update=extension.get("updateDate", 0) // 1000,
+                        browser="firefox",
+                        id=extension.get("id"),
+                        name=extension.get("defaultLocale", {}).get("name"),
+                        short_name=None,
+                        default_title=None,
+                        description=extension.get("defaultLocale", {}).get("description"),
+                        version=extension.get("version"),
+                        ext_path=extension.get("path"),
+                        from_webstore=None,
+                        permissions=extension.get("userPermissions", {}).get("permissions"),
+                        manifest_version=extension.get("manifestVersion"),
+                        source_uri=extension.get("sourceURI"),
+                        optional_permissions=extension.get("optionalPermissions", {}).get("permissions"),
+                        source=extension_file,
+                        _target=self.target,
+                        _user=user.user,
+                    )
 
             except FileNotFoundError:
                 self.target.log.info(

--- a/dissect/target/plugins/apps/browser/firefox.py
+++ b/dissect/target/plugins/apps/browser/firefox.py
@@ -18,8 +18,8 @@ from dissect.target.plugin import export
 from dissect.target.plugins.apps.browser.browser import (
     GENERIC_COOKIE_FIELDS,
     GENERIC_DOWNLOAD_RECORD_FIELDS,
-    GENERIC_HISTORY_RECORD_FIELDS,
     GENERIC_EXTENSION_RECORD_FIELDS,
+    GENERIC_HISTORY_RECORD_FIELDS,
     GENERIC_PASSWORD_RECORD_FIELDS,
     BrowserPlugin,
     try_idna,
@@ -44,10 +44,7 @@ try:
 except ImportError:
     HAS_CRYPTO = False
 
-FIREFOX_EXTENSION_RECORD_FIELDS = [
-    ("uri", "sourceURI"),
-    ("string[]", "optionalPermissions")
-]
+FIREFOX_EXTENSION_RECORD_FIELDS = [("uri", "sourceURI"), ("string[]", "optionalPermissions")]
 
 log = logging.getLogger(__name__)
 
@@ -334,7 +331,7 @@ class FirefoxPlugin(BrowserPlugin):
                 permissions (string[]): Permissions of the extension.
                 manifest (varint): Version of the extensions' manifest.
                 optionalPermissions (string[]): Optional permissions of the extension.
-                sourceURI (path): Source path from which the extension was downloaded. 
+                sourceURI (path): Source path from which the extension was downloaded.
                 source (path): The source file of the download record.
         """
         for user, _, profile_dir in self._iter_profiles():
@@ -352,33 +349,36 @@ class FirefoxPlugin(BrowserPlugin):
                 for extension in extensions.get("addons", []):
                     try:
                         yield self.BrowserExtensionRecord(
-                            ts_install = extension.get("installDate", 0) // 1000,
-                            ts_update = extension.get("updateDate", 0) // 1000,
-                            browser = "firefox",
-                            id = extension.get("id"),
-                            name = extension.get("defaultLocale").get("name"),
-                            short_name = None,
-                            default_title = None,
-                            description = extension.get("defaultLocale").get("description"),
-                            version = extension.get("version"),
-                            ext_path = extension.get("path"),
-                            from_webstore = None,
-                            permissions = extension.get("userPermissions").get("permissions"),
-                            manifest_version = extension.get("manifestVersion"),
-                            sourceURI = extension.get("sourceURI"),
-                            optionalPermissions = extension.get("optionalPermissions").get("permissions"),
-                            source = extension_file,
-                            _target = self.target,
-                            _user = user.user
+                            ts_install=extension.get("installDate", 0) // 1000,
+                            ts_update=extension.get("updateDate", 0) // 1000,
+                            browser="firefox",
+                            id=extension.get("id"),
+                            name=extension.get("defaultLocale").get("name"),
+                            short_name=None,
+                            default_title=None,
+                            description=extension.get("defaultLocale").get("description"),
+                            version=extension.get("version"),
+                            ext_path=extension.get("path"),
+                            from_webstore=None,
+                            permissions=extension.get("userPermissions").get("permissions"),
+                            manifest_version=extension.get("manifestVersion"),
+                            sourceURI=extension.get("sourceURI"),
+                            optionalPermissions=extension.get("optionalPermissions").get("permissions"),
+                            source=extension_file,
+                            _target=self.target,
+                            _user=user.user,
                         )
                     except (AttributeError, KeyError) as e:
                         self.target.log.info("No browser extensions found in: %s", extension_file, exc_info=e)
 
             except FileNotFoundError:
-                self.target.log.info("No 'extensions.json' addon file found for user %s in directory %s", user, profile_dir)
+                self.target.log.info(
+                    "No 'extensions.json' addon file found for user %s in directory %s", user, profile_dir
+                )
             except json.JSONDecodeError:
                 self.target.log.warning(
-                    "extensions.json file in directory %s is malformed, consider inspecting the file manually", profile_dir
+                    "extensions.json file in directory %s is malformed, consider inspecting the file manually",
+                    profile_dir,
                 )
 
     @export(record=BrowserPasswordRecord)
@@ -457,6 +457,7 @@ class FirefoxPlugin(BrowserPlugin):
                 self.target.log.warning(
                     "logins.json file in directory %s is malformed, consider inspecting the file manually", profile_dir
                 )
+
 
 # Define separately because it is not defined in asn1crypto
 pbeWithSha1AndTripleDES_CBC = "1.2.840.113549.1.12.5.1.3"

--- a/dissect/target/plugins/apps/browser/firefox.py
+++ b/dissect/target/plugins/apps/browser/firefox.py
@@ -86,7 +86,6 @@ class FirefoxPlugin(BrowserPlugin):
         "browser/firefox/password", GENERIC_PASSWORD_RECORD_FIELDS
     )
 
-
     def __init__(self, target):
         super().__init__(target)
         self.users_dirs: list[tuple[UserDetails, TargetPath]] = []

--- a/dissect/target/plugins/apps/browser/firefox.py
+++ b/dissect/target/plugins/apps/browser/firefox.py
@@ -78,13 +78,14 @@ class FirefoxPlugin(BrowserPlugin):
         "browser/firefox/download", GENERIC_DOWNLOAD_RECORD_FIELDS
     )
 
+    BrowserExtensionRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
+        "browser/firefox/extension", GENERIC_EXTENSION_RECORD_FIELDS + FIREFOX_EXTENSION_RECORD_FIELDS
+    )
+
     BrowserPasswordRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
         "browser/firefox/password", GENERIC_PASSWORD_RECORD_FIELDS
     )
 
-    BrowserExtensionRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
-        "browser/firefox/extension", GENERIC_EXTENSION_RECORD_FIELDS + FIREFOX_EXTENSION_RECORD_FIELDS
-    )
 
     def __init__(self, target):
         super().__init__(target)

--- a/tests/_data/plugins/apps/browser/firefox/extensions.json
+++ b/tests/_data/plugins/apps/browser/firefox/extensions.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64dedc51788d785c920d4e920c50ab2cfc8c5ba88f8ebb37c800c0a67c27e0cd
+size 44136

--- a/tests/plugins/apps/browser/test_firefox.py
+++ b/tests/plugins/apps/browser/test_firefox.py
@@ -19,8 +19,6 @@ from dissect.target.plugins.apps.browser.firefox import (
 )
 from tests._utils import absolute_path
 
-# NOTE: Missing extensions tests for Firefox.
-
 
 @pytest.fixture
 def target_firefox_win(target_win_users: Target, fs_win: VirtualFilesystem) -> Iterator[Target]:
@@ -106,6 +104,38 @@ def test_firefox_cookies(target_platform: Target, request: pytest.FixtureRequest
         "_lr_retry_request",
         "_uc_referrer",
         "_uc_referrer",
+    ]
+
+
+@pytest.mark.parametrize(
+    "target_platform",
+    ["target_firefox_win", "target_firefox_unix"],
+)
+def test_firefox_extensions(target_platform: Target, request: pytest.FixtureRequest) -> None:
+    target_platform = request.getfixturevalue(target_platform)
+
+    records = list(target_platform.firefox.extensions())
+
+    assert set(["firefox"]) == set(record.browser for record in records)
+    assert len(records) == 2
+    assert records[0].id == "uBlock0@raymondhill.net"
+    assert records[0].ts_install == dt("2024-04-23 07:07:21+00:00")
+    assert records[0].ts_update == dt("2024-04-23 07:07:21+00:00")
+    assert (
+        records[0].ext_path == "C:\\Users\\Win11\\AppData\\Roaming\\Mozilla\\Firefox\\Profiles"
+        "\\9nxit8q0.default-release\\extensions\\uBlock0@raymondhill.net.xpi"
+    )
+    assert records[0].permissions == [
+        "alarms",
+        "dns",
+        "menus",
+        "privacy",
+        "storage",
+        "tabs",
+        "unlimitedStorage",
+        "webNavigation",
+        "webRequest",
+        "webRequestBlocking",
     ]
 
 


### PR DESCRIPTION
This PR adds the capability to parse firefox extensions (at least for Firefox 26+) to the firefox browser plugin. 
```
target-query -f firefox.extensions TARGET | rdump -L 
[reading from stdin]
[...]
--[ RECORD 12 ]--
           hostname = WINDOWS11
             domain = None
         ts_install = 2024-04-23 08:03:15+00:00
          ts_update = 2024-04-23 08:03:15+00:00
            browser = firefox
                 id = wappalyzer@crunchlabz.com
               name = Wappalyzer - Technology profiler
         short_name = None
      default_title = None
        description = Identify web technologies
            version = 6.10.68
           ext_path = C:\Users\Win11\AppData\Roaming\Mozilla\Firefox\Profiles\9nxit8q0.default-release\extensions\wappalyzer@crunchlabz.com.xpi
      from_webstore = None
        permissions = ['cookies', 'storage', 'tabs', 'webRequest']
   manifest_version = 2
             source = C:\Users\Win11\AppData\Roaming\Mozilla\Firefox\Profiles\9nxit8q0.default-release\extensions.json
          sourceURI = https://addons.mozilla.org/firefox/downloads/file/4239079/wappalyzer-6.10.68.xpi
optionalPermissions = ['downloads']
           username = Win11
            user_id = S-1-5-21-3098589626-1388384975-1619029170-1001
         user_group = None
          user_home = C:\Users\Win11
[...]
```