### PR TITLE
Fix 3.12 ET and datetime deprecation warnings

### DIFF
--- a/dissect/target/plugins/os/windows/adpolicy.py
+++ b/dissect/target/plugins/os/windows/adpolicy.py
@@ -70,8 +70,7 @@ class ADPolicyPlugin(Plugin):
                 tree = ElementTree.fromstring(xml)
                 for task in tree.findall(".//{*}Task"):
                     # https://github.com/python/cpython/issues/83122
-                    properties = task.find("Properties")
-                    if properties is None:
+                    if (properties := task.find("Properties")) is None:
                         properties = task
 
                     task_data = ElementTree.tostring(task)

--- a/dissect/target/plugins/os/windows/adpolicy.py
+++ b/dissect/target/plugins/os/windows/adpolicy.py
@@ -69,7 +69,11 @@ class ADPolicyPlugin(Plugin):
                 xml = task_file.read_text()
                 tree = ElementTree.fromstring(xml)
                 for task in tree.findall(".//{*}Task"):
-                    properties = task.find("Properties") or task
+                    # https://github.com/python/cpython/issues/83122
+                    properties = task.find("Properties")
+                    if properties is None:
+                        properties = task
+
                     task_data = ElementTree.tostring(task)
                     yield ADPolicyRecord(
                         last_modification_time=task_file_stat.st_mtime,

--- a/dissect/target/plugins/os/windows/regf/shimcache.py
+++ b/dissect/target/plugins/os/windows/regf/shimcache.py
@@ -1,6 +1,6 @@
 import binascii
 from datetime import datetime
-from enum import IntEnum, auto
+from enum import IntEnum
 from io import BytesIO
 from typing import Callable, Generator, Optional, Tuple, Union
 
@@ -116,7 +116,7 @@ class SHIMCACHE_WIN_TYPE(IntEnum):
     VERSION_NT61 = 0x0601
     VERSION_NT52 = 0x0502
 
-    VERSION_WIN81_NO_HEADER = auto()
+    VERSION_WIN81_NO_HEADER = 0x1002  # auto()
 
 
 def win_10_path(ed: Structure) -> str:

--- a/dissect/target/plugins/os/windows/task_helpers/tasks_xml.py
+++ b/dissect/target/plugins/os/windows/task_helpers/tasks_xml.py
@@ -189,7 +189,7 @@ class XmlTask:
             bytes: The raw XML data as string of the element if found, otherwise None.
         """
         data = self.task_element.find(xml_path) if xml_path else self.task_element
-        if data:
+        if data is not None:
             return ElementTree.tostring(data, encoding="utf-8").strip()
 
     def get_triggers(self) -> Iterator[GroupedRecord]:

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -5,7 +5,7 @@ import argparse
 import logging
 import pathlib
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Callable
 
 from flow.record import RecordPrinter, RecordStreamWriter, RecordWriter
@@ -390,7 +390,7 @@ def main():
         log.debug("", exc_info=e)
         parser.exit(1)
 
-    timestamp = datetime.utcnow()
+    timestamp = datetime.now(tz=timezone.utc)
 
     execution_report.set_plugin_stats(PLUGINS)
     log.debug("%s", execution_report.get_formatted_report())

--- a/tests/plugins/apps/ssh/test_putty.py
+++ b/tests/plugins/apps/ssh/test_putty.py
@@ -102,9 +102,10 @@ def test_putty_plugin_saved_sessions_unix(target_unix_users: Target, fs_unix: Vi
 
     assert len(records) == 1
 
-    assert records[0].ts == datetime.utcfromtimestamp(
-        stat(absolute_path("_data/plugins/apps/ssh/putty/sessions/example-saved-session")).st_mtime
-    ).replace(tzinfo=timezone.utc)
+    assert records[0].ts == datetime.fromtimestamp(
+        stat(absolute_path("_data/plugins/apps/ssh/putty/sessions/example-saved-session")).st_mtime,
+        tz=timezone.utc,
+    )
     assert records[0].session_name == "example-saved-session"
     assert records[0].protocol == "ssh"
     assert records[0].host == "192.168.123.130"

--- a/tests/plugins/os/unix/test_generic.py
+++ b/tests/plugins/os/unix/test_generic.py
@@ -10,10 +10,10 @@ log_mtime = stat(absolute_path("_data/plugins/os/unix/log/empty.log")).st_mtime
 def test_unix_generic_activity(target_unix, fs_unix):
     fs_unix.map_file("/var/log/some.log", absolute_path("_data/plugins/os/unix/log/empty.log"))
     target_unix.add_plugin(GenericPlugin)
-    assert target_unix.activity == datetime.utcfromtimestamp(log_mtime).replace(tzinfo=timezone.utc)
+    assert target_unix.activity == datetime.fromtimestamp(log_mtime, tz=timezone.utc)
 
 
 def test_unix_generic_install_date(target_unix, fs_unix):
     fs_unix.map_file("/var/log/installer/syslog", absolute_path("_data/plugins/os/unix/log/empty.log"))
     target_unix.add_plugin(GenericPlugin)
-    assert target_unix.install_date == datetime.utcfromtimestamp(log_mtime).replace(tzinfo=timezone.utc)
+    assert target_unix.install_date == datetime.fromtimestamp(log_mtime, tz=timezone.utc)


### PR DESCRIPTION
This PR, together with https://github.com/fox-it/flow.record/pull/136 should fix all pytest deprecation warnings when running CPython 3.12.