### PR TITLE
Support st_blksize and st_blocks on JFFS2

### DIFF
--- a/dissect/target/filesystems/jffs.py
+++ b/dissect/target/filesystems/jffs.py
@@ -122,6 +122,6 @@ class JFFSFilesystemEntry(FilesystemEntry):
         # JFFS2 block size is a function of the "erase size" of the underlying flash device.
         # Linux stat reports the default block size, which is defined as 4k in libc.
         st_info.st_blksize = 4096
-        st_info.st_blocks = (node.isize + 511) // 512 if node.isize else 0
+        st_info.st_blocks = (node.isize + 511) // 512 if self.is_file() else 0
 
         return st_info

--- a/dissect/target/filesystems/jffs.py
+++ b/dissect/target/filesystems/jffs.py
@@ -119,4 +119,9 @@ class JFFSFilesystemEntry(FilesystemEntry):
             ]
         )
 
+        # JFFS2 block size is a function of the "erase size" of the underlying flash device.
+        # Linux stat reports the default block size, which is defined as 4k in libc.
+        st_info.st_blksize = 4096
+        st_info.st_blocks = (node.isize + 511) // 512 if node.isize else 0
+
         return st_info

--- a/tests/filesystems/test_jffs2.py
+++ b/tests/filesystems/test_jffs2.py
@@ -18,7 +18,7 @@ def jffs_fs() -> Iterator[JFFSFilesystem]:
 def jffs_fs_file_entry(jffs_fs: JFFSFilesystem) -> Iterator[JFFSFilesystemEntry]:
     raw_inode = Mock(uid=1000, guid=999, isize=165002)
     inode = Mock(
-        mode=33204,
+        mode=0o100664,
         inum=4,
         inode=raw_inode,
         atime=datetime(2024, 10, 1, 12, 0, 0),
@@ -37,7 +37,7 @@ def jffs_fs_file_entry(jffs_fs: JFFSFilesystem) -> Iterator[JFFSFilesystemEntry]
 def jffs_fs_directory_entry(jffs_fs: JFFSFilesystem) -> Iterator[JFFSFilesystemEntry]:
     raw_inode = Mock(uid=1000, guid=999, isize=0)
     inode = Mock(
-        mode=16893,
+        mode=0o40775,
         inum=2,
         inode=raw_inode,
         atime=datetime(2024, 10, 1, 12, 0, 0),

--- a/tests/filesystems/test_jffs2.py
+++ b/tests/filesystems/test_jffs2.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from typing import Iterator
+from unittest.mock import Mock, patch
+import pytest
+
+from dissect.target.filesystems.jffs import JFFSFilesystem, JFFSFilesystemEntry
+
+
+@pytest.fixture
+def jffs_fs() -> Iterator[JFFSFilesystem]:
+    with patch("dissect.jffs.jffs2.JFFS2"):
+        jffs_fs = JFFSFilesystem(Mock())
+        yield jffs_fs
+
+
+@pytest.fixture
+def jffs_fs_entry(jffs_fs: JFFSFilesystem) -> Iterator[JFFSFilesystemEntry]:
+    raw_inode = Mock(uid=1000, guid=999, isize=165002)
+    inode = Mock(
+        mode=33204,
+        inum=4,
+        inode=raw_inode,
+        atime=datetime(2024, 10, 1, 12, 0, 0),
+        mtime=datetime(2024, 10, 2, 12, 0, 0),
+        ctime=datetime(2024, 10, 3, 12, 0, 0),
+    )
+
+    entry = JFFSFilesystemEntry(jffs_fs, "/some_file", inode)
+    yield entry
+
+
+def test_jffs2(jffs_fs: JFFSFilesystem, jffs_fs_entry: JFFSFilesystemEntry) -> None:
+    stat = jffs_fs_entry.stat()
+
+    entry = jffs_fs_entry.entry
+    assert stat.st_mode == entry.mode
+    assert stat.st_ino == entry.inum
+    assert stat.st_dev == id(jffs_fs)
+    assert stat.st_nlink == 1
+    assert stat.st_uid == entry.inode.uid
+    assert stat.st_gid == entry.inode.gid
+    assert stat.st_size == entry.inode.isize
+    assert stat.st_atime == entry.atime.timestamp()
+    assert stat.st_mtime == entry.mtime.timestamp()
+    assert stat.st_ctime == entry.ctime.timestamp()
+    assert stat.st_blksize == 4096
+    assert stat.st_blocks == 323

--- a/tests/filesystems/test_jffs2.py
+++ b/tests/filesystems/test_jffs2.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Iterator
 from unittest.mock import Mock, patch
+
 import pytest
 
 from dissect.target.filesystems.jffs import JFFSFilesystem, JFFSFilesystemEntry

--- a/tests/filesystems/test_xfs.py
+++ b/tests/filesystems/test_xfs.py
@@ -25,7 +25,7 @@ def xfs_fs_entry(xfs_fs: XfsFilesystem) -> Iterator[XfsFilesystemEntry]:
     ctime = datetime(2024, 10, 3, 12, 0, 0)
     crtime = datetime(2024, 10, 4, 12, 0, 0)
 
-    dinode = Mock(di_mode=33272, di_nlink=1, di_uid=1000, di_gid=999)
+    dinode = Mock(di_mode=0o100750, di_nlink=1, di_uid=1000, di_gid=999)
     inode = Mock(
         nblocks=10,
         inode=dinode,


### PR DESCRIPTION
The block size  is a function of the "erase size" of the underlying flash device.
Linux stat reports the default block size, which is defined as 4k in libc. 

Note that JFFS2 does not support non-residential symlinks (see https://github.com/torvalds/linux/blob/6485cf5ea253d40d507cd71253c9568c5470cd27/fs/jffs2/dir.c#L299)

Closes #819 