### PR TITLE
Add support for ISO 8601 formatted auth log timestamps

### DIFF
--- a/dissect/target/plugins/os/unix/log/auth.py
+++ b/dissect/target/plugins/os/unix/log/auth.py
@@ -348,7 +348,7 @@ def iso_readlines(file: TargetPath, limit: int | None = None) -> Iterator[tuple[
                 continue
 
             try:
-                ts = datetime.strptime(match[0], "%Y-%m-%dT%H:%M:%S.%f%:z")
+                ts = datetime.strptime(match[0], "%Y-%m-%dT%H:%M:%S.%f%z")
 
             except ValueError as e:
                 log.warning("Unable to parse ISO timestamp in line: %s", line)

--- a/dissect/target/plugins/os/unix/log/auth.py
+++ b/dissect/target/plugins/os/unix/log/auth.py
@@ -338,7 +338,7 @@ def iso_readlines(file: TargetPath, limit: int | None = None) -> Iterator[tuple[
     """Iterator reading the provided auth log file in ISO format. Mimics ``year_rollover_helper`` behaviour."""
 
     with open_decompress(file, "rt") as fh:
-        for count, line in enumerate(fh.readlines()):
+        for count, line in enumerate(fh):
             if limit and count > limit:
                 break
 
@@ -361,5 +361,4 @@ def iso_readlines(file: TargetPath, limit: int | None = None) -> Iterator[tuple[
 def is_iso_fmt(file: TargetPath) -> bool:
     """Determine if the provided auth log file uses new ISO format logging or not."""
 
-    results = list(iso_readlines(file, limit=3))
-    return any(results)
+    return any(iso_readlines(file, limit=3))

--- a/dissect/target/plugins/os/unix/log/auth.py
+++ b/dissect/target/plugins/os/unix/log/auth.py
@@ -348,7 +348,7 @@ def iso_readlines(file: TargetPath, limit: int | None = None) -> Iterator[tuple[
                 continue
 
             try:
-                ts = datetime.strptime(match[0], "%Y-%m-%dT%H:%M:%S.%f%z")
+                ts = datetime.strptime(match[0], "%Y-%m-%dT%H:%M:%S.%f%:z")
 
             except ValueError as e:
                 log.warning("Unable to parse ISO timestamp in line: %s", line)

--- a/tests/_data/plugins/os/unix/log/auth/iso.log
+++ b/tests/_data/plugins/os/unix/log/auth/iso.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40bf6c229952ac458617f51273ed63a6b628877da90582e2e5e81a4d2b323309
+size 1281


### PR DESCRIPTION
This PR builds on top of #860 and introduces support for ISO 8601 formatted timestamps in `auth.log` files which can (finally :partying_face:) be found in newer Debian and Ubuntu systems. Fixes #903. 