### PR TITLE
Fix parsing journal when value is string None

### DIFF
--- a/dissect/target/plugins/os/unix/log/journal.py
+++ b/dissect/target/plugins/os/unix/log/journal.py
@@ -259,7 +259,7 @@ c_journal = cstruct().load(journal_def)
 
 def get_optional(value: str, to_type: Callable):
     """Return the value if True, otherwise return None."""
-    return to_type(value) if value else None
+    return to_type(value) if value and value != 'None' else None
 
 
 class JournalFile:


### PR DESCRIPTION
A journal entry can contain fields with the string value None.  Currently parsing to int fails as it only checks for None type and  not None string.

fixes #736 