### PR TITLE
Fix AttributeError in syscache plugin

### DIFF
--- a/dissect/target/plugins/os/windows/syscache.py
+++ b/dissect/target/plugins/os/windows/syscache.py
@@ -77,7 +77,8 @@ class SyscachePlugin(Plugin):
                 full_path = None
                 if mft:
                     try:
-                        full_path = self.target.fs.path("\\".join(["sysvol", mft.mft(file_segment).fullpath()]))
+                        if path := mft(file_segment).full_path():
+                            full_path = self.target.fs.path("\\".join(["sysvol", path]))
                     except ntfs.Error:
                         pass
 

--- a/tests/_data/plugins/os/windows/syscache/Syscache-mft.hve
+++ b/tests/_data/plugins/os/windows/syscache/Syscache-mft.hve
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e80985a82a3edb23f802148e5eee1a6c462acf5e5a663c80393c9b7ef4a7b11d
+size 786432

--- a/tests/plugins/os/windows/test_syscache.py
+++ b/tests/plugins/os/windows/test_syscache.py
@@ -1,3 +1,4 @@
+from dissect.target.filesystems.ntfs import NtfsFilesystem
 from dissect.target.plugins.os.windows.syscache import SyscachePlugin
 from tests._utils import absolute_path
 
@@ -10,3 +11,24 @@ def test_syscache_plugin(target_win, fs_win):
 
     results = list(target_win.syscache())
     assert len(results) == 401
+
+
+def test_syscache_plugin_real_mft(target_win, fs_win):
+    filesystem = NtfsFilesystem(mft=open(absolute_path("_data/plugins/filesystem/ntfs/mft/mft.raw"), "rb"))
+
+    # We need to change the type of the mocked filesystem, since syscache.py checks for explicit value
+    target_win.fs.mounts["sysvol"].__type__ = "ntfs"
+    target_win.fs.mounts["sysvol"].ntfs = filesystem.ntfs
+
+    syscache_file = absolute_path("_data/plugins/os/windows/syscache/Syscache-mft.hve")
+    fs_win.map_file("System Volume Information/Syscache.hve", syscache_file)
+
+    target_win.add_plugin(SyscachePlugin)
+
+    results = list(target_win.syscache())
+    assert len(results) == 401
+
+    filepaths = [entry.path for entry in results]
+    assert filepaths.count(None) == 399
+    assert "sysvol\\NamelessDirectory\\totally_normal.txt" in filepaths
+    assert "sysvol\\text_document.txt" in filepaths


### PR DESCRIPTION
``dissect.ntfs`` changes probably caused regression in syscache plugin that now raises following ``AttributeError`` for me:

```
$ target-query -q -f syscache  DC1.tar
Traceback (most recent call last):
  File "/home/user/test-venv/bin/target-query", line 8, in <module>
    sys.exit(main())
  File "/home/user/test-venv/lib/python3.9/site-packages/dissect/target/tools/utils.py", line 276, in wrapper
    return func(*args, **kwargs)
  File "/home/user/test-venv/lib/python3.9/site-packages/dissect/target/tools/query.py", line 384, in main
    raise e
  File "/home/user/test-venv/lib/python3.9/site-packages/dissect/target/tools/query.py", line 373, in main
    for record_entries in entry:
  File "/home/user/test-venv/lib/python3.9/site-packages/dissect/target/plugins/os/windows/syscache.py", line 78, in syscache
    full_path = self.target.fs.path("\\".join(["sysvol", mft.mft(file_segment).fullpath()]))
AttributeError: 'Mft' object has no attribute 'mft'
```

Also when MFT record is missing plugin raises following ``TypeError``, PR also fixes this:
```
Traceback (most recent call last):
  File "/home/user/test-venv/bin/target-query", line 8, in <module>
    sys.exit(main())
  File "/home/user/test-venv/lib/python3.9/site-packages/dissect/target/tools/utils.py", line 276, in wrapper
    return func(*args, **kwargs)
  File "/home/user/test-venv/lib/python3.9/site-packages/dissect/target/tools/query.py", line 384, in main
    raise e
  File "/home/user/test-venv/lib/python3.9/site-packages/dissect/target/tools/query.py", line 373, in main
    for record_entries in entry:
  File "/home/user/test-venv/lib/python3.9/site-packages/dissect/target/plugins/os/windows/syscache.py", line 81, in syscache
    full_path = self.target.fs.path("\\".join(["sysvol", mft.ntfs.mft(file_segment).full_path()]))
TypeError: sequence item 1: expected str instance, NoneType found
```