### PR TITLE
Add _target field to firefox and chromium  plugins

### DIFF
--- a/dissect/target/plugins/apps/browser/chromium.py
+++ b/dissect/target/plugins/apps/browser/chromium.py
@@ -279,6 +279,7 @@ class ChromiumMixin:
                         is_http_only=bool(cookie.is_httponly),
                         same_site=bool(cookie.samesite),
                         source=db_file,
+                        _target=self.target,
                         _user=user.user,
                     )
             except SQLError as e:

--- a/dissect/target/plugins/apps/browser/firefox.py
+++ b/dissect/target/plugins/apps/browser/firefox.py
@@ -228,6 +228,7 @@ class FirefoxPlugin(BrowserPlugin):
                         is_http_only=bool(cookie.isHttpOnly),
                         same_site=bool(cookie.sameSite),
                         source=db_file,
+                        _target=self.target,
                         _user=user.user,
                     )
             except SQLError as e:


### PR DESCRIPTION
The browser.cookies plugin returned records without target information for Firefox and Chromium browsers.
