### PR TITLE
Add support for targetrc file to execute commands when a target shell is spawned

### DIFF
--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
-from typing import Any, BinaryIO, Callable, Iterator, Optional, TextIO
+from typing import Any, BinaryIO, Callable, Iterator, TextIO
 
 from dissect.cstruct import hexdump
 from flow.record import RecordOutput
@@ -135,7 +135,7 @@ class ExtendedCmd(cmd.Cmd):
         except Exception as e:
             log.debug("Error processing .targetrc file: %s", e)
 
-    def _get_targetrc_path(self) -> Optional[pathlib.Path]:
+    def _get_targetrc_path(self) -> pathlib.Path | None:
         """Get the path to the run commands file. Can return ``None`` if ``DEFAULT_RUNCOMMANDS_FILE`` is not set."""
         return pathlib.Path(self.DEFAULT_RUNCOMMANDS_FILE).expanduser() if self.DEFAULT_RUNCOMMANDS_FILE else None
 

--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -96,7 +96,7 @@ class ExtendedCmd(cmd.Cmd):
 
     CMD_PREFIX = "cmd_"
     _runtime_aliases = {}
-    DEFAULT_RUNCOMMANDSFILE = None
+    DEFAULT_RUNCOMMANDS_FILE = None
 
     def __init__(self, cyber: bool = False):
         cmd.Cmd.__init__(self)
@@ -136,13 +136,12 @@ class ExtendedCmd(cmd.Cmd):
             log.debug("Error processing .targetrc file: %s", e)
 
     def _get_targetrc_path(self) -> Optional[pathlib.Path]:
-        """Get the path to the run commands file. Can return None if DEFAULT_RUNCOMMANDSFILE is not set."""
-        return pathlib.Path(self.DEFAULT_RUNCOMMANDSFILE).expanduser() if self.DEFAULT_RUNCOMMANDSFILE else None
+        """Get the path to the run commands file. Can return ``None`` if ``DEFAULT_RUNCOMMANDS_FILE`` is not set."""
+        return pathlib.Path(self.DEFAULT_RUNCOMMANDS_FILE).expanduser() if self.DEFAULT_RUNCOMMANDS_FILE else None
 
     def preloop(self) -> None:
         super().preloop()
-        targetrc_path = self._get_targetrc_path()
-        if targetrc_path is not None:
+        if targetrc_path := self._get_targetrc_path():
             self._load_targetrc(targetrc_path)
 
     @staticmethod
@@ -333,8 +332,8 @@ class TargetCmd(ExtendedCmd):
     DEFAULT_HISTFILESIZE = 10_000
     DEFAULT_HISTDIR = None
     DEFAULT_HISTDIRFMT = ".dissect_history_{uid}_{target}"
-    DEFAULT_RUNCOMMANDSFILE = "~/.targetrc"
-    CONFIG_KEY_RUNCOMMANDSFILE = "TARGETRCFILE"
+    DEFAULT_RUNCOMMANDS_FILE = "~/.targetrc"
+    CONFIG_KEY_RUNCOMMANDS_FILE = "TARGETRCFILE"
 
     def __init__(self, target: Target):
         self.target = target
@@ -368,7 +367,7 @@ class TargetCmd(ExtendedCmd):
         """Get the path to the run commands file."""
 
         return pathlib.Path(
-            getattr(self.target._config, self.CONFIG_KEY_RUNCOMMANDSFILE, self.DEFAULT_RUNCOMMANDSFILE)
+            getattr(self.target._config, self.CONFIG_KEY_RUNCOMMANDS_FILE, self.DEFAULT_RUNCOMMANDS_FILE)
         ).expanduser()
 
     def preloop(self) -> None:
@@ -1178,8 +1177,8 @@ class RegistryCli(TargetCmd):
     """CLI for browsing the registry."""
 
     # Registry shell is incompatible with default shell, so override the default rc file and config key
-    DEFAULT_RUNCOMMANDSFILE = "~/.targetrc.registry"
-    CONFIG_KEY_RUNCOMMANDSFILE = "TARGETRCFILE_REGISTRY"
+    DEFAULT_RUNCOMMANDS_FILE = "~/.targetrc.registry"
+    CONFIG_KEY_RUNCOMMANDS_FILE = "TARGETRCFILE_REGISTRY"
 
     def __init__(self, target: Target, registry: regutil.RegfHive | None = None):
         self.prompt_base = _target_name(target)

--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -514,10 +514,10 @@ class TargetCli(TargetCmd):
         self.cwd = None
         self.chdir("/")
 
-        self.runcommandsfile = pathlib.Path(
+        runcommands_file = pathlib.Path(
             getattr(target._config, "TARGETRCFILE", self.DEFAULT_RUNCOMMANDSFILE)
         ).expanduser()
-        self.load_runcommands()
+        self.load_runcommands(runcommands_file)
 
     @property
     def prompt(self) -> str:
@@ -537,10 +537,10 @@ class TargetCli(TargetCmd):
             suggestions.append(suggestion)
         return suggestions
 
-    def load_runcommands(self):
+    def load_runcommands(self, runcommands_file: pathlib.Path) -> None:
         """Load and execute commands from the run commands file."""
         try:
-            with self.runcommandsfile.open() as fh:
+            with runcommands_file.open() as fh:
                 for line in fh:
                     if (line := line.strip()) and not line.startswith("#"):  # Ignore empty lines and comments
                         self.onecmd(line)
@@ -548,7 +548,7 @@ class TargetCli(TargetCmd):
             # The .targetrc file is optional
             pass
         except Exception as e:
-            self.stdout.write(f"Error reading run commands file: {e}\n")
+            self.stdout.write(f"Error processing run commands file: {e}\n")
 
     def resolve_path(self, path: str) -> fsutil.TargetPath:
         if not path:

--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -517,7 +517,7 @@ class TargetCli(TargetCmd):
         runcommands_file = pathlib.Path(
             getattr(target._config, "TARGETRCFILE", self.DEFAULT_RUNCOMMANDSFILE)
         ).expanduser()
-        self.load_runcommands(runcommands_file)
+        self._load_targetrc(runcommands_file)
 
     @property
     def prompt(self) -> str:
@@ -537,10 +537,10 @@ class TargetCli(TargetCmd):
             suggestions.append(suggestion)
         return suggestions
 
-    def load_runcommands(self, runcommands_file: pathlib.Path) -> None:
+    def _load_targetrc(self, path: pathlib.Path) -> None:
         """Load and execute commands from the run commands file."""
         try:
-            with runcommands_file.open() as fh:
+            with path.open() as fh:
                 for line in fh:
                     if (line := line.strip()) and not line.startswith("#"):  # Ignore empty lines and comments
                         self.onecmd(line)
@@ -548,7 +548,7 @@ class TargetCli(TargetCmd):
             # The .targetrc file is optional
             pass
         except Exception as e:
-            self.stdout.write(f"Error processing run commands file: {e}\n")
+            log.debug("Error processing .targetrc file: %s", e)
 
     def resolve_path(self, path: str) -> fsutil.TargetPath:
         if not path:

--- a/tests/tools/test_shell.py
+++ b/tests/tools/test_shell.py
@@ -153,6 +153,9 @@ def targetrc_file() -> Iterator[list[str]]:
 def test_targetcli_targetrc(target_bare: Target, targetrc_file: list[str]) -> None:
     with patch.object(TargetCli, "onecmd", autospec=True) as mock_onecmd:
         cli = TargetCli(target_bare)
+
+        cli.preloop()
+
         expected_calls = [call(cli, cmd) for cmd in targetrc_file]
         mock_onecmd.assert_has_calls(expected_calls, any_order=False)
 


### PR DESCRIPTION
Support execution of a `~/.targetrc` file when a target shell is opened, and `~/.targetrc.registry` in case of the registry shell.

We have decided on separate run command files because the registry and target shell are not compatible.


Additionally:

- The run commands files to be executed can be configured per-target by setting the `TARGETRCFILE` (and `TARGETRCFILE_REGISTRY`)  variables inside the target configuration file.

 Closes #592