### PR TITLE
Add option to scan children in YARA plugin

### DIFF
--- a/dissect/target/plugins/filesystem/yara.py
+++ b/dissect/target/plugins/filesystem/yara.py
@@ -47,7 +47,6 @@ class YaraPlugin(Plugin):
     @arg("-p", "--path", default="/", help="path on target(s) to recursively scan")
     @arg("-m", "--max-size", default=DEFAULT_MAX_SCAN_SIZE, help="maximum file size in bytes to scan")
     @arg("-c", "--check", default=False, action="store_true", help="check if every YARA rule is valid")
-    @arg("--children", action="store_true", help="include children")
     @export(record=YaraMatchRecord)
     def yara(
         self,

--- a/dissect/target/plugins/filesystem/yara.py
+++ b/dissect/target/plugins/filesystem/yara.py
@@ -85,10 +85,7 @@ class YaraPlugin(Plugin):
             for file in files:
                 try:
                     if (file_size := file.stat().st_size) > max_size:
-                        self.target.log.info(
-                            "Not scanning file of %s MB: '%s'",
-                            (file_size // 1024 // 1024), file
-                        )
+                        self.target.log.info("Not scanning file of %s MB: '%s'", (file_size // 1024 // 1024), file)
                         continue
 
                     buf = file.open().read()

--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -344,7 +344,7 @@ class Target:
                 child_plugin.check_compatible()
                 self._child_plugins[child_plugin.__type__] = child_plugin
             except PluginError as e:
-                self.log.info("Child plugin reported itself as incompatible: %s (%s)", plugin_desc["class"], e)
+                self.log.debug("Child plugin reported itself as incompatible: %s (%s)", plugin_desc["class"], e)
             except Exception:
                 self.log.exception(
                     "An exception occurred while checking for child plugin compatibility: %s", plugin_desc["class"]

--- a/dissect/target/tools/yara.py
+++ b/dissect/target/tools/yara.py
@@ -45,8 +45,8 @@ def main():
         parser.exit(1)
 
     try:
-        for target in Target.open_all(args.targets):
-            target.log.info("Scanning target")
+        for target in Target.open_all(args.targets, args.children):
+            target.log.info("Scanning target %s", target)
             rs = record_output(args.strings, False)
             for record in target.yara(args.rules, args.path, args.max_size, args.check):
                 rs.write(record)

--- a/dissect/target/tools/yara.py
+++ b/dissect/target/tools/yara.py
@@ -27,6 +27,7 @@ def main():
 
     parser.add_argument("targets", metavar="TARGETS", nargs="*", help="Targets to load")
     parser.add_argument("-s", "--strings", default=False, action="store_true", help="print output as string")
+    parser.add_argument("--children", action="store_true", help="include children")
 
     for args, kwargs in getattr(YaraPlugin.yara, "__args__", []):
         parser.add_argument(*args, **kwargs)
@@ -46,7 +47,6 @@ def main():
 
     try:
         for target in Target.open_all(args.targets, args.children):
-            target.log.info("Scanning target %s", target)
             rs = record_output(args.strings, False)
             for record in target.yara(args.rules, args.path, args.max_size, args.check):
                 rs.write(record)


### PR DESCRIPTION
This is a small improvement on #646 that adds `--children` to `target-yara` / `target-query -f yara`.