### PR TITLE
[Bug] Add missing _target field to record for Defender exclusion plugin

### DIFF
--- a/dissect/target/plugins/os/windows/defender.py
+++ b/dissect/target/plugins/os/windows/defender.py
@@ -517,6 +517,7 @@ class MicrosoftDefenderPlugin(plugin.Plugin):
                         regf_mtime=exclusion_type_subkey.timestamp,
                         type=exclusion_type,
                         value=exclusion_value,
+                        _target=self.target,
                     )
 
     def _mplog_processimage(self, data: dict) -> Iterator[DefenderMPLogProcessImageRecord]:


### PR DESCRIPTION
It is what it says in the title. The defender.exclusion plugin was missing the _target field which causes the hostname etc. to be None. 
