### PR TITLE
Fixed KeyError when loading Windows targets over SMB

### DIFF
--- a/dissect/target/plugins/os/windows/_os.py
+++ b/dissect/target/plugins/os/windows/_os.py
@@ -21,7 +21,7 @@ class WindowsPlugin(OSPlugin):
         self.add_mounts()
 
         target.props["sysvol_drive"] = next(
-            (mnt for mnt, fs in target.fs.mounts.items() if fs is target.fs.mounts["sysvol"] and mnt != "sysvol"),
+            (mnt for mnt, fs in target.fs.mounts.items() if fs is target.fs.mounts.get("sysvol", None) and mnt != "sysvol"),
             None,
         )
 
@@ -79,10 +79,10 @@ class WindowsPlugin(OSPlugin):
             self.target.log.debug("", exc_info=e)
 
         # Fallback mount the sysvol to C: if we didn't manage to mount it to any other drive letter
-        if operator.countOf(self.target.fs.mounts.values(), self.target.fs.mounts["sysvol"]) == 1:
+        if operator.countOf(self.target.fs.mounts.values(), self.target.fs.mounts.get("sysvol", None)) == 1:
             if "c:" not in self.target.fs.mounts:
                 self.target.log.debug("Unable to determine drive letter of sysvol, falling back to C:")
-                self.target.fs.mount("c:", self.target.fs.mounts["sysvol"])
+                self.target.fs.mount("c:", self.target.fs.mounts.get("sysvol", None))
             else:
                 self.target.log.warning("Unknown drive letter for sysvol")
 


### PR DESCRIPTION
Change various `["sysvol"]` statements to `.get` methods as to avoid breaking SMB targets with low-privileged credentials

```
│                                                                                                  │
│ /home/user/.local/lib/python3.11/site-packages/dissect/target/plugins/os/windows/_os.py:82 in    │
│ add_mounts                                                                                       │
│                                                                                                  │
│    79 │   │   │   self.target.log.debug("", exc_info=e)                                          │
│    80 │   │                                                                                      │
│    81 │   │   # Fallback mount the sysvol to C: if we didn't manage to mount it to any other d   │
│ ❱  82 │   │   if operator.countOf(self.target.fs.mounts.values(), self.target.fs.mounts["sysvo   │
│    83 │   │   │   if "c:" not in self.target.fs.mounts:                                          │
│    84 │   │   │   │   self.target.log.debug("Unable to determine drive letter of sysvol, falli   │
│    85 │   │   │   │   self.target.fs.mount("c:", self.target.fs.mounts["sysvol"])                │
│                                                                                                  │
│ ╭─────────────────────────────────────── locals ────────────────────────────────────────╮        │
│ │ self = <dissect.target.plugins.os.windows._os.WindowsPlugin object at 0x7f87c488a3d0> │        │
│ ╰───────────────────────────────────────────────────────────────────────────────────────╯        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
KeyError: 'sysvol'
```