### PR TITLE
Allow RegfValue.type to fall back to int

### DIFF
--- a/dissect/target/helpers/regutil.py
+++ b/dissect/target/helpers/regutil.py
@@ -707,8 +707,12 @@ class RegfValue(RegistryValue):
         return self.kv.value
 
     @property
-    def type(self) -> RegistryValueType:
-        return RegistryValueType(self.kv.type)
+    def type(self) -> RegistryValueType | int:
+        try:
+            return RegistryValueType(self.kv.type)
+
+        except ValueError:
+            return self.kv.type
 
 
 class RegFlex:

--- a/dissect/target/helpers/regutil.py
+++ b/dissect/target/helpers/regutil.py
@@ -52,7 +52,7 @@ class RegistryValueType(IntEnum):
     QWORD = c_regf.REG_QWORD
 
     @classmethod
-    def _missing_(cls, value):
+    def _missing_(cls, value: int) -> IntEnum:
         # Allow values other than defined members
         member = int.__new__(cls, value)
         member._name_ = None

--- a/dissect/target/helpers/regutil.py
+++ b/dissect/target/helpers/regutil.py
@@ -724,7 +724,7 @@ class RegfValue(RegistryValue):
         return self.kv.value
 
     @property
-    def type(self) -> RegistryValueType | int:
+    def type(self) -> RegistryValueType:
         return RegistryValueType(self.kv.type)
 
 

--- a/tests/helpers/test_regutil.py
+++ b/tests/helpers/test_regutil.py
@@ -1,4 +1,4 @@
-from typing import Union
+from __future__ import annotations
 
 import pytest
 from dissect.regf import c_regf
@@ -173,7 +173,7 @@ def key_collection(hivecollection: HiveCollection) -> KeyCollection:
         ("some\\other\\bla\\", "bla"),
     ],
 )
-def test_registry_key_get(hive: RegistryHive, key_path: str, key_name: Union[str, RegistryKeyNotFoundError]) -> None:
+def test_registry_key_get(hive: RegistryHive, key_path: str, key_name: str | RegistryKeyNotFoundError) -> None:
     key = hive.key("\\")
 
     if key_name is RegistryKeyNotFoundError:
@@ -195,7 +195,7 @@ def test_registry_key_get(hive: RegistryHive, key_path: str, key_name: Union[str
 def test_key_collection_get(
     key_collection: KeyCollection,
     key_path: str,
-    key_name: Union[str, RegistryKeyNotFoundError],
+    key_name: str | RegistryKeyNotFoundError,
 ) -> None:
     if key_name is RegistryKeyNotFoundError:
         with pytest.raises(key_name):

--- a/tests/helpers/test_regutil.py
+++ b/tests/helpers/test_regutil.py
@@ -1,6 +1,7 @@
 from typing import Union
 
 import pytest
+from dissect.regf import c_regf
 
 from dissect.target.helpers.regutil import (
     HiveCollection,
@@ -339,3 +340,28 @@ def test_glob_ext(key_collection: KeyCollection, pattern: str, key_paths: list[s
         collection_paths.append(key_collection.path)
 
     assert sorted(collection_paths) == sorted(key_paths)
+
+
+@pytest.mark.parametrize(
+    "input, expected_name, expected_value",
+    [
+        (c_regf.REG_NONE, "NONE", 0),
+        (c_regf.REG_SZ, "SZ", 1),
+        (c_regf.REG_EXPAND_SZ, "EXPAND_SZ", 2),
+        (c_regf.REG_BINARY, "BINARY", 3),
+        (c_regf.REG_DWORD, "DWORD", 4),
+        (c_regf.REG_DWORD_BIG_ENDIAN, "DWORD_BIG_ENDIAN", 5),
+        (c_regf.REG_LINK, "LINK", 6),
+        (c_regf.REG_MULTI_SZ, "MULTI_SZ", 7),
+        (c_regf.REG_RESOURCE_LIST, "RESOURCE_LIST", 8),
+        (c_regf.REG_FULL_RESOURCE_DESCRIPTOR, "FULL_RESOURCE_DESCRIPTOR", 9),
+        (c_regf.REG_RESOURCE_REQUIREMENTS_LIST, "RESOURCE_REQUIREMENTS_LIST", 10),
+        (c_regf.REG_QWORD, "QWORD", 11),
+        (1337, None, 1337),
+    ],
+)
+def test_registry_value_type_enum(input: int, expected_name: str | None, expected_value: int) -> None:
+    """test if registry value types are not parsed strictly within the Enum"""
+    regf_value = RegistryValueType(input)
+    assert regf_value == expected_value
+    assert regf_value.name == expected_name


### PR DESCRIPTION
This PR fixes edge cases where `RegfValue.type` cannot be translated to the `RegistryValueType` enum.