### PR TITLE
Linux network plugin: NetworkManager & systemd-networkd

### DIFF
--- a/dissect/target/helpers/configutil.py
+++ b/dissect/target/helpers/configutil.py
@@ -891,7 +891,7 @@ KNOWN_FILES: dict[str, type[ConfigurationParser]] = {
 }
 
 
-def parse(path: Union[FilesystemEntry, TargetPath], hint: Optional[str] = None, *args, **kwargs) -> ConfigParser:
+def parse(path: Union[FilesystemEntry, TargetPath], hint: Optional[str] = None, *args, **kwargs) -> ConfigurationParser:
     """Parses the content of an ``path`` or ``entry`` to a dictionary.
 
     Args:
@@ -922,7 +922,7 @@ def parse_config(
     entry: FilesystemEntry,
     hint: Optional[str] = None,
     options: Optional[ParserOptions] = None,
-) -> ConfigParser:
+) -> ConfigurationParser:
     parser_type = _select_parser(entry, hint)
 
     parser = parser_type.create_parser(options)

--- a/dissect/target/helpers/record.py
+++ b/dissect/target/helpers/record.py
@@ -145,6 +145,7 @@ EmptyRecord = RecordDescriptor(
 
 COMMON_INTERFACE_ELEMENTS = [
     ("string", "name"),
+    ("string[]", "mac"),
     ("string", "type"),
     ("boolean", "enabled"),
     ("net.ipaddress[]", "dns"),
@@ -159,7 +160,6 @@ UnixInterfaceRecord = TargetRecordDescriptor(
     "unix/network/interface",
     [
         *COMMON_INTERFACE_ELEMENTS,
-        ("string[]", "mac"),  # We are dealing with possibilities, not reality. There are also bonded interfaces.
         ("boolean", "dhcp_ipv4"),  # NetworkManager allows for dual-stack configurations.
         ("boolean", "dhcp_ipv6"),
         ("datetime", "last_connected"),
@@ -172,7 +172,6 @@ WindowsInterfaceRecord = TargetRecordDescriptor(
     "windows/network/interface",
     [
         *COMMON_INTERFACE_ELEMENTS,
-        ("string", "mac"),
         ("varint", "metric"),
         ("stringlist", "search_domain"),
         ("datetime", "first_connected"),
@@ -187,7 +186,6 @@ MacInterfaceRecord = TargetRecordDescriptor(
     "macos/network/interface",
     [
         *COMMON_INTERFACE_ELEMENTS,
-        ("string", "mac"),
         ("varint", "interface_service_order"),
         ("boolean", "dhcp"),
         ("varint", "vlan"),

--- a/dissect/target/helpers/record.py
+++ b/dissect/target/helpers/record.py
@@ -147,31 +147,39 @@ COMMON_INTERFACE_ELEMENTS = [
     ("string", "name"),
     ("string", "type"),
     ("boolean", "enabled"),
-    ("string", "mac"),
     ("net.ipaddress[]", "dns"),
     ("net.ipaddress[]", "ip"),
     ("net.ipaddress[]", "gateway"),
+    ("net.ipnetwork[]", "network"),
     ("string", "source"),
 ]
 
 
 UnixInterfaceRecord = TargetRecordDescriptor(
     "unix/network/interface",
-    COMMON_INTERFACE_ELEMENTS,
+    [
+        *COMMON_INTERFACE_ELEMENTS,
+        ("string[]", "mac"),  # We are dealing with possibilities, not reality. There are also bonded interfaces.
+        ("boolean", "dhcp_ipv4"),  # NetworkManager allows for dual-stack configurations.
+        ("boolean", "dhcp_ipv6"),
+        ("datetime", "last_connected"),
+        ("varint[]", "vlan"),
+        ("string", "configurator"),
+    ],
 )
 
 WindowsInterfaceRecord = TargetRecordDescriptor(
     "windows/network/interface",
     [
         *COMMON_INTERFACE_ELEMENTS,
-        ("varint", "vlan"),
-        ("net.ipnetwork[]", "network"),
+        ("string", "mac"),
         ("varint", "metric"),
         ("stringlist", "search_domain"),
         ("datetime", "first_connected"),
         ("datetime", "last_connected"),
         ("net.ipaddress[]", "subnetmask"),
         ("boolean", "dhcp"),
+        ("varint", "vlan"),
     ],
 )
 
@@ -179,10 +187,10 @@ MacInterfaceRecord = TargetRecordDescriptor(
     "macos/network/interface",
     [
         *COMMON_INTERFACE_ELEMENTS,
-        ("varint", "vlan"),
-        ("net.ipnetwork[]", "network"),
+        ("string", "mac"),
         ("varint", "interface_service_order"),
         ("boolean", "dhcp"),
+        ("varint", "vlan"),
     ],
 )
 

--- a/dissect/target/helpers/utils.py
+++ b/dissect/target/helpers/utils.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import logging
 import re
 import urllib.parse
 from datetime import datetime, timezone, tzinfo
 from enum import Enum
 from pathlib import Path
-from typing import BinaryIO, Callable, Iterator, Optional, Union
+from typing import BinaryIO, Callable, Iterator, Optional, TypeVar, Union
 
 from dissect.util.ts import from_unix
 
@@ -22,6 +24,23 @@ def findall(buf: bytes, needle: bytes) -> Iterator[int]:
 
         yield offset
         offset += 1
+
+
+T = TypeVar("T")
+
+
+def to_list(value: T | list[T]) -> list[T]:
+    """Convert a single value or a list of values to a list.
+
+    Args:
+        value: The value to convert.
+
+    Returns:
+        A list of values.
+    """
+    if not isinstance(value, list):
+        return [value]
+    return value
 
 
 class StrEnum(str, Enum):

--- a/dissect/target/plugins/general/network.py
+++ b/dissect/target/plugins/general/network.py
@@ -79,7 +79,7 @@ class NetworkPlugin(Plugin):
     @internal
     def with_mac(self, mac: str) -> Iterator[InterfaceRecord]:
         for interface in self.interfaces():
-            if interface.mac == mac:
+            if mac in interface.mac:
                 yield interface
 
     @internal

--- a/dissect/target/plugins/os/unix/bsd/osx/network.py
+++ b/dissect/target/plugins/os/unix/bsd/osx/network.py
@@ -89,5 +89,5 @@ class MacNetworkPlugin(NetworkPlugin):
                 )
 
             except Exception as e:
-                self.target.log.warning("Error reading configuration for network device %s: %s", name, e)
+                self.target.log.warning("Error reading configuration for network device %s", name, exc_info=e)
                 continue

--- a/dissect/target/plugins/os/unix/bsd/osx/network.py
+++ b/dissect/target/plugins/os/unix/bsd/osx/network.py
@@ -84,6 +84,7 @@ class MacNetworkPlugin(NetworkPlugin):
                     network=network,
                     interface_service_order=interface_service_order,
                     dhcp=dhcp,
+                    mac=[],
                     _target=self.target,
                 )
 

--- a/dissect/target/plugins/os/unix/linux/_os.py
+++ b/dissect/target/plugins/os/unix/linux/_os.py
@@ -6,10 +6,7 @@ from dissect.target.filesystem import Filesystem
 from dissect.target.plugin import OperatingSystem, export
 from dissect.target.plugins.os.unix._os import UnixPlugin
 from dissect.target.plugins.os.unix.bsd.osx._os import MacPlugin
-from dissect.target.plugins.os.unix.linux.network_managers import (
-    LinuxNetworkManager,
-    parse_unix_dhcp_log_messages,
-)
+from dissect.target.plugins.os.unix.linux.network_managers import LinuxNetworkManager
 from dissect.target.plugins.os.windows._os import WindowsPlugin
 from dissect.target.target import Target
 
@@ -33,16 +30,7 @@ class LinuxPlugin(UnixPlugin, LinuxNetworkManager):
 
     @export(property=True)
     def ips(self) -> list[str]:
-        """Returns a list of static IP addresses and DHCP lease IP addresses found on the host system."""
-        ips = set()
-
-        for ip_set in self.network_manager.get_config_value("ips"):
-            ips.update(ip_set)
-
-        for ip in parse_unix_dhcp_log_messages(self.target, iter_all=False):
-            ips.add(ip)
-
-        return list(ips)
+        return self.target.network.ips()
 
     @export(property=True)
     def dns(self) -> list[str]:

--- a/dissect/target/plugins/os/unix/linux/network.py
+++ b/dissect/target/plugins/os/unix/linux/network.py
@@ -43,6 +43,13 @@ class LinuxConfigParser:
 
 
 class NetworkManagerConfigParser(LinuxConfigParser):
+    """NetworkManager configuration parser.
+
+    NetworkManager configuration files are generally in an INI-like format.
+    Note that Red Hat and Fedora deprecated ifcfg files.
+    Documentation: https://networkmanager.dev/docs/api/latest/nm-settings-keyfile.html
+    """
+
     config_paths: list[str] = [
         "/etc/NetworkManager/system-connections/",
         "/usr/lib/NetworkManager/system-connections/",
@@ -145,6 +152,14 @@ class NetworkManagerConfigParser(LinuxConfigParser):
 
 
 class SystemdNetworkConfigParser(LinuxConfigParser):
+    """Systemd network configuration parser.
+
+    Systemd network configuration files are generally in an INI-like format with some quirks.
+    Note that drop-in directories are not yet supported.
+
+    Documentation: https://www.freedesktop.org/software/systemd/man/latest/systemd.network.html
+    """
+
     config_paths: list[str] = [
         "/etc/systemd/network/",
         "/run/systemd/network/",
@@ -252,7 +267,8 @@ class SystemdNetworkConfigParser(LinuxConfigParser):
     def _parse_dns_ip(self, address: str) -> ip_address:
         """Parse DNS address from systemd network configuration file.
 
-        See https://www.freedesktop.org/software/systemd/man/latest/systemd.network.html DNS for details.
+        The optional brackets and port number make this hard to parse.
+        See https://www.freedesktop.org/software/systemd/man/latest/systemd.network.html and search for DNS.
         """
 
         match = self.dns_ip_patttern.search(address)

--- a/dissect/target/plugins/os/unix/linux/network.py
+++ b/dissect/target/plugins/os/unix/linux/network.py
@@ -28,14 +28,14 @@ class LinuxConfigParser:
     def __init__(self, target: Target):
         self._target = target
 
-    def _config_files(self, config_paths: list[str], glob: str) -> Iterator[TargetPath]:
+    def _config_files(self, config_paths: list[str], glob: str) -> list[TargetPath]:
         """Yield all configuration files in config_paths matching the given extension."""
         all_files = []
         for config_path in config_paths:
             paths = self._target.fs.path(config_path).glob(glob)
             all_files.extend(config_file for config_file in paths if config_file.is_file())
 
-        yield from sorted(all_files, key=lambda p: p.name)
+        return sorted(all_files, key=lambda p: p.name)
 
     def interfaces(self) -> Iterator[UnixInterfaceRecord]:
         """Parse network interfaces from configuration files."""
@@ -146,7 +146,8 @@ class SystemdNetworkConfigParser(LinuxConfigParser):
         "/usr/local/lib/systemd/network/",
     ]
 
-    # Can be enclosed in brackets for IPv6. Can also have port and SNI, which we ignore.
+    # Can be enclosed in brackets for IPv6. Can also have port, iface name, and SNI, which we ignore.
+    # Example: [1111:2222::3333]:9953%ifname#example.com
     dns_ip_patttern = re.compile(r"((?:\d{1,3}\.){3}\d{1,3})|\[(\[?[0-9a-fA-F:]+\]?)\]")
 
     def interfaces(self) -> Iterator:

--- a/dissect/target/plugins/os/unix/linux/network.py
+++ b/dissect/target/plugins/os/unix/linux/network.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from ipaddress import ip_address, ip_interface
 from typing import Iterator
 
@@ -135,7 +135,7 @@ class NetworkManagerConfigParser(LinuxConfigParser):
             return None
 
         timestamp_int = int(value)
-        return datetime.fromtimestamp(timestamp_int)
+        return datetime.fromtimestamp(timestamp_int, timezone.utc)
 
 
 class SystemdNetworkConfigParser(LinuxConfigParser):

--- a/dissect/target/plugins/os/unix/linux/network.py
+++ b/dissect/target/plugins/os/unix/linux/network.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from ipaddress import ip_address, ip_interface
+from typing import Iterator
+
+from dissect.target import Target
+from dissect.target.helpers import configutil
+from dissect.target.helpers.record import UnixInterfaceRecord
+from dissect.target.plugins.general.network import NetworkPlugin
+from dissect.target.target import TargetPath
+
+
+class LinuxNetworkPlugin(NetworkPlugin):
+    def _interfaces(self) -> Iterator[UnixInterfaceRecord]:
+        """Try all available network configuration managers and aggregate the results."""
+        for manager_cls in MANAGERS:
+            manager: LinuxConfigParser = manager_cls(self.target)
+            yield from manager.interfaces()
+
+
+class LinuxConfigParser:
+    VlanIdByName = dict[str, int]
+
+    def __init__(self, target: Target):
+        self._target = target
+
+    def _config_files(self, config_paths: list[str], glob: str) -> Iterator[TargetPath]:
+        """Yield all configuration files in config_paths matching the given extension."""
+        all_files = []
+        for config_path in config_paths:
+            paths = self._target.fs.path(config_path).glob(glob)
+            all_files.extend(config_file for config_file in paths if config_file.is_file())
+
+        yield from sorted(all_files, key=lambda p: p.name)
+
+    def interfaces(self) -> Iterator[UnixInterfaceRecord]:
+        """Parse network interfaces from configuration files."""
+        yield from ()
+
+
+class NetworkManagerConfigParser(LinuxConfigParser):
+    config_paths: list[str] = [
+        "/etc/NetworkManager/system-connections/",
+        "/usr/lib/NetworkManager/system-connections/",
+        "/run/NetworkManager/system-connections/",
+    ]
+
+    def interfaces(self) -> Iterator[UnixInterfaceRecord]:
+        connections: dict[str, dict] = {}
+        vlan_id_by_interface: LinuxConfigParser.VlanIdByName = {}
+
+        for connection_file_path in self._config_files(self.config_paths, "*"):
+            try:
+                connection = configutil.parse(connection_file_path, hint="ini")
+
+                common_section: dict[str, str] = connection.get("connection", {})
+                interface_type = common_section.get("type", "")
+                sub_type: dict[str, str] = connection.get(interface_type, {})
+
+                if interface_type == "vlan":
+                    # Store vlan id by parent interface name
+                    parent_interface = sub_type.get("parent", None)
+                    vlan_id = sub_type.get("id", None)
+                    if parent_interface and vlan_id:
+                        vlan_id_by_interface[parent_interface] = int(vlan_id)
+                    continue
+
+                dns = set[ip_address]()
+                ip_interfaces: set[ip_interface] = set()
+                gateways: set[ip_address] = set()
+                dhcp_settings: dict[str, str] = {"ipv4": "", "ipv6": ""}
+
+                for ip_version in ["ipv4", "ipv6"]:
+                    ip_section: dict[str, str] = connection.get(ip_version, {})
+                    for key, value in ip_section.items():
+                        # nmcli inserts a trailling semicolon
+                        if key == "dns" and (stripped := value.rstrip(";")):
+                            dns.update({ip_address(addr) for addr in stripped.split(";")})
+                        elif key.startswith("address"):
+                            # Undocumented: single gateway on address line. Observed when running:
+                            # nmcli connection add type ethernet ... ip4 192.168.2.138/24 gw4 192.168.2.1
+                            ip, *gateway = value.split(",", 1)
+                            ip_interfaces.add(ip_interface(ip))
+                            if gateway:
+                                gateways.add(ip_address(gateway[0]))
+                        elif key.startswith("gateway"):
+                            gateways.add(ip_address(value))
+                        elif key == "method":
+                            dhcp_settings[ip_version] = value
+                        elif key.startswith("route"):
+                            if gateway := self._parse_route(value):
+                                gateways.add(gateway)
+
+                name = common_section.get("interface-name", None)
+                mac_address = [sub_type.get("mac-address", "")] if sub_type.get("mac-address", "") else []
+                connections[name] = {  # Store as dict to allow for clean updating with vlan
+                    "source": str(connection_file_path),
+                    "enabled": None,  # Stored in run-time state
+                    "last_connected": self._parse_lastconnected(common_section.get("timestamp", "")),
+                    "name": name,
+                    "mac": mac_address,
+                    "type": interface_type,
+                    "dhcp_ipv4": dhcp_settings.get("ipv4", {}) == "auto",
+                    "dhcp_ipv6": dhcp_settings.get("ipv6", {}) == "auto",
+                    "dns": list(dns),
+                    "ip": [interface.ip for interface in ip_interfaces],
+                    "network": [interface.network for interface in ip_interfaces],
+                    "gateway": list(gateways),
+                    "configurator": "NetworkManager",
+                }
+            except Exception as e:
+                self._target.log.warning("Error parsing network config file %s: %s", connection_file_path, e)
+
+        for parent_interface_name, vlan_id in vlan_id_by_interface.items():
+            if parent_connection := connections.get(parent_interface_name):
+                parent_connection["vlan"] = {vlan_id}
+
+        for connection in connections.values():
+            yield UnixInterfaceRecord(**connection)
+
+    def _parse_route(self, route: str) -> ip_address | None:
+        """Parse a route and return gateway IP address."""
+        if (elements := route.split(",")) and len(elements) > 1:
+            return ip_address(elements[1])
+
+        return None
+
+    def _parse_lastconnected(self, value: str) -> datetime | None:
+        """Parse last connected timestamp."""
+        if not value:
+            return None
+
+        timestamp_int = int(value)
+        return datetime.fromtimestamp(timestamp_int)
+
+
+class SystemdNetworkConfigParser(LinuxConfigParser):
+    config_paths: list[str] = [
+        "/etc/systemd/network/",
+        "/run/systemd/network/",
+        "/usr/lib/systemd/network/",
+        "/usr/local/lib/systemd/network/",
+    ]
+
+    # Can be enclosed in brackets for IPv6. Can also have port and SNI, which we ignore.
+    dns_ip_patttern = re.compile(r"((?:\d{1,3}\.){3}\d{1,3})|\[(\[?[0-9a-fA-F:]+\]?)\]")
+
+    def interfaces(self) -> Iterator:
+        virtual_networks = self._parse_virtual_networks()
+        yield from self._parse_networks(virtual_networks)
+
+    def _parse_virtual_networks(self) -> LinuxConfigParser.VlanIdByName:
+        """Parse virtual network configurations from systemd network configuration files."""
+
+        virtual_networks: LinuxConfigParser.VlanIdByName = {}
+        for config_file in self._config_files(self.config_paths, "*.netdev"):
+            try:
+                virtual_network_config = configutil.parse(config_file, hint="systemd")
+                net_dev_section: dict[str, str] = virtual_network_config.get("NetDev", {})
+                if net_dev_section.get("Kind") != "vlan":
+                    continue
+
+                vlan_id = virtual_network_config.get("VLAN", {}).get("Id")
+                if (name := net_dev_section.get("Name")) and vlan_id:
+                    virtual_networks[name] = int(vlan_id)
+            except Exception as e:
+                self._target.log.warning("Error parsing virtual network config file %s: %s", config_file, e)
+
+        return virtual_networks
+
+    def _parse_networks(self, virtual_networks: LinuxConfigParser.VlanIdByName) -> Iterator[UnixInterfaceRecord]:
+        """Parse network configurations from systemd network configuration files."""
+        for config_file in self._config_files(self.config_paths, "*.network"):
+            try:
+                config = configutil.parse(config_file, hint="systemd")
+
+                match_section: dict[str, str] = config.get("Match", {})
+                network_section: dict[str, str] = config.get("Network", {})
+                link_section: dict[str, str] = config.get("Link", {})
+
+                ip_interfaces: set[ip_interface] = set()
+                gateways: set[ip_address] = set()
+                dns: set[ip_address] = set()
+                mac_addresses = set[str]()
+
+                dhcp_ipv4, dhcp_ipv6 = self._parse_dhcp(network_section.get("DHCP"))
+                if link_mac := link_section.get("MACAddress"):
+                    mac_addresses.add(link_mac)
+                if match_macs := match_section.get("MACAddress"):
+                    mac_addresses.update(match_macs.split(" "))
+                if permanent_macs := match_section.get("PermanentMACAddress"):
+                    mac_addresses.update(permanent_macs.split(" "))
+
+                if dns_value := network_section.get("DNS"):
+                    if isinstance(dns_value, str):
+                        dns_value = [dns_value]
+                    dns.update({self._parse_dns_ip(dns_ip) for dns_ip in dns_value})
+
+                if address_value := network_section.get("Address"):
+                    if isinstance(address_value, str):
+                        address_value = [address_value]
+                    ip_interfaces.update({ip_interface(addr) for addr in address_value})
+
+                if gateway_value := network_section.get("Gateway"):
+                    if isinstance(gateway_value, str):
+                        gateway_value = [gateway_value]
+                    gateways.update({ip_address(gateway) for gateway in gateway_value})
+
+                vlan_values = network_section.get("VLAN", [])
+                vlan_ids = {
+                    virtual_networks[vlan_name]
+                    for vlan_name in ([vlan_values] if isinstance(vlan_values, str) else vlan_values)
+                    if vlan_name in virtual_networks
+                }
+
+                # There are possibly multiple route sections, but they are collapsed into one by the parser.
+                route_section = config.get("Route", {})
+                gateway_values = route_section.get("Gateway", [])
+                if isinstance(gateway_values, str):
+                    gateway_values = [gateway_values]
+                gateways.update(filter(None, map(self._parse_gateway, gateway_values)))
+
+                yield UnixInterfaceRecord(
+                    source=str(config_file),
+                    type=match_section.get("Type", None),
+                    enabled=None,  # Unknown, dependent on run-time state
+                    dhcp_ipv4=dhcp_ipv4,
+                    dhcp_ipv6=dhcp_ipv6,
+                    name=match_section.get("Name", None),
+                    dns=list(dns),
+                    mac=list(mac_addresses),
+                    ip=[interface.ip for interface in ip_interfaces],
+                    network=[interface.network for interface in ip_interfaces],
+                    gateway=list(gateways),
+                    vlan=list(vlan_ids),
+                    configurator="systemd-networkd",
+                )
+            except Exception as e:
+                self._target.log.warning("Error parsing network config file %s: %s", config_file, e)
+
+    def _parse_dns_ip(self, address: str) -> ip_address:
+        """Parse DNS address from systemd network configuration file.
+
+        See https://www.freedesktop.org/software/systemd/man/latest/systemd.network.html DNS for details.
+        """
+
+        match = self.dns_ip_patttern.search(address)
+        if match:
+            return ip_address(match.group(1) or match.group(2))
+        else:
+            raise ValueError(f"Invalid DNS address format: {address}")
+
+    def _parse_dhcp(self, value: str | None) -> tuple[bool, bool]:
+        """Parse DHCP value from systemd network configuration file to a boolean tuple (ipv4, ipv6)."""
+
+        if value is None or value == "no":
+            return False, False
+        elif value == "yes":
+            return True, True
+        elif value == "ipv4":
+            return True, False
+        elif value == "ipv6":
+            return False, True
+        else:
+            raise ValueError(f"Invalid DHCP value: {value}")
+
+    def _parse_gateway(self, value: str | None) -> ip_address | None:
+        return None if not value or value in {"_dhcp4", "_ipv6ra"} else ip_address(value)
+
+
+MANAGERS = [NetworkManagerConfigParser, SystemdNetworkConfigParser]

--- a/dissect/target/plugins/os/unix/linux/network.py
+++ b/dissect/target/plugins/os/unix/linux/network.py
@@ -13,6 +13,8 @@ from dissect.target.target import TargetPath
 
 
 class LinuxNetworkPlugin(NetworkPlugin):
+    """Linux network interface plugin."""
+
     def _interfaces(self) -> Iterator[UnixInterfaceRecord]:
         """Try all available network configuration managers and aggregate the results."""
         for manager_cls in MANAGERS:

--- a/dissect/target/plugins/os/unix/linux/network.py
+++ b/dissect/target/plugins/os/unix/linux/network.py
@@ -4,14 +4,21 @@ import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from ipaddress import ip_address, ip_interface
-from typing import Iterator, Literal, NamedTuple
+from typing import TYPE_CHECKING, Any, Iterator, Literal, NamedTuple
 
-from dissect.target import Target
 from dissect.target.helpers import configutil
 from dissect.target.helpers.record import UnixInterfaceRecord
 from dissect.target.helpers.utils import to_list
 from dissect.target.plugins.general.network import NetworkPlugin
-from dissect.target.target import TargetPath
+
+if TYPE_CHECKING:
+    from ipaddress import IPv4Address, IPv4Interface, IPv6Address, IPv6Interface
+
+    from dissect.target import Target
+    from dissect.target.target import TargetPath
+
+    NetAddress = IPv4Address | IPv6Address
+    NetInterface = IPv4Interface | IPv6Interface
 
 
 class LinuxNetworkPlugin(NetworkPlugin):
@@ -67,9 +74,9 @@ class NetworkManagerConfigParser(LinuxNetworkConfigParser):
         name: str | None = None
         mac_address: str | None = None
         type: str = ""
-        dns: set[ip_address] = field(default_factory=set)
-        ip_interfaces: set[ip_interface] = field(default_factory=set)
-        gateways: set[ip_address] = field(default_factory=set)
+        dns: set[NetAddress] = field(default_factory=set)
+        ip_interfaces: set[NetInterface] = field(default_factory=set)
+        gateways: set[NetAddress] = field(default_factory=set)
         dhcp_ipv4: bool = False
         dhcp_ipv6: bool = False
         vlan: set[int] = field(default_factory=set)
@@ -121,7 +128,8 @@ class NetworkManagerConfigParser(LinuxNetworkConfigParser):
                 connections.append(context)
 
             except Exception as e:
-                self._target.log.warning("Error parsing network config file %s: %s", connection_file_path, e)
+                self._target.log.warning("Error parsing network config file %s", connection_file_path)
+                self._target.log.debug("", exc_info=e)
 
         for connection in connections:
             vlan_ids_from_interface = vlan_id_by_interface.get(connection.name, set())
@@ -132,7 +140,7 @@ class NetworkManagerConfigParser(LinuxNetworkConfigParser):
 
             yield connection.to_record()
 
-    def _parse_route(self, route: str) -> ip_address | None:
+    def _parse_route(self, route: str) -> NetAddress | None:
         """Parse a route and return gateway IP address."""
         if (elements := route.split(",")) and len(elements) > 1:
             return ip_address(elements[1])
@@ -153,7 +161,7 @@ class NetworkManagerConfigParser(LinuxNetworkConfigParser):
             return
 
         if key == "dns":
-            context.dns.update({ip_address(addr) for addr in trimmed.split(";") if addr})
+            context.dns.update(ip_address(addr) for addr in trimmed.split(";") if addr)
         elif key.startswith("address"):
             # Undocumented: single gateway on address line. Observed when running:
             # nmcli connection add type ethernet ... ip4 192.168.2.138/24 gw4 192.168.2.1
@@ -172,7 +180,7 @@ class NetworkManagerConfigParser(LinuxNetworkConfigParser):
             if gateway := self._parse_route(value):
                 context.gateways.add(gateway)
 
-    def _parse_vlan(self, sub_type: dict["str", any], vlan_id_by_interface: VlanIdByInterface) -> None:
+    def _parse_vlan(self, sub_type: dict[str, Any], vlan_id_by_interface: VlanIdByInterface) -> None:
         parent_interface = sub_type.get("parent")
         vlan_id = sub_type.get("id")
         if not parent_interface or not vlan_id:
@@ -228,7 +236,8 @@ class SystemdNetworkConfigParser(LinuxNetworkConfigParser):
                     vlan_ids = virtual_networks.setdefault(name, set())
                     vlan_ids.add(int(vlan_id))
             except Exception as e:
-                self._target.log.warning("Error parsing virtual network config file %s", config_file, exc_info=e)
+                self._target.log.warning("Error parsing virtual network config file %s", config_file)
+                self._target.log.debug("", exc_info=e)
 
         return virtual_networks
 
@@ -242,9 +251,9 @@ class SystemdNetworkConfigParser(LinuxNetworkConfigParser):
                 network_section: dict[str, str] = config.get("Network", {})
                 link_section: dict[str, str] = config.get("Link", {})
 
-                ip_interfaces: set[ip_interface] = set()
-                gateways: set[ip_address] = set()
-                dns: set[ip_address] = set()
+                ip_interfaces: set[NetInterface] = set()
+                gateways: set[NetAddress] = set()
+                dns: set[NetAddress] = set()
                 mac_addresses: set[str] = set()
 
                 if link_mac := link_section.get("MACAddress"):
@@ -253,13 +262,13 @@ class SystemdNetworkConfigParser(LinuxNetworkConfigParser):
                 mac_addresses.update(match_section.get("PermanentMACAddress", "").split())
 
                 dns_value = to_list(network_section.get("DNS", []))
-                dns.update({self._parse_dns_ip(dns_ip) for dns_ip in dns_value})
+                dns.update(self._parse_dns_ip(dns_ip) for dns_ip in dns_value)
 
                 address_value = to_list(network_section.get("Address", []))
-                ip_interfaces.update({ip_interface(addr) for addr in address_value})
+                ip_interfaces.update(ip_interface(addr) for addr in address_value)
 
                 gateway_value = to_list(network_section.get("Gateway", []))
-                gateways.update({ip_address(gateway) for gateway in gateway_value})
+                gateways.update(ip_address(gateway) for gateway in gateway_value)
 
                 vlan_ids: set[int] = set()
                 vlan_names = to_list(network_section.get("VLAN", []))
@@ -268,7 +277,7 @@ class SystemdNetworkConfigParser(LinuxNetworkConfigParser):
                         vlan_ids.update(ids)
 
                 # There are possibly multiple route sections, but they are collapsed into one by the parser.
-                route_section: dict[str, any] = config.get("Route", {})
+                route_section: dict[str, Any] = config.get("Route", {})
                 gateway_values = to_list(route_section.get("Gateway", []))
                 gateways.update(filter(None, map(self._parse_gateway, gateway_values)))
 
@@ -276,11 +285,11 @@ class SystemdNetworkConfigParser(LinuxNetworkConfigParser):
 
                 yield UnixInterfaceRecord(
                     source=str(config_file),
-                    type=match_section.get("Type", None),
+                    type=match_section.get("Type"),
                     enabled=None,  # Unknown, dependent on run-time state
                     dhcp_ipv4=dhcp_ipv4,
                     dhcp_ipv6=dhcp_ipv6,
-                    name=match_section.get("Name", None),
+                    name=match_section.get("Name"),
                     dns=list(dns),
                     mac=list(mac_addresses),
                     ip=[interface.ip for interface in ip_interfaces],
@@ -290,20 +299,20 @@ class SystemdNetworkConfigParser(LinuxNetworkConfigParser):
                     configurator="systemd-networkd",
                 )
             except Exception as e:
-                self._target.log.warning("Error parsing network config file %s", config_file, exc_info=e)
+                self._target.log.warning("Error parsing network config file %s", config_file)
+                self._target.log.debug("", exc_info=e)
 
-    def _parse_dns_ip(self, address: str) -> ip_address:
+    def _parse_dns_ip(self, address: str) -> NetAddress:
         """Parse DNS address from systemd network configuration file.
 
         The optional brackets and port number make this hard to parse.
         See https://www.freedesktop.org/software/systemd/man/latest/systemd.network.html and search for DNS.
         """
 
-        match = self.dns_ip_patttern.search(address)
-        if not match:
-            raise ValueError(f"Invalid DNS address format: {address}")
+        if match := self.dns_ip_patttern.search(address):
+            return ip_address(match.group("withoutBrackets") or match.group("withBrackets"))
 
-        return ip_address(match.group("withoutBrackets") or match.group("withBrackets"))
+        raise ValueError(f"Invalid DNS address format: {address}")
 
     def _parse_dhcp(self, value: str | None) -> DhcpConfig:
         """Parse DHCP value from systemd network configuration file to a named tuple (ipv4, ipv6)."""
@@ -319,7 +328,7 @@ class SystemdNetworkConfigParser(LinuxNetworkConfigParser):
 
         raise ValueError(f"Invalid DHCP value: {value}")
 
-    def _parse_gateway(self, value: str | None) -> ip_address | None:
+    def _parse_gateway(self, value: str | None) -> NetAddress | None:
         if (not value) or (value in {"_dhcp4", "_ipv6ra"}):
             return None
 

--- a/dissect/target/plugins/os/windows/network.py
+++ b/dissect/target/plugins/os/windows/network.py
@@ -281,7 +281,8 @@ class WindowsNetworkPlugin(NetworkPlugin):
                     pass
 
                 # Extract the rest of the device information
-                device_info["mac"] = _try_value(subkey, "NetworkAddress")
+                if mac_address := _try_value(subkey, "NetworkAddress"):
+                    device_info["mac"] = [mac_address]
                 device_info["vlan"] = _try_value(subkey, "VlanID")
 
                 if timestamp := _try_value(subkey, "NetworkInterfaceInstallTimestamp"):

--- a/tests/_data/plugins/os/unix/linux/NetworkManager/vlan.nmconnection
+++ b/tests/_data/plugins/os/unix/linux/NetworkManager/vlan.nmconnection
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ebf03683c2328a8497a38cbd038184e0760c1334dda413d7f768ab5d9136807
+size 201

--- a/tests/_data/plugins/os/unix/linux/NetworkManager/vlan2.nmconnection
+++ b/tests/_data/plugins/os/unix/linux/NetworkManager/vlan2.nmconnection
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b0ea3831e424cb610acd39ef1662f9a63d625b90fc962558d9cb31df9af7d00
+size 231

--- a/tests/_data/plugins/os/unix/linux/NetworkManager/wired-static.nmconnection
+++ b/tests/_data/plugins/os/unix/linux/NetworkManager/wired-static.nmconnection
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:887db9ac918cad1d6b62eb796cf97ded4c2791610937fdaa14cf23e872dd8276
+size 409

--- a/tests/_data/plugins/os/unix/linux/NetworkManager/wireless.nmconnection
+++ b/tests/_data/plugins/os/unix/linux/NetworkManager/wireless.nmconnection
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9812f728545918f4c4f1ce519145be73986fab4f9b6140eb6c6ce7a8a11c8c75
+size 130

--- a/tests/_data/plugins/os/unix/linux/systemd.network/20-vlan.netdev
+++ b/tests/_data/plugins/os/unix/linux/systemd.network/20-vlan.netdev
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ffcbd8f72fc41f21e1702332b5c6a8f2c3fb78085f21a3a3435cb3015d4dc23
+size 48

--- a/tests/_data/plugins/os/unix/linux/systemd.network/20-vlan2.netdev
+++ b/tests/_data/plugins/os/unix/linux/systemd.network/20-vlan2.netdev
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38c91d7d3f1f55765d6da2bb76863f8f5be659f28c3e1204a9a17df683acdc58
+size 48

--- a/tests/_data/plugins/os/unix/linux/systemd.network/20-wired-static.network
+++ b/tests/_data/plugins/os/unix/linux/systemd.network/20-wired-static.network
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2644524e0f127e1ce21751b32fa0d166405dd488fe435f4b7eb08faf7e4a8048
+size 132

--- a/tests/_data/plugins/os/unix/linux/systemd.network/30-wired-static-complex.network
+++ b/tests/_data/plugins/os/unix/linux/systemd.network/30-wired-static-complex.network
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef770dec329eb6a7e09987b4c3d472a2e451019463c01e3cd7ad7f3bfb857862
+size 400

--- a/tests/_data/plugins/os/unix/linux/systemd.network/40-wireless-ipv4.network
+++ b/tests/_data/plugins/os/unix/linux/systemd.network/40-wireless-ipv4.network
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7395907b756bd08ba172bece9ce48c144a142999d0956b5e4dfe436e5119d484
+size 51

--- a/tests/_data/plugins/os/unix/linux/systemd.network/40-wireless-ipv6.network
+++ b/tests/_data/plugins/os/unix/linux/systemd.network/40-wireless-ipv6.network
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62a93e614178f653ccf928d2ca658888e029e67beff30ccb0efc88e3df8ac84d
+size 51

--- a/tests/_data/plugins/os/unix/linux/systemd.network/40-wireless.network
+++ b/tests/_data/plugins/os/unix/linux/systemd.network/40-wireless.network
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23a6c023a9c8422c4ca865557653446c3ba5680a6b6e73f57f5361cc4aba7bc2
+size 50

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -8,11 +8,23 @@ from dissect.target.filesystem import VirtualFilesystem
 from dissect.target.helpers import fsutil, utils
 
 
-def test_slugify():
+def test_to_list_single_value() -> None:
+    assert utils.to_list(1) == [1]
+    assert utils.to_list("a") == ["a"]
+    assert utils.to_list(None) == [None]
+
+
+def test_to_list_list_value() -> None:
+    assert utils.to_list([1, 2, 3]) == [1, 2, 3]
+    assert utils.to_list(["a", "b", "c"]) == ["a", "b", "c"]
+    assert utils.to_list([]) == []
+
+
+def test_slugify() -> None:
     assert utils.slugify("foo/bar\\baz bla") == "foo_bar_baz_bla"
 
 
-def test_filesystem_readinto():
+def test_filesystem_readinto() -> None:
     data = b"hello_world"
     mocked_file = mock_open(read_data=b"hello_world")
 
@@ -22,7 +34,7 @@ def test_filesystem_readinto():
     assert len(buffer) == 512
 
 
-def test_helpers_fsutil_year_rollover_helper():
+def test_helpers_fsutil_year_rollover_helper() -> None:
     vfs = VirtualFilesystem()
 
     content = """

--- a/tests/plugins/general/test_network.py
+++ b/tests/plugins/general/test_network.py
@@ -17,7 +17,7 @@ def network_record(request: pytest.FixtureRequest) -> InterfaceRecord:
         name="interface_name",
         type="physical",
         enabled=True,
-        mac="DE:AD:BE:EF:00:00",
+        mac=["DE:AD:BE:EF:00:00"],
         ip=["10.42.42.10"],
         gateway=["10.42.42.1"],
         dns=["8.8.8.8", "1.1.1.1"],

--- a/tests/plugins/os/unix/bsd/osx/test_network.py
+++ b/tests/plugins/os/unix/bsd/osx/test_network.py
@@ -95,7 +95,7 @@ def dhcp(fake_plist: dict) -> Iterator[dict]:
                 (0, "vlan", ["None"]),
                 (0, "enabled", ["True"]),
                 (0, "interface_service_order", ["0"]),
-                (0, "mac", ["None"]),
+                (0, "mac", []),
                 (0, "vlan", ["None"]),
             ],
             1,

--- a/tests/plugins/os/unix/linux/test_network.py
+++ b/tests/plugins/os/unix/linux/test_network.py
@@ -38,7 +38,7 @@ def test_networkmanager_parser(target_linux: Target, fs_linux: VirtualFilesystem
     assert not wired.dhcp_ipv6
     assert wired.enabled is None
     assert wired.last_connected == datetime.fromisoformat("2024-10-29 07:59:54+00:00")
-    assert wired.vlan == [10]
+    assert Counter(wired.vlan) == Counter([10, 11])
     assert wired.source == "/etc/NetworkManager/system-connections/wired-static.nmconnection"
     assert wired.configurator == "NetworkManager"
 
@@ -80,6 +80,7 @@ def test_systemd_network_parser(target_linux: Target, fs_linux: VirtualFilesyste
         posixpath.join(fixture_dir, "40-wireless-ipv6.network"),
     )
     fs_linux.map_file("/etc/systemd/network/20-vlan.netdev", posixpath.join(fixture_dir, "20-vlan.netdev"))
+    fs_linux.map_file("/etc/systemd/network/20-vlan2.netdev", posixpath.join(fixture_dir, "20-vlan2.netdev"))
 
     systemd_network_config_parser = SystemdNetworkConfigParser(target_linux)
     interfaces = list(systemd_network_config_parser.interfaces())
@@ -98,7 +99,7 @@ def test_systemd_network_parser(target_linux: Target, fs_linux: VirtualFilesyste
     assert not wired_static.dhcp_ipv6
     assert wired_static.enabled is None
     assert wired_static.last_connected is None
-    assert wired_static.vlan == [100]
+    assert Counter(wired_static.vlan) == Counter([100, 101])
     assert wired_static.source == "/etc/systemd/network/20-wired-static.network"
     assert wired_static.configurator == "systemd-networkd"
 
@@ -147,7 +148,7 @@ def test_systemd_network_parser(target_linux: Target, fs_linux: VirtualFilesyste
     assert wireless_ipv6.source == "/usr/local/lib/systemd/network/40-wireless-ipv6.network"
 
 
-def test_linux_network_plugin_interfaces(target_linux: Target, fs_linux: VirtualFilesystem) -> None:
+def test_linux_network_plugin_interfaces(target_linux: Target) -> None:
     """Assert that the LinuxNetworkPlugin aggregates from all Config Parsers."""
 
     MockLinuxConfigParser1: LinuxNetworkConfigParser = MagicMock()

--- a/tests/plugins/os/unix/linux/test_network.py
+++ b/tests/plugins/os/unix/linux/test_network.py
@@ -51,7 +51,7 @@ def test_networkmanager_parser(target_linux: Target, fs_linux: VirtualFilesystem
     assert not wired.dhcp_ipv4
     assert not wired.dhcp_ipv6
     assert wired.enabled is None
-    assert wired.last_connected == datetime.fromisoformat("2024-10-29 08:59:54+00:00")
+    assert wired.last_connected == datetime.fromisoformat("2024-10-29 07:59:54+00:00")
     assert wired.vlan == [10]
     assert wired.source == "/etc/NetworkManager/system-connections/wired-static.nmconnection"
     assert wired.configurator == "NetworkManager"

--- a/tests/plugins/os/unix/linux/test_network.py
+++ b/tests/plugins/os/unix/linux/test_network.py
@@ -1,0 +1,167 @@
+import os
+import posixpath
+from datetime import datetime
+from ipaddress import ip_address, ip_network
+from typing import Counter
+from unittest.mock import MagicMock, patch
+
+from dissect.target import Target
+from dissect.target.filesystem import VirtualFilesystem
+from dissect.target.plugins.general.network import UnixInterfaceRecord
+from dissect.target.plugins.os.unix.linux.network import (
+    LinuxConfigParser,
+    LinuxNetworkPlugin,
+    NetworkManagerConfigParser,
+    SystemdNetworkConfigParser,
+)
+
+
+def test_networkmanager_parser(target_linux: Target, fs_linux: VirtualFilesystem) -> None:
+    fixture_dir = "tests/_data/plugins/os/unix/linux/NetworkManager/"
+    fs_linux.makedirs("/etc/NetworkManager/system-connections")
+
+    fs_linux.map_file(
+        "/etc/NetworkManager/system-connections/wired-static.nmconnection",
+        os.path.join(fixture_dir, "wired-static.nmconnection"),
+    )
+    fs_linux.map_file(
+        "/etc/NetworkManager/system-connections/vlan.nmconnection",
+        os.path.join(fixture_dir, "vlan.nmconnection"),
+    )
+    fs_linux.map_file(
+        "/etc/NetworkManager/system-connections/wireless.nmconnection",
+        os.path.join(fixture_dir, "wireless.nmconnection"),
+    )
+
+    network_manager_config_parser = NetworkManagerConfigParser(target_linux)
+    interfaces = list(network_manager_config_parser.interfaces())
+
+    assert len(interfaces) == 2
+    wired, wireless = interfaces
+
+    assert wired.name == "enp0s3"
+    assert wired.type == "ethernet"
+    assert wired.mac == ["08:00:27:5B:4A:EB"]
+    assert Counter(wired.ip) == Counter([ip_address("192.168.2.138"), ip_address("10.1.1.10")])
+    assert wired.dns == [ip_address("88.88.88.88")]
+    assert Counter(wired.gateway) == Counter(
+        [ip_address("192.168.2.2"), ip_address("2620:52:0:2219:222:68ff:fe11:5403"), ip_address("192.168.2.3")]
+    )
+    assert Counter(wired.network) == Counter([ip_network("192.168.2.0/24"), ip_network("10.1.0.0/16")])
+    assert not wired.dhcp_ipv4
+    assert not wired.dhcp_ipv6
+    assert wired.enabled is None
+    assert wired.last_connected == datetime.fromisoformat("2024-10-29 08:59:54+00:00")
+    assert wired.vlan == [10]
+    assert wired.source == "/etc/NetworkManager/system-connections/wired-static.nmconnection"
+    assert wired.configurator == "NetworkManager"
+
+    assert wireless.name == "wlp2s0"
+    assert wireless.type == "wifi"
+    assert wireless.mac == []
+    assert wireless.ip == []
+    assert wireless.dns == []
+    assert wireless.gateway == []
+    assert wireless.network == []
+    assert wireless.dhcp_ipv4
+    assert wireless.dhcp_ipv6
+    assert wireless.enabled is None
+    assert wireless.last_connected is None
+    assert wireless.vlan == []
+    assert wireless.source == "/etc/NetworkManager/system-connections/wireless.nmconnection"
+    assert wireless.configurator == "NetworkManager"
+
+
+def test_systemd_network_parser(target_linux: Target, fs_linux: VirtualFilesystem) -> None:
+    fixture_dir = "tests/_data/plugins/os/unix/linux/systemd.network/"
+    fs_linux.makedirs("/etc/systemd/network")
+
+    fs_linux.map_file(
+        "/etc/systemd/network/20-wired-static.network", posixpath.join(fixture_dir, "20-wired-static.network")
+    )
+    fs_linux.map_file(
+        "/etc/systemd/network/30-wired-static-complex.network",
+        posixpath.join(fixture_dir, "30-wired-static-complex.network"),
+    )
+    fs_linux.map_file(
+        "/usr/lib/systemd/network/40-wireless.network", posixpath.join(fixture_dir, "40-wireless.network")
+    )
+    fs_linux.map_file("/etc/systemd/network/20-vlan.netdev", posixpath.join(fixture_dir, "20-vlan.netdev"))
+
+    systemd_network_config_parser = SystemdNetworkConfigParser(target_linux)
+    interfaces = list(systemd_network_config_parser.interfaces())
+
+    assert len(interfaces) == 3
+
+    wired_static, wired_static_complex, wireless = interfaces
+
+    assert wired_static.name == "enp1s0"
+    assert wired_static.type is None
+    assert wired_static.mac == ["aa::bb::cc::dd::ee::ff"]
+    assert wired_static.ip == [ip_address("10.1.10.9")]
+    assert wired_static.dns == [ip_address("10.1.10.1")]
+    assert wired_static.gateway == [ip_address("10.1.10.1")]
+    assert wired_static.network == [ip_network("10.1.10.0/24")]
+    assert not wired_static.dhcp_ipv4
+    assert not wired_static.dhcp_ipv6
+    assert wired_static.enabled is None
+    assert wired_static.last_connected is None
+    assert wired_static.vlan == [100]
+    assert wired_static.source == "/etc/systemd/network/20-wired-static.network"
+    assert wired_static.configurator == "systemd-networkd"
+
+    assert wired_static_complex.name == "enp1s0"
+    assert wired_static_complex.type == "ether"
+    assert Counter(wired_static_complex.mac) == Counter(
+        ["aa::bb::cc::dd::ee::ff", "ff::ee::dd::cc::bb::aa", "cc::ff::bb::aa::dd", "bb::aa::dd::cc::ff"]
+    )
+    assert Counter(wired_static_complex.ip) == Counter([ip_address("10.1.10.9"), ip_address("10.1.9.10")])
+    assert Counter(wired_static_complex.dns) == Counter(
+        [ip_address("10.1.10.1"), ip_address("10.1.10.2"), ip_address("1111:2222::3333")]
+    )
+    assert Counter(wired_static_complex.gateway) == Counter(
+        [ip_address("10.1.6.3"), ip_address("10.1.10.2"), ip_address("10.1.9.3")]
+    )
+    assert Counter(wired_static_complex.network) == Counter([ip_network("10.1.0.0/16"), ip_network("10.1.9.0/24")])
+    assert not wired_static_complex.dhcp_ipv4
+    assert not wired_static_complex.dhcp_ipv6
+    assert wired_static_complex.enabled is None
+    assert wired_static_complex.last_connected is None
+    assert wired_static_complex.vlan == []
+    assert wired_static_complex.source == "/etc/systemd/network/30-wired-static-complex.network"
+    assert wired_static_complex.configurator == "systemd-networkd"
+
+    assert wireless.name == "wlp2s0"
+    assert wireless.type == "wifi"
+    assert wireless.mac == []
+    assert wireless.ip == []
+    assert wireless.dns == []
+    assert wireless.gateway == []
+    assert wireless.network == []
+    assert wireless.dhcp_ipv4
+    assert wireless.dhcp_ipv6
+    assert wireless.enabled is None
+    assert wireless.last_connected is None
+    assert wired_static_complex.vlan == []
+    assert wireless.source == "/usr/lib/systemd/network/40-wireless.network"
+    assert wired_static_complex.configurator == "systemd-networkd"
+
+
+def test_linux_network_plugin_interfaces(target_linux: Target, fs_linux: VirtualFilesystem) -> None:
+    """Assert that the LinuxNetworkPlugin aggregates from all Config Parsers."""
+
+    MockLinuxConfigParser1: LinuxConfigParser = MagicMock()
+    MockLinuxConfigParser1.return_value.interfaces.return_value = []
+
+    MockLinuxConfigParser2: LinuxConfigParser = MagicMock()
+    MockLinuxConfigParser2.return_value.interfaces.return_value = [UnixInterfaceRecord()]
+
+    with patch(
+        "dissect.target.plugins.os.unix.linux.network.MANAGERS", [MockLinuxConfigParser1, MockLinuxConfigParser2]
+    ):
+        linux_network_plugin = LinuxNetworkPlugin(target_linux)
+        interfaces = list(linux_network_plugin.interfaces())
+
+        assert len(interfaces) == 1
+        MockLinuxConfigParser1.return_value.interfaces.assert_called_once()
+        MockLinuxConfigParser2.return_value.interfaces.assert_called_once()

--- a/tests/plugins/os/windows/test_network.py
+++ b/tests/plugins/os/windows/test_network.py
@@ -271,7 +271,7 @@ def test_windows_network_none(
                     "ip": ["192.168.0.10"],
                     "dns": ["192.168.0.2"],
                     "gateway": ["192.168.0.1"],
-                    "mac": "FE:EE:EE:EE:EE:ED",
+                    "mac": ["FE:EE:EE:EE:EE:ED"],
                     "subnetmask": ["255.255.255.0"],
                     "network": ["192.168.0.0/24"],
                     "first_connected": datetime.fromisoformat("2012-12-21 00:00:00+00:00"),
@@ -287,7 +287,7 @@ def test_windows_network_none(
                     "ip": ["10.0.0.10"],
                     "dns": ["10.0.0.2"],
                     "gateway": ["10.0.0.1"],
-                    "mac": "FE:EE:EE:EE:EE:ED",
+                    "mac": ["FE:EE:EE:EE:EE:ED"],
                     "subnetmask": ["255.255.255.0"],
                     "network": ["10.0.0.0/24"],
                     "first_connected": datetime.fromisoformat("2012-12-21 00:00:00+00:00"),
@@ -344,7 +344,7 @@ def test_network_dhcp_and_static(
             ips.update(interface.ip)
             dns.update(interface.dns)
             gateways.update(interface.gateway)
-            macs.add(interface.mac)
+            macs.update(interface.mac)
 
             assert interface.ip == expected["ip"]
             assert interface.dns == expected["dns"]


### PR DESCRIPTION
Implement the `NetworkPlugin` for Linux.

Initial support is for:
- NetworkManager
- systemd-networkd

~~The `ips` method of the Linux OS plugin is implemented using the new parser; other methods such as `dns` and `dhcp` still use the legacy solution until we implemented parsers for the remaining network configuration systems. Let me know if this is wrong.~~ 

Update: I retained the old `ips`. The new implementation can be invoked by prefixing with the `network` namespace, i.e. `-f network.interfaces`

While doing research I discovered  that systemd supports "drop-in"  configuration directories (see https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html) . Since this feature applicable to all systemd domains and not only networking, I propose we extend the systemd config parser with support for this (https://github.com/fox-it/dissect.target/issues/933). I checked this with Stefan de Reuver.

Keep in mind that unlike the OSX and Windows implementations, which report actual values,  the Linux implementation reports configuration of interfaces, or "potential" interfaces, as there is often no way to determine which configuration was active. I think this results in some friction with the interface records; for example, the mac address needed to be extended to a list.

Closes #776   