### PR TITLE
Fix edge case where unix history path is a directory

### DIFF
--- a/dissect/target/plugins/os/unix/history.py
+++ b/dissect/target/plugins/os/unix/history.py
@@ -52,7 +52,7 @@ class CommandHistoryPlugin(Plugin):
         for user_details in self.target.user_details.all_with_home():
             for shell, history_relative_path in self.COMMAND_HISTORY_RELATIVE_PATHS:
                 history_path = user_details.home_path.joinpath(history_relative_path)
-                if history_path.exists():
+                if history_path.is_file():
                     history_files.append((shell, history_path, user_details.user))
         return history_files
 


### PR DESCRIPTION
In the edge case where the path of a unix history file is a directory, the unix history plugin fails as it only checks the path exists and, if so, assumes it is a file. This PR fixes this problem by explicitly checking the path is a file. 

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
