### PR TITLE
Add a path remapping option to LogLoader

### DIFF
--- a/dissect/target/loaders/log.py
+++ b/dissect/target/loaders/log.py
@@ -11,13 +11,20 @@ from dissect.target.plugin import arg
 
 
 @arg("--log-hint", dest="hint", help="hint for file type")
+@arg("--path", dest="path", help="Map log file(s) to a specific path in the target filesystem")
 class LogLoader(Loader):
-    """Load separate log files without a target.
+    """Load separate log files without a target. By default attempts to map discovered log files based on their file
+    extension. The loader can also map log files to a specific path in the target filesystem using the ``--path``
+    option.
 
     Usage:
 
     ``target-query /evtx/* -L log -f evtx``
 
+    or by specifying a manual path, which can be a directory or a single file:
+
+    * ``target-query log://evidence/extracted_wtmp?path=/var/log/wtmp -f wtmp``
+    * ``target-query log://evidence/apache?path=/var/log/apache2 -f apache.access``
     """
 
     LOGS_DIRS = {
@@ -40,9 +47,19 @@ class LogLoader(Loader):
         vfs = VirtualFilesystem(case_sensitive=False, alt_separator=target.fs.alt_separator)
         target.filesystems.add(vfs)
         target.fs.mount("/", vfs)
-        for entry in self.path.parent.glob(self.path.name):
-            ext = self.options.get("hint", entry.suffix.lower()).strip(".")
-            if (mapping := self.LOGS_DIRS.get(ext, None)) is None:
-                continue
-            mapping = str(vfs.path(mapping).joinpath(entry.name))
-            vfs.map_file(mapping, str(entry))
+        if manual_path := self.options.get("path"):
+            if self.path.is_dir():
+                for entry in self.path.glob("*"):
+                    # Map every entry in the directory to the manual path
+                    mapping = str(vfs.path(manual_path).joinpath(entry.name))
+                    vfs.map_file(mapping, str(entry))
+            else:
+                # Manual path is a single file, map it into the virtual filesystem
+                vfs.map_file(manual_path, str(self.path))
+        else:
+            for entry in self.path.parent.glob(self.path.name):
+                ext = self.options.get("hint", entry.suffix.lower()).strip(".")
+                if (mapping := self.LOGS_DIRS.get(ext, None)) is None:
+                    continue
+                mapping = str(vfs.path(mapping).joinpath(entry.name))
+                vfs.map_file(mapping, str(entry))

--- a/tests/loaders/test_log.py
+++ b/tests/loaders/test_log.py
@@ -15,6 +15,8 @@ from dissect.target.loaders.log import LogLoader
         ("/dir/*.evt*", None, "/dir/test.evtx", "/sysvol/windows/system32/winevt/logs/test.evtx"),
         ("/dir/*.evt*", None, "/dir/test.evt", "/sysvol/windows/system32/config/test.evt"),
         ("/source/iis.log", "log:///dir/with/files/*.log?hint=iis", "/source/iis.log", "/sysvol/files/logs/iis.log"),
+        ("/source/", "log://?path=/var/log", "/source/test.log", "/var/log/test.log"),
+        ("/source/test.log", "log://test.log?path=/var/log/test.log", "/source/test.log", "/var/log/test.log"),
     ],
 )
 def test_log_loader(target_default: Target, path: str, uri: str, input_file: str, expected_mapping: str) -> None:


### PR DESCRIPTION
This PR is a band-aid to address the issues discussed in https://github.com/fox-it/dissect.target/pull/399. When I have forensic artifacts without a target (e.g, when doing a ctf, or processing outputs from other tooling) I'd like to be able to invoke a plugin to parse it. While I agree with the discussion in #399 that it would be better to have a uniform API where every plugin specifies what paths they need to work (and then having an option to provide / extend these paths on the fly), it might take a while to implement that.

The change in this PR allows the user to 'remap' a given file / directory to a specific location in the virtual filesystem, so that plugins that do little more than parsing a (set of) file(s) will work. For example, a wtmp file could be parsed like this:

`target-query "log://wtmp?path=/var/log/wtmp" -f wtmp`

Or apache access logs like this:
`target-query "log://apache_dir?path=/var/log/apache" -f apache.access`

Of course, for a lot of plugins, this still won't be enough to make it work. For example, the commandhistory plugin requires the target to have users. Windows plugins doing anything with the registry are also not addressed by this (as also mentioned in https://github.com/fox-it/dissect.target/issues/411). Lastly, it still requires the user to know where a given forensic artifact is expected to be located to map it accordingly.

If you have something better in mind, feel free to just close this PR and implement that instead. Perhaps it's better to just extend the `LOGS_DIRS` dict, but that seemed to me like further hardcoding away the underlying problem.