### PR TITLE
Add target-shell history

### DIFF
--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -87,9 +87,10 @@ class Target:
         self._applied = False
 
         try:
-            self._config = config.load(self.path)
+            self._config = config.load([self.path, os.getcwd()])
         except Exception as e:
-            self.log.debug("Error loading config file", exc_info=e)
+            self.log.warning("Error loading config file: %s", self.path)
+            self.log.debug("", exc_info=e)
             self._config = config.load(None)  # This loads an empty config.
 
         # Fill the disks and/or volumes and/or filesystems and apply() will

--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -136,12 +136,18 @@ class TargetCmd(cmd.Cmd):
 
     def preloop(self) -> None:
         if readline and self.histfile.exists():
-            readline.read_history_file(self.histfile)
+            try:
+                readline.read_history_file(self.histfile)
+            except Exception as e:
+                log.debug("Error reading history file: %s", e)
 
     def postloop(self) -> None:
         if readline:
             readline.set_history_length(self.histfilesize)
-            readline.write_history_file(self.histfile)
+            try:
+                readline.write_history_file(self.histfile)
+            except Exception as e:
+                log.debug("Error writing history file: %s", e)
 
     def __getattr__(self, attr: str) -> Any:
         if attr.startswith("help_"):
@@ -1271,10 +1277,6 @@ def run_cli(cli: cmd.Cmd) -> None:
         except KeyboardInterrupt:
             # Add a line when pressing ctrl+c, so the next one starts at a new line
             print()
-
-        except PermissionError as e:
-            log.error(e)
-            break
 
         except Exception as e:
             if cli.debug:

--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -131,7 +131,6 @@ class TargetCmd(cmd.Cmd):
             self.histfile = pathlib.Path(self.histdir).resolve() / pathlib.Path(
                 self.histdirfmt.format(uid=os.getuid(), target=target.name)
             )
-
         else:
             self.histfile = pathlib.Path(getattr(target._config, "HISTFILE", self.DEFAULT_HISTFILE)).expanduser()
 


### PR DESCRIPTION
This PR adds support for target-shell history files to dissect as described in #650.

Small changes were made to the config helper utility to also scan the current working directory for `.targetcfg.py` files. The storage location of the shell history by default is `$HOME/.dissect_history` and can be changed with the `HISTFILE` variable in `.targetcfg.py`.