### PR TITLE
Mark OSX home directory as a posix path

### DIFF
--- a/dissect/target/plugins/os/unix/bsd/osx/_os.py
+++ b/dissect/target/plugins/os/unix/bsd/osx/_os.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import plistlib
 from typing import Iterator, Optional
 
+from flow.record.fieldtypes import posix_path
+
 from dissect.target.filesystem import Filesystem
 from dissect.target.helpers.record import UnixUserRecord
 from dissect.target.plugin import OperatingSystem, export
@@ -71,7 +73,7 @@ class MacPlugin(BsdPlugin):
                         uid=user.get("uid", [None])[0],
                         gid=user.get("gid", [None])[0],
                         gecos=user.get("realname", [None])[0],
-                        home=home_dir,
+                        home=posix_path(home_dir) if home_dir else None,
                         shell=user.get("shell", [None])[0],
                         source=path,
                     )

--- a/tests/plugins/os/unix/bsd/osx/test__os.py
+++ b/tests/plugins/os/unix/bsd/osx/test__os.py
@@ -25,7 +25,7 @@ def test_unix_bsd_osx_os(target_osx_users, fs_osx):
 
     assert dissect_user.name == "_dissect"
     assert dissect_user.passwd == "*"
-    assert dissect_user.home == "/var/empty"
+    assert str(dissect_user.home) == "/var/empty"
     assert dissect_user.shell == "/usr/bin/false"
     assert dissect_user.source == "/var/db/dslocal/nodes/Default/users/_dissect.plist"
 

--- a/tests/plugins/os/unix/bsd/osx/test__os.py
+++ b/tests/plugins/os/unix/bsd/osx/test__os.py
@@ -25,6 +25,9 @@ def test_unix_bsd_osx_os(target_osx_users, fs_osx):
 
     assert dissect_user.name == "_dissect"
     assert dissect_user.passwd == "*"
+    # When the test is running under windows, comparing to the string representation ensures
+    # that the home directory is stored in posix format.
+    # The __eq__ operator of the path class is too lenient.
     assert str(dissect_user.home) == "/var/empty"
     assert dissect_user.shell == "/usr/bin/false"
     assert dissect_user.source == "/var/db/dslocal/nodes/Default/users/_dissect.plist"

--- a/tests/plugins/os/unix/bsd/osx/test__os.py
+++ b/tests/plugins/os/unix/bsd/osx/test__os.py
@@ -1,3 +1,5 @@
+from flow.record.fieldtypes import posix_path
+
 from dissect.target.plugins.os.unix.bsd.osx._os import MacPlugin
 from tests._utils import absolute_path
 
@@ -25,10 +27,8 @@ def test_unix_bsd_osx_os(target_osx_users, fs_osx):
 
     assert dissect_user.name == "_dissect"
     assert dissect_user.passwd == "*"
-    # When the test is running under windows, comparing to the string representation ensures
-    # that the home directory is stored in posix format.
-    # The __eq__ operator of the path class is too lenient.
-    assert str(dissect_user.home) == "/var/empty"
+    assert dissect_user.home == "/var/empty"
+    assert isinstance(dissect_user.home, posix_path)
     assert dissect_user.shell == "/usr/bin/false"
     assert dissect_user.source == "/var/db/dslocal/nodes/Default/users/_dissect.plist"
 


### PR DESCRIPTION
This fixes an issue where the home directory could not be found when running dissect on windows.

@pyrco also helped 

Closes #866 