### PR TITLE
Add fixes for target-shell prompt

### DIFF
--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -21,9 +21,9 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Any, BinaryIO, Callable, Iterator, TextIO
 
+from dissect.cstruct import hexdump
 from flow.record import RecordOutput
 
-from dissect.cstruct import hexdump
 from dissect.target.exceptions import (
     PluginError,
     RegistryError,


### PR DESCRIPTION
There was an issue with the `TargetCmd` in the case the prompt was defined in the config file, yet didn't contain `{cmd}` or `{base}`. This fixes that issue

and some fixes for typing consistency