### PR TITLE
Microsoft Office add-in detection 

### DIFF
--- a/dissect/target/helpers/regutil.py
+++ b/dissect/target/helpers/regutil.py
@@ -179,7 +179,7 @@ class RegistryKey:
         except RegistryValueNotFoundError:
             if default is self.__marker:
                 raise
-            return VirtualValue(VirtualHive(), value, default)
+            return VirtualValue(self.hive, value, default)
 
     def _value(self, value: str) -> RegistryValue:
         raise NotImplementedError()

--- a/dissect/target/helpers/regutil.py
+++ b/dissect/target/helpers/regutil.py
@@ -26,7 +26,7 @@ GLOB_MAGIC_REGEX = re.compile(r"[*?[]")
 KeyType = Union[regf.IndexLeaf, regf.FastLeaf, regf.HashLeaf, regf.IndexRoot, regf.NamedKey]
 """The possible key types that can be returned from the registry."""
 
-ValueType = Union[int, str, bytes, list[str]]
+ValueType = Union[int, str, bytes, list[str], None]
 """The possible value types that can be returned from the registry."""
 
 

--- a/dissect/target/helpers/regutil.py
+++ b/dissect/target/helpers/regutil.py
@@ -26,7 +26,7 @@ GLOB_MAGIC_REGEX = re.compile(r"[*?[]")
 KeyType = Union[regf.IndexLeaf, regf.FastLeaf, regf.HashLeaf, regf.IndexRoot, regf.NamedKey]
 """The possible key types that can be returned from the registry."""
 
-ValueType = Union[int, str, bytes, list[str], None]
+ValueType = Union[int, str, bytes, list[str]]
 """The possible value types that can be returned from the registry."""
 
 

--- a/dissect/target/helpers/regutil.py
+++ b/dissect/target/helpers/regutil.py
@@ -10,7 +10,7 @@ from enum import IntEnum
 from functools import cached_property
 from io import BytesIO
 from pathlib import Path
-from typing import BinaryIO, Iterator, Optional, TextIO, Union
+from typing import BinaryIO, Iterator, NewType, Optional, TextIO, Union
 
 from dissect.regf import c_regf, regf
 
@@ -161,9 +161,10 @@ class RegistryKey:
         """Returns a list of subkeys from this key."""
         raise NotImplementedError()
 
-    __marker = object()
+    Marker = NewType("Marker", object)
+    __marker = Marker(object())
 
-    def value(self, value: str, default: ValueType = __marker) -> RegistryValue:
+    def value(self, value: str, default: ValueType | Marker = __marker) -> RegistryValue:
         """Returns a specific value from this key.
 
         Args:

--- a/dissect/target/helpers/regutil.py
+++ b/dissect/target/helpers/regutil.py
@@ -26,7 +26,7 @@ GLOB_MAGIC_REGEX = re.compile(r"[*?[]")
 KeyType = Union[regf.IndexLeaf, regf.FastLeaf, regf.HashLeaf, regf.IndexRoot, regf.NamedKey]
 """The possible key types that can be returned from the registry."""
 
-ValueType = Union[int, str, bytes, list[str]]
+ValueType = Union[int, str, bytes, list[str], None]
 """The possible value types that can be returned from the registry."""
 
 
@@ -171,6 +171,18 @@ class RegistryKey:
             RegistryValueNotFoundError: If this key has no value with the requested name.
         """
         raise NotImplementedError()
+
+    def value_or_default(self, value: str, default: ValueType = None) -> RegistryValue:
+        """Returns a specific value from this key, or a default value if it does not exist.
+
+        Args:
+            value: The name of the value to retrieve.
+            default: The default value to return if the value does not exist.
+        """
+        try:
+            return self.value(value)
+        except RegistryValueNotFoundError:
+            return VirtualValue(VirtualHive(), value, default)
 
     def values(self) -> list[RegistryValue]:
         """Returns a list of all the values from this key."""

--- a/dissect/target/helpers/utils.py
+++ b/dissect/target/helpers/utils.py
@@ -40,7 +40,7 @@ def to_list(value: T | list[T] | None) -> list[T]:
     """
     if value is None:
         return []
-    elif not isinstance(value, list):
+    if not isinstance(value, list):
         return [value]
 
     return value

--- a/dissect/target/helpers/utils.py
+++ b/dissect/target/helpers/utils.py
@@ -29,8 +29,8 @@ def findall(buf: bytes, needle: bytes) -> Iterator[int]:
 T = TypeVar("T")
 
 
-def to_list(value: T | list[T]) -> list[T]:
-    """Convert a single value or a list of values to a list.
+def to_list(value: T | list[T] | None) -> list[T]:
+    """Convert a single value or a list of values to a list. A value of `None` is converted to an empty list.
 
     Args:
         value: The value to convert.
@@ -38,8 +38,11 @@ def to_list(value: T | list[T]) -> list[T]:
     Returns:
         A list of values.
     """
-    if not isinstance(value, list):
+    if value is None:
+        return []
+    elif not isinstance(value, list):
         return [value]
+
     return value
 
 

--- a/dissect/target/helpers/utils.py
+++ b/dissect/target/helpers/utils.py
@@ -30,7 +30,7 @@ T = TypeVar("T")
 
 
 def to_list(value: T | list[T] | None) -> list[T]:
-    """Convert a single value or a list of values to a list. A value of `None` is converted to an empty list.
+    """Convert a single value or a list of values to a list. A value of ``None`` is converted to an empty list.
 
     Args:
         value: The value to convert.

--- a/dissect/target/loaders/cb.py
+++ b/dissect/target/loaders/cb.py
@@ -161,7 +161,7 @@ class CbRegistryKey(RegistryKey):
     def subkeys(self) -> list[CbRegistryKey]:
         return list(map(self.subkey, self.data["sub_keys"]))
 
-    def value(self, value: str) -> str:
+    def _value(self, value: str) -> str:
         reg_value = value.lower()
         for val in self.values():
             if val.name.lower() == reg_value:

--- a/dissect/target/loaders/cb.py
+++ b/dissect/target/loaders/cb.py
@@ -25,7 +25,12 @@ from dissect.target.exceptions import (
 )
 from dissect.target.filesystems.cb import CbFilesystem
 from dissect.target.helpers.fsutil import TargetPath
-from dissect.target.helpers.regutil import RegistryHive, RegistryKey, RegistryValue
+from dissect.target.helpers.regutil import (
+    RegistryHive,
+    RegistryKey,
+    RegistryValue,
+    ValueType,
+)
 from dissect.target.loader import Loader
 from dissect.target.plugins.os.windows.registry import RegistryPlugin
 
@@ -161,7 +166,7 @@ class CbRegistryKey(RegistryKey):
     def subkeys(self) -> list[CbRegistryKey]:
         return list(map(self.subkey, self.data["sub_keys"]))
 
-    def _value(self, value: str) -> str:
+    def _value(self, value: str) -> CbRegistryValue:
         reg_value = value.lower()
         for val in self.values():
             if val.name.lower() == reg_value:
@@ -197,7 +202,7 @@ class CbRegistryValue(RegistryValue):
         return self._name
 
     @property
-    def value(self) -> str:
+    def value(self) -> ValueType:
         return self._value
 
     @property

--- a/dissect/target/loaders/smb.py
+++ b/dissect/target/loaders/smb.py
@@ -22,7 +22,12 @@ from dissect.target.exceptions import (
 )
 from dissect.target.filesystems.smb import SmbFilesystem
 from dissect.target.helpers.fsutil import TargetPath
-from dissect.target.helpers.regutil import RegistryHive, RegistryKey, RegistryValue
+from dissect.target.helpers.regutil import (
+    RegistryHive,
+    RegistryKey,
+    RegistryValue,
+    ValueType,
+)
 from dissect.target.loader import Loader
 from dissect.target.plugins.os.windows._os import WindowsPlugin
 from dissect.target.plugins.os.windows.registry import RegistryPlugin
@@ -308,7 +313,7 @@ class SmbRegistryKey(RegistryKey):
 
         return subkeys
 
-    def _value(self, value: str) -> str:
+    def _value(self, value: str) -> SmbRegistryValue:
         reg_value = value.lower()
         for val in self.values():
             if val.name.lower() == reg_value:
@@ -351,7 +356,7 @@ class SmbRegistryValue(RegistryValue):
         return self._name
 
     @property
-    def value(self) -> str:
+    def value(self) -> ValueType:
         return self._value
 
     @property

--- a/dissect/target/loaders/smb.py
+++ b/dissect/target/loaders/smb.py
@@ -308,7 +308,7 @@ class SmbRegistryKey(RegistryKey):
 
         return subkeys
 
-    def value(self, value: str) -> str:
+    def _value(self, value: str) -> str:
         reg_value = value.lower()
         for val in self.values():
             if val.name.lower() == reg_value:

--- a/dissect/target/plugins/apps/productivity/msoffice.py
+++ b/dissect/target/plugins/apps/productivity/msoffice.py
@@ -286,7 +286,7 @@ class MSOffice(Plugin):
         source_locations = [source_location.get("DefaultValue") for source_location in source_location_elements]
 
         display_name_element = manifest_tree.find(".//DisplayName", ns)
-        display_name = display_name_element.get("DefaultValue") if display_name_element else None
+        display_name = display_name_element.get("DefaultValue") if display_name_element is not None else None
 
         return OfficeWebAddinRecord(
             name=display_name,

--- a/dissect/target/plugins/apps/productivity/msoffice.py
+++ b/dissect/target/plugins/apps/productivity/msoffice.py
@@ -31,6 +31,7 @@ OfficeWebAddinRecord = TargetRecordDescriptor(
         ("path", "manifest"),
         ("string", "version"),
         ("string", "provider_name"),
+        ("datetime", "modification_time"),
     ],
 )
 
@@ -294,6 +295,7 @@ class MSOffice(Plugin):
             version=manifest_tree.findtext(".//Version", namespaces=ns),
             provider_name=manifest_tree.findtext(".//ProviderName", namespaces=ns),
             source_locations=filter(None, source_locations),
+            modification_time=manifest_path.stat().st_mtime,
         )
 
     def _office_install_root(self, component: str) -> str:

--- a/dissect/target/plugins/apps/productivity/msoffice.py
+++ b/dissect/target/plugins/apps/productivity/msoffice.py
@@ -232,7 +232,7 @@ class MSOffice(Plugin):
 
         for user_details in self.target.user_details.all_with_home():
             for manifest_path in user_details.home_path.glob(self.WEB_ADDIN_MANIFEST_GLOB):
-                if manifest_path.is_file():
+                if manifest_path.is_file() and manifest_path.suffix != ".metadata":
                     yield manifest_path
 
     def _walk_startup_folder(self, startup_folder: str, user_sid: str | None = None) -> Iterable[OfficeStartupItem]:

--- a/dissect/target/plugins/apps/productivity/msoffice.py
+++ b/dissect/target/plugins/apps/productivity/msoffice.py
@@ -176,7 +176,6 @@ class MSOffice(Plugin):
         These add-ins can interact with the content in Office documents and provide additional features and capabilities.
         The WEF folder contains cached data and manifests for Office Web Add-ins.
         The manifest includes information about the add-ins, such as their source locations, display names, and other metadata.
-        The folder is used by Office applications to load and manage the add-ins.
 
         References:
             - https://learn.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins
@@ -190,7 +189,7 @@ class MSOffice(Plugin):
             name (string): The display name of the add-in.
             version (string): The version of the add-in.
             provider_name (string): The provider name of the add-in.
-            source_locations (string[]): URLs referencing the source code of the add-in.
+            source_locations (string[]): URLs referencing the web assets of the add-in (such as javascript and html files).
         """  # noqa: E501
 
         for manifest_file in self._wef_cache_folders():

--- a/dissect/target/plugins/apps/productivity/msoffice.py
+++ b/dissect/target/plugins/apps/productivity/msoffice.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+from typing import Iterable, Iterator, Set
+from xml.etree.ElementTree import Element
+
+from defusedxml import ElementTree
+from flow.record.fieldtypes import windows_path
+
+from dissect.target.exceptions import RegistryError, UnsupportedPluginError
+from dissect.target.helpers import fsutil
+from dissect.target.helpers.record import TargetRecordDescriptor
+from dissect.target.helpers.regutil import KeyCollection
+from dissect.target.helpers.utils import to_list
+from dissect.target.plugin import Plugin, export
+from dissect.target.target import Target
+
+OfficeStartupItem = TargetRecordDescriptor(
+    "productivity/msoffice/startup_item", [("path", "path"), ("datetime", "creation_time")]
+)
+
+# Web add-in
+OfficeWebAddinRecord = TargetRecordDescriptor(
+    "productivity/msoffice/web_addin",
+    [
+        ("string[]", "source_locations"),
+        ("string", "name"),
+        ("path", "manifest"),
+        ("string", "version"),
+        ("string", "provider_name"),
+    ],
+)
+
+# COM and VSTO add-ins
+OfficeNativeAddinRecord = TargetRecordDescriptor(
+    "productivity/msoffice/native_addin",
+    [
+        ("string", "name"),
+        ("string", "type"),
+        ("path[]", "codebases"),
+        ("string", "load_behavior"),
+        ("path", "manifest"),
+    ],
+)
+
+
+class ClickOnceDeploymentManifestParser:
+    """Parser for information about vsto plugins"""
+
+    XML_NAMESPACE = {"": "urn:schemas-microsoft-com:asm.v2"}
+
+    def __init__(self, target: Target, user_sid: str) -> None:
+        self._target = target
+        self._user_sid = user_sid
+        self._visited_manifests: Set[Path] = set()
+        self._codebases: Set[Path] = set()
+
+    def find_codebases(self, manifest_path: str) -> Iterable[str]:
+        """Dig for executables given a manifest"""
+
+        self._visited_manifests.clear()
+        self._codebases.clear()
+        return self._parse_manifest(manifest_path)
+
+    def _parse_manifest(self, manifest_path_str: str) -> Set[Path]:
+        # See https://learn.microsoft.com/en-us/visualstudio/deployment/clickonce-deployment-manifest?view=vs-2022
+
+        manifest_path: Path = self._target.resolve(manifest_path_str, self._user_sid)
+        if manifest_path in self._visited_manifests:
+            return self._codebases  # Prevent cycles
+
+        self._visited_manifests.add(manifest_path)
+        try:
+            manifest_tree: Element = ElementTree.fromstring(manifest_path.read_text("utf-8-sig"))
+        except Exception as e:
+            self._target.log.warning("Error parsing manifest %s", manifest_path)
+            self._target.log.debug("", exc_info=e)
+            return set()
+
+        dependent_assemblies = manifest_tree.findall(".//dependentAssembly", self.XML_NAMESPACE)
+        for dependent_assembly in dependent_assemblies:
+            self._parse_dependent_assembly(dependent_assembly, manifest_path.parent)
+
+        return self._codebases
+
+    def _parse_dependent_assembly(self, dependent_assembly: Element, cwd: Path) -> None:
+        # See https://learn.microsoft.com/en-us/visualstudio/deployment/dependency-element-clickonce-deployment?view=vs-2022#dependentassembly # noqa: E501
+
+        if dependent_assembly.get("dependencyType") != "install":
+            return  # Ignore prerequisites dependencies
+
+        if not (codebase_str_path := dependent_assembly.get("codebase")):
+            return
+
+        codebase_str_path = fsutil.abspath(codebase_str_path, str(cwd), alt_separator=self._target.fs.alt_separator)
+        codebase_path: Path = self._target.fs.path(codebase_str_path)
+        if not codebase_path.exists():
+            return  # Ignore files which are not actually installed, for example due to language settings
+
+        if codebase_path.name.endswith(".manifest"):
+            self._parse_manifest(str(codebase_path))  # Yes, a codebase can point to another manifest
+            return
+
+        self._codebases.add(codebase_path)
+
+
+class MSOffice(Plugin):
+    """Microsoft Office productivity suite plugin."""
+
+    __namespace__ = "msoffice"
+
+    HIVES = ["HKLM", "HKCU"]
+    OFFICE_KEY = "Software\\Microsoft\\Office"
+    OFFICE_COMPONENTS = ["Access", "Excel", "Outlook", "PowerPoint", "Word", "OneNote"]
+    ADD_IN_KEY = "Addins"
+    WEB_ADDIN_MANIFEST_GLOB = "AppData/Local/Microsoft/Office/16.0/Wef/**/Manifests/**/*"
+    OFFICE_DEFAULT_USER_STARTUP = [
+        "%APPDATA%/Microsoft/Templates",
+        "%APPDATA%/Microsoft/Word/Startup",
+        "%APPDATA%/Microsoft/Excel/XLSTART",
+    ]
+
+    OFFICE_DEFAULT_ROOT = "C:/Program Files/Microsoft Office/root/Office16/"
+
+    # Office is fixed at version 16.0 since Microsoft Office 2016 (released in 2015)
+    OFFICE_STARTUP_OPTIONS = [
+        ("Software\\Microsoft\\Office\\16.0\\Word\\Options", "STARTUP-PATH"),
+        ("Software\\Microsoft\\Office\\16.0\\Word\\Options", "UserTemplates"),
+        ("Software\\Microsoft\\Office\\16.0\\Excel\\Options", "AltStartup"),
+    ]
+
+    CLASSES_ROOTS = [
+        "HKCR",
+        # Click To Run Application Virtualization:
+        "HKLM\\SOFTWARE\\Microsoft\\Office\\ClickToRun\\REGISTRY\\MACHINE\\Software\\Classes",
+        # For 32-bit software running under 64-bit Windows:
+        "HKLM\\SOFTWARE\\Wow6432Node\\Classes",
+    ]
+
+    def check_compatible(self) -> None:
+        if not self.target.has_function("registry") or not list(self.target.registry.keys(f"HKLM\\{self.OFFICE_KEY}")):
+            raise UnsupportedPluginError("Registry key not found: %s", self.OFFICE_KEY)
+
+    @export(record=[OfficeWebAddinRecord, OfficeNativeAddinRecord, OfficeStartupItem])
+    def all(self) -> Iterator[OfficeWebAddinRecord | OfficeNativeAddinRecord | OfficeStartupItem]:
+        """Aggregate to list all add-in types and startup items"""
+
+        yield from self.startup()
+        yield from self.web()
+        yield from self.native()
+
+    @export(record=OfficeWebAddinRecord)
+    def web(self) -> Iterator[OfficeWebAddinRecord]:
+        """List all web add-ins by parsing the manifests in the web extension framework cache"""
+
+        for manifest_file in self._wef_cache_folders():
+            try:
+                yield self._parse_web_addin_manifest(manifest_file)
+            except Exception as e:
+                self.target.log.warning("Error parsing web-addin manifest %s", manifest_file)
+                self.target.log.debug("", exc_info=e)
+
+    @export(record=OfficeNativeAddinRecord)
+    def native(self) -> Iterator[OfficeNativeAddinRecord]:
+        """List all native (COM / vsto) add-ins by parsing the registry and manifest files."""
+
+        addin_path_tuples = itertools.product(self.HIVES, [self.OFFICE_KEY], self.OFFICE_COMPONENTS, [self.ADD_IN_KEY])
+        for addin_path_tuple in addin_path_tuples:
+            addin_path = "\\".join(addin_path_tuple)
+            addin_key: KeyCollection = self.target.registry.key_or_empty(addin_path)
+
+            for addin in itertools.chain.from_iterable(addin_key.subkeys()):
+                key_owner = self.target.registry.get_user(addin)
+                sid = key_owner.sid if key_owner else None
+
+                if manifest_path_str := addin.value_or_default("Manifest").value:
+                    addin_type = "vsto"
+                    executables = self._parse_vsto_manifest(manifest_path_str, sid)
+                else:
+                    addin_type = "com"
+                    dll_str = self._lookup_com_executable(addin.name)
+                    executables = to_list(self.target.resolve(dll_str, sid))
+
+                yield OfficeNativeAddinRecord(
+                    name=addin.value_or_default("FriendlyName").value,
+                    load_behavior=self._parse_load_behavior(addin),
+                    type=addin_type,
+                    manifest=windows_path(manifest_path_str) if manifest_path_str else None,
+                    codebases=executables,
+                )
+
+    @export(record=OfficeStartupItem)
+    def startup(self) -> Iterable[OfficeStartupItem]:
+        """List items in startup paths.
+
+        Note that on Office 365, legacy addins such as .wll are no longer automatically loaded.
+        """
+
+        # Get items from default machine-scoped startup folder
+        for machine_startup_folder in self._machine_startup_folders():
+            yield from self._walk_startup_folder(machine_startup_folder)
+
+        # Get items from default user-scoped startup folder
+        for user in self.target.user_details.all_with_home():
+            for user_startup_folder in self.OFFICE_DEFAULT_USER_STARTUP:
+                yield from self._walk_startup_folder(user_startup_folder, user.user.sid)
+
+        # Get items from alternate machine or user scoped startup folder
+        for hive in self.HIVES:
+            for options_key, startup_value in self.OFFICE_STARTUP_OPTIONS:
+                for alt_startup_folder in self.target.registry.value_or_empty(f"{hive}\\{options_key}", startup_value):
+                    user = self.target.registry.get_user(alt_startup_folder)
+                    user_sid = user.sid if user else None
+                    yield from self._walk_startup_folder(alt_startup_folder.value, user_sid)
+
+    def _wef_cache_folders(self) -> Iterable[Path]:
+        """List cache folders which contain office web-addin data."""
+
+        for user_details in self.target.user_details.all_with_home():
+            for manifest_path in user_details.home_path.glob(self.WEB_ADDIN_MANIFEST_GLOB):
+                if manifest_path.is_file():
+                    yield manifest_path
+
+    def _walk_startup_folder(self, startup_folder: str, user_sid: str | None = None) -> Iterable[OfficeStartupItem]:
+        """Resolve the given path and return all statup items"""
+
+        resolved_startup_folder_str = self.target.resolve(startup_folder, user_sid)
+        resolved_startup_folder: Path = self.target.fs.path(resolved_startup_folder_str)
+        if not resolved_startup_folder.exists() or not resolved_startup_folder.is_dir():
+            return
+
+        for current_path, _, plugin_files in resolved_startup_folder.walk():
+            for plugin_file in plugin_files:
+                item_startup = current_path / plugin_file
+                yield OfficeStartupItem(path=item_startup, creation_time=item_startup.stat().st_birthtime)
+
+    def _lookup_com_executable(self, prog_id: str) -> str | None:
+        """Lookup the com executable given a prog id using the registry."""
+
+        for classes_root in self.CLASSES_ROOTS:
+            try:
+                cls_id = self.target.registry.value(f"{classes_root}\\{prog_id}\\CLSID", "(Default)").value
+                inproc_key = f"{classes_root}\\CLSID\\{cls_id}\\InprocServer32"
+                return self.target.registry.value(inproc_key, "(Default)").value
+            except RegistryError:
+                pass
+
+    def _parse_vsto_manifest(self, manifest_path: str, user_sid: str) -> Iterable[str]:
+        """Parse a vsto manifest.
+
+        Non-local manifests, i.e. not ending with suffix "vstolocal" are listed but skipped.
+        """
+
+        if not manifest_path.endswith("vstolocal"):
+            self.target.log.warning("Parsing of remote vsto manifest %s is not supported")
+            return [manifest_path]
+
+        manifest_parser = ClickOnceDeploymentManifestParser(self.target, user_sid)
+        return manifest_parser.find_codebases(manifest_path.removesuffix("|vstolocal"))
+
+    def _parse_web_addin_manifest(self, manifest_path: Path) -> OfficeWebAddinRecord:
+        """Parses a web addin manifest.
+
+        See https://learn.microsoft.com/en-us/office/dev/add-ins/develop/xml-manifest-overview?tabs=tabid-1
+        """
+
+        ns = {"": "http://schemas.microsoft.com/office/appforoffice/1.1"}
+
+        manifest_tree: Element = ElementTree.fromstring(manifest_path.read_text("utf-8-sig"))
+
+        source_location_elements = manifest_tree.findall(".//SourceLocation", ns)
+        source_locations = [source_location.get("DefaultValue") for source_location in source_location_elements]
+
+        display_name_element = manifest_tree.find(".//DisplayName", ns)
+        display_name = display_name_element.get("DefaultValue") if display_name_element is not None else None
+
+        return OfficeWebAddinRecord(
+            name=display_name,
+            manifest=manifest_path,
+            version=manifest_tree.findtext(".//Version", namespaces=ns),
+            provider_name=manifest_tree.findtext(".//ProviderName", namespaces=ns),
+            source_locations=filter(None, source_locations),
+        )
+
+    def _office_install_root(self, component: str) -> str:
+        """Return the installation root for a office component"""
+
+        # Typically, all components share the same root.
+        # Curiously enough, the "Common" component has no InstallRoot defined.
+        key = f"HKLM\\{self.OFFICE_KEY}\\16.0\\{component}\\InstallRoot"
+        if office_key := self.target.registry.value_or_empty(key, "Path"):
+            return office_key.value
+
+        return self.OFFICE_DEFAULT_ROOT
+
+    def _machine_startup_folders(self) -> Iterable[str]:
+        """Return machine-scoped office startup folders"""
+
+        yield fsutil.join(self._office_install_root("Word"), "STARTUP", alt_separator="\\")
+        yield fsutil.join(self._office_install_root("Excel"), "XLSTART", alt_separator="\\")
+        yield fsutil.join(self._office_install_root("Word"), "Templates", alt_separator="\\")
+        yield fsutil.join(self._office_install_root("Word"), "Document Themes", alt_separator="\\")
+
+    def _parse_load_behavior(self, addin: KeyCollection) -> str | None:
+        """Parse the registry value which controls if the add-in autostarts.
+
+        See https://learn.microsoft.com/en-us/visualstudio/vsto/registry-entries-for-vsto-add-ins?view=vs-2022#LoadBehavior # noqa: E501
+        """
+
+        load_behavior = addin.value_or_default("LoadBehavior").value
+        if load_behavior is None:
+            return None
+        elif load_behavior == 3 or load_behavior == 16:
+            return "Autostart"
+        elif load_behavior == 9:
+            return "OnDemand"
+
+        return "Manual"

--- a/dissect/target/plugins/apps/productivity/msoffice.py
+++ b/dissect/target/plugins/apps/productivity/msoffice.py
@@ -248,12 +248,12 @@ class MSOffice(Plugin):
                     dll_str = self._lookup_com_executable(addin.name)
                     executables = to_list(self.target.resolve(dll_str, sid))
 
-                nativePluginStatus = self._parse_plugin_status(addin)
+                native_plugin_status = self._parse_plugin_status(addin)
                 yield OfficeNativeAddinRecord(
                     name=addin.value("FriendlyName", None).value,
                     modification_time=addin.timestamp,
-                    loaded=nativePluginStatus.loaded if nativePluginStatus else None,
-                    load_behavior=nativePluginStatus.load_behavior.name if nativePluginStatus else None,
+                    loaded=native_plugin_status.loaded if native_plugin_status else None,
+                    load_behavior=native_plugin_status.load_behavior.name if native_plugin_status else None,
                     type=addin_type,
                     manifest=windows_path(manifest_path_str) if manifest_path_str else None,
                     codebases=executables,

--- a/dissect/target/plugins/apps/productivity/msoffice.py
+++ b/dissect/target/plugins/apps/productivity/msoffice.py
@@ -64,7 +64,7 @@ class ClickOnceDeploymentManifestParser:
         installed: bool
         codebase: Path
 
-    def __init__(self, root_manifest_path: Path, target: Target, user_sid: str) -> None:
+    def __init__(self, root_manifest_path: Path, target: Target, user_sid: str):
         self.root_manifest_path = root_manifest_path
         self._target = target
         self._user_sid = user_sid
@@ -180,7 +180,7 @@ class MSOffice(Plugin):
         References:
             - https://learn.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins
 
-        Yields a OfficeWebAddinRecord with fields:
+        Yields a ``OfficeWebAddinRecord`` with fields:
 
         .. code-block:: text
 
@@ -216,7 +216,7 @@ class MSOffice(Plugin):
             - https://learn.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins
             - https://learn.microsoft.com/en-us/visualstudio/vsto/registry-entries-for-vsto-add-ins
 
-        Yields a OfficeNativeAddinRecord with fields:
+        Yields a ``OfficeNativeAddinRecord`` with fields:
 
         .. code-block:: text
 
@@ -266,7 +266,7 @@ class MSOffice(Plugin):
         References:
             - https://pentestlab.blog/2019/12/11/persistence-office-application-startup/
 
-        Yields a OfficeNativeAddinRecord with fields:
+        Yields a ``OfficeStartupItem`` with fields:
 
         .. code-block:: text
 

--- a/dissect/target/plugins/apps/productivity/msoffice.py
+++ b/dissect/target/plugins/apps/productivity/msoffice.py
@@ -164,6 +164,10 @@ class MSOffice(Plugin):
         "HKLM\\SOFTWARE\\Wow6432Node\\Classes",
     ]
 
+    def __init__(self, target: Target):
+        super().__init__(target)
+        self._office_install_root = lru_cache(32)(self._office_install_root)
+
     def check_compatible(self) -> None:
         if not self.target.has_function("registry") or not list(self.target.registry.keys(f"HKLM\\{self.OFFICE_KEY}")):
             raise UnsupportedPluginError("Registry key not found: %s", self.OFFICE_KEY)
@@ -376,7 +380,6 @@ class MSOffice(Plugin):
         except RegistryError:
             return self.OFFICE_DEFAULT_ROOT
 
-    @lru_cache(16)
     def _machine_startup_folders(self) -> Iterable[str]:
         """Return machine-scoped office startup folders"""
 

--- a/dissect/target/plugins/filesystem/resolver.py
+++ b/dissect/target/plugins/filesystem/resolver.py
@@ -48,7 +48,7 @@ class ResolverPlugin(Plugin):
         for entry, environment in REPLACEMENTS:
             path = re.sub(entry, re.escape(environment), path, flags=re.IGNORECASE)
 
-        path = self.target.expand_env(path)
+        path = self.target.expand_env(path, user_sid)
         # Normalize again because environment variable expansion may have introduced backslashes again
         path = fsutil.normalize(path, alt_separator=self.target.fs.alt_separator)
 
@@ -96,12 +96,12 @@ class ResolverPlugin(Plugin):
             lookup = " ".join([lookup, part]) if lookup else part
             for ext in pathext:
                 lookup_ext = lookup + ext
-                if self.target.fs.exists(lookup_ext):
+                if self.target.fs.is_file(lookup_ext):
                     return lookup_ext
 
                 for search_path in search_paths:
                     lookup_path = fsutil.join(search_path, lookup_ext, alt_separator=self.target.fs.alt_separator)
-                    if self.target.fs.exists(lookup_path):
+                    if self.target.fs.is_file(lookup_path):
                         return lookup_path
 
         return path

--- a/dissect/target/plugins/os/unix/linux/network.py
+++ b/dissect/target/plugins/os/unix/linux/network.py
@@ -86,7 +86,7 @@ class NetworkManagerConfigParser(LinuxNetworkConfigParser):
                 source=self.source,
                 last_connected=self.last_connected,
                 name=self.name,
-                mac=[self.mac_address] if self.mac_address else [],
+                mac=to_list(self.mac_address),
                 type=self.type,
                 dhcp_ipv4=self.dhcp_ipv4,
                 dhcp_ipv6=self.dhcp_ipv6,

--- a/dissect/target/plugins/os/windows/registry.py
+++ b/dissect/target/plugins/os/windows/registry.py
@@ -9,7 +9,6 @@ from typing import Iterator, Optional, Union
 
 from dissect.target.exceptions import (
     HiveUnavailableError,
-    RegistryError,
     RegistryKeyNotFoundError,
     RegistryValueNotFoundError,
     UnsupportedPluginError,
@@ -291,17 +290,6 @@ class RegistryPlugin(Plugin):
     def value(self, key: str, value: str) -> ValueCollection:
         """Convenience method for accessing a specific value."""
         return self.key(key).value(value)
-
-    @internal
-    def value_or_empty(self, key: str, value: str) -> ValueCollection:
-        """Convenience method for trying to access a specific value.
-
-        Returns a empty collection if the key or value does not exist.
-        """
-        try:
-            return self.value(key, value)
-        except RegistryError:
-            return ValueCollection()
 
     @internal
     def subkey(self, key: str, subkey: str) -> KeyCollection:

--- a/dissect/target/plugins/os/windows/registry.py
+++ b/dissect/target/plugins/os/windows/registry.py
@@ -5,7 +5,7 @@ import re
 import warnings
 from collections import defaultdict
 from functools import lru_cache
-from typing import Iterator, Optional, Union
+from typing import Iterator, Optional
 
 from dissect.target.exceptions import (
     HiveUnavailableError,
@@ -297,12 +297,12 @@ class RegistryPlugin(Plugin):
         return self.key(key).subkey(subkey)
 
     @internal
-    def iterkeys(self, keys: Union[str, list[str]]) -> Iterator[KeyCollection]:
+    def iterkeys(self, keys: str | list[str]) -> Iterator[KeyCollection]:
         warnings.warn("The iterkeys() function is deprecated, use keys() instead", DeprecationWarning)
         yield from self.keys(keys)
 
     @internal
-    def keys(self, keys: Union[str, list[str]]) -> Iterator[RegistryKey]:
+    def keys(self, keys: str | list[str]) -> Iterator[RegistryKey]:
         """Yields all keys that match the given queries.
 
         Automatically resolves CurrentVersion keys. Also flattens KeyCollections.
@@ -318,7 +318,7 @@ class RegistryPlugin(Plugin):
                 pass
 
     @internal
-    def values(self, keys: Union[str, list[str]], value: str) -> Iterator[RegistryValue]:
+    def values(self, keys: str | list[str], value: str) -> Iterator[RegistryValue]:
         """Yields all values that match the given queries.
 
         Automatically resolves CurrentVersion keys. Also flattens ValueCollections.

--- a/tests/_data/plugins/apps/productivity/vsto/MicrosoftDataStreamerforExcel.dll.manifest
+++ b/tests/_data/plugins/apps/productivity/vsto/MicrosoftDataStreamerforExcel.dll.manifest
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dabee600e4c373b075e6dc67c018bd5113fd9439799a0b8dde95bc11d159b7be
+size 177659

--- a/tests/_data/plugins/apps/productivity/vsto/MicrosoftDataStreamerforExcel.vsto
+++ b/tests/_data/plugins/apps/productivity/vsto/MicrosoftDataStreamerforExcel.vsto
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab397e918c1c5ffdcf208e90942f1876aea5a9f5b4e6389d0a67a5bcf487a75d
+size 16249

--- a/tests/_data/plugins/apps/productivity/wef/Manifests/wa200007708_1.0.0.0
+++ b/tests/_data/plugins/apps/productivity/wef/Manifests/wa200007708_1.0.0.0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c79656873e67bdce7fc14f87b2bfbf3a9989078a9f7e6ccaf3ff3413a943cdb
+size 25530

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -11,7 +11,7 @@ from dissect.target.helpers import fsutil, utils
 def test_to_list_single_value() -> None:
     assert utils.to_list(1) == [1]
     assert utils.to_list("a") == ["a"]
-    assert utils.to_list(None) == [None]
+    assert utils.to_list(None) == []
 
 
 def test_to_list_list_value() -> None:

--- a/tests/plugins/apps/productivity/test_msoffice.py
+++ b/tests/plugins/apps/productivity/test_msoffice.py
@@ -110,7 +110,8 @@ def test_office_vsto_addin(target_win_users: Target, fs_win: VirtualFilesystem, 
     item, *_ = startup_items
     assert item.name == "An Excel vsto addin"
     assert item.type == "vsto"
-    assert item.load_behavior == "Manual"
+    assert item.load_behavior == "Autostart"
+    assert not item.loaded
     assert item.manifest == "c:\\vsto\\MicrosoftDataStreamerforExcel.vsto|vstolocal"
     assert item.codebases == ["c:\\vsto\\MicrosoftDataStreamerforExcel.dll"]
 

--- a/tests/plugins/apps/productivity/test_msoffice.py
+++ b/tests/plugins/apps/productivity/test_msoffice.py
@@ -1,0 +1,134 @@
+import io
+
+from dissect.target.filesystem import VirtualFilesystem
+from dissect.target.helpers import fsutil
+from dissect.target.helpers.regutil import VirtualHive, VirtualKey
+from dissect.target.plugins.apps.productivity.msoffice import MSOffice
+from dissect.target.target import Target
+
+
+def test_office_startup_default_machine(
+    target_win_users: Target, fs_win: VirtualFilesystem, hive_hklm: VirtualHive
+) -> None:
+    """Test if machine-scoped startup items are found in default locations"""
+
+    office_install_path = "C:/Office"
+    key_path = "Software\\Microsoft\\Office\\16.0\\Word\\InstallRoot"
+    startup_item_path = fsutil.join(office_install_path, "STARTUP/plugin.wll")
+
+    install_root_key = VirtualKey(hive_hklm, key_path)
+    install_root_key.add_value("Path", office_install_path)
+    hive_hklm.map_key(key_path, install_root_key)
+    fs_win.map_file_fh(startup_item_path.removeprefix("C:/"), io.BytesIO(b"Plugin Data"))
+
+    office_plugin = MSOffice(target_win_users)
+    startup_items = list(office_plugin.startup())
+
+    assert len(startup_items) == 1
+    item, *_ = startup_items
+    assert item.path == startup_item_path
+    assert item.creation_time == target_win_users.fs.stat(startup_item_path).st_birthtime
+
+
+def test_office_startup_default_user(target_win_users: Target, fs_win: VirtualFilesystem) -> None:
+    """Test if user-scoped startup items are found in default locations."""
+
+    startup_item_path = "C:/Users/John/AppData/Roaming/Microsoft/Templates/normal.dotx"
+    fs_win.map_file_fh(startup_item_path.removeprefix("C:/"), io.BytesIO(b"Template Data"))
+
+    office_plugin = MSOffice(target_win_users)
+    startup_items = list(office_plugin.startup())
+
+    assert len(startup_items) == 1
+    item, *_ = startup_items
+    assert item.path == startup_item_path
+    assert item.creation_time == target_win_users.fs.stat(startup_item_path).st_birthtime
+
+
+def test_office_startup_options(target_win_users: Target, fs_win: VirtualFilesystem, hive_hklm: VirtualHive) -> None:
+    """Test if startup items are found in custom specified locations"""
+
+    startup_item_path = "C:/FUNWAREZ/innocent.dll"
+    key_path = "Software\\Microsoft\\Office\\16.0\\Word\\Options"
+
+    custom_startup_key = VirtualKey(hive_hklm, key_path)
+    custom_startup_key.add_value("STARTUP-PATH", "C:/FUNWAREZ")
+    hive_hklm.map_key(key_path, custom_startup_key)
+    fs_win.map_file_fh(startup_item_path.removeprefix("C:/"), io.BytesIO(b"Exploit Data"))
+
+    office_plugin = MSOffice(target_win_users)
+    startup_items = list(office_plugin.startup())
+
+    assert len(startup_items) == 1
+    item, *_ = startup_items
+    assert item.path == startup_item_path
+    assert item.creation_time == target_win_users.fs.stat(startup_item_path).st_birthtime
+
+
+def test_office_com_addin(target_win_users: Target, hive_hklm: VirtualHive) -> None:
+    """Test if COM add-ins are found"""
+
+    addin_prog_id = "ExcelAddin"
+    addin_key_path = f"Software\\Microsoft\\Office\\Excel\\Addins\\{addin_prog_id}"
+    cls_id = "{ADC6CB82-424C-11D2-952A-00C04FA34F05}"
+
+    addin_key = VirtualKey(hive_hklm, addin_key_path)
+    addin_key.add_value("FriendlyName", "An Excel com addin")
+    addin_key.add_value("LoadBehavior", 3)
+    hive_hklm.map_key(addin_key_path, addin_key)
+    hive_hklm.map_value(f"Software\\Classes\\{addin_prog_id}\\CLSID", "(Default)", cls_id)
+    hive_hklm.map_value(f"Software\\Classes\\CLSID\\{cls_id}\\InprocServer32", "(Default)", "c:\\payload.exe")
+
+    office_plugin = MSOffice(target_win_users)
+    startup_items = list(office_plugin.native())
+
+    assert len(startup_items) == 1
+    item, *_ = startup_items
+    assert item.name == "An Excel com addin"
+    assert item.type == "com"
+    assert item.load_behavior == "Autostart"
+    assert item.codebases == ["c:\\payload.exe"]
+
+
+def test_office_vsto_addin(target_win_users: Target, fs_win: VirtualFilesystem, hive_hklm: VirtualHive) -> None:
+    """Test if vsto add-ins are found"""
+
+    addin_prog_id = "ExcelAddin"
+    addin_key_path = f"Software\\Microsoft\\Office\\Excel\\Addins\\{addin_prog_id}"
+
+    fs_win.map_dir("vsto", "tests/_data/plugins/apps/productivity/vsto")
+    addin_key = VirtualKey(hive_hklm, addin_key_path)
+    addin_key.add_value("FriendlyName", "An Excel vsto addin")
+    addin_key.add_value("LoadBehavior", 2)
+    addin_key.add_value("Manifest", "c:\\vsto\\MicrosoftDataStreamerforExcel.vsto|vstolocal")
+    hive_hklm.map_key(addin_key_path, addin_key)
+
+    office_plugin = MSOffice(target_win_users)
+    startup_items = list(office_plugin.native())
+
+    assert len(startup_items) == 1
+    item, *_ = startup_items
+    assert item.name == "An Excel vsto addin"
+    assert item.type == "vsto"
+    assert item.load_behavior == "Manual"
+    assert item.manifest == "c:\\vsto\\MicrosoftDataStreamerforExcel.vsto|vstolocal"
+    assert item.codebases == ["c:\\vsto\\MicrosoftDataStreamerforExcel.dll"]
+
+
+def test_office_web_addin(target_win_users: Target, fs_win: VirtualFilesystem) -> None:
+    """Test if web add-ins are found"""
+
+    fs_win.map_dir("users/John/AppData/local/Microsoft/Office/16.0/Wef", "tests/_data/plugins/apps/productivity/wef")
+
+    office_plugin = MSOffice(target_win_users)
+    startup_items = list(office_plugin.web())
+
+    assert len(startup_items) == 1
+    item, *_ = startup_items
+    assert item.name == "ChatGPT for MS Word"
+    assert item.provider_name == "Apps Do Wonders LLC"
+    assert (
+        item.manifest == "C:\\Users\\John\\AppData\\local\\Microsoft\\Office\\16.0\\Wef\\Manifests\\wa200007708_1.0.0.0"
+    )
+    assert item.source_locations == ["https://word-addin.appsdowonders.com/taskpane.html"]
+    assert item.version == "1.0.0.0"

--- a/tests/plugins/filesystem/test_resolver.py
+++ b/tests/plugins/filesystem/test_resolver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import OrderedDict
 from unittest.mock import patch
 
@@ -32,7 +34,7 @@ def extended_win_fs(fs_win):
         ),
     ],
 )
-def test_resolver_plugin_resolve(target_win, target_unix, test_target, resolve_func):
+def test_resolver_plugin_resolve(target_win, target_unix, test_target, resolve_func) -> None:
     targets = {
         "target_win": target_win,
         "target_unix": target_unix,
@@ -50,11 +52,11 @@ def test_resolver_plugin_resolve_no_path(target_win):
     assert target_win.resolve(path) is path
 
 
-def mock_expand_env(path):
+def mock_expand_env(path, user_sid: str | None = None) -> str:
     return path
 
 
-def mock_user_env(user):
+def mock_user_env(user) -> OrderedDict[str, str]:
     path_envs = {
         None: OrderedDict(
             (("%path%", "sysvol/windows/syswow64"),),
@@ -147,7 +149,7 @@ def mock_user_env(user):
         ),
     ],
 )
-def test_resolver_plugin_resolve_windows(target_win, extended_win_fs, path, user, resolved_path):
+def test_resolver_plugin_resolve_windows(target_win, path, extended_win_fs, user, resolved_path) -> None:
     resolver_plugin = ResolverPlugin(target_win)
     target_win.pathext  # This will load the EnvironmentVariablePlugin
     env_plugin = next(plugin for plugin in target_win._plugins if type(plugin).__name__ == "EnvironmentVariablePlugin")

--- a/tests/plugins/filesystem/test_resolver.py
+++ b/tests/plugins/filesystem/test_resolver.py
@@ -5,12 +5,13 @@ from unittest.mock import patch
 
 import pytest
 
-from dissect.target.filesystem import VirtualFile
+from dissect.target.filesystem import VirtualFile, VirtualFilesystem
 from dissect.target.plugins.filesystem.resolver import ResolverPlugin
+from dissect.target.target import Target
 
 
 @pytest.fixture
-def extended_win_fs(fs_win):
+def extended_win_fs(fs_win: VirtualFilesystem) -> VirtualFilesystem:
     fs_win.map_file_entry("windows/system32/calc.exe", VirtualFile(fs_win, "windows/system32/calc.exe", None))
     fs_win.map_file_entry("windows/syswow64/calc.exe", VirtualFile(fs_win, "windows/syswow64/calc.exe", None))
     fs_win.map_file_entry("some dir with spaces/calc.exe", VirtualFile(fs_win, "some dir with spaces/calc.exe", None))
@@ -34,7 +35,7 @@ def extended_win_fs(fs_win):
         ),
     ],
 )
-def test_resolver_plugin_resolve(target_win, target_unix, test_target, resolve_func) -> None:
+def test_resolver_plugin_resolve(target_win: Target, target_unix: Target, test_target: str, resolve_func: str) -> None:
     targets = {
         "target_win": target_win,
         "target_unix": target_unix,
@@ -47,16 +48,16 @@ def test_resolver_plugin_resolve(target_win, target_unix, test_target, resolve_f
         resolve_func.assert_called()
 
 
-def test_resolver_plugin_resolve_no_path(target_win):
+def test_resolver_plugin_resolve_no_path(target_win: Target) -> None:
     path = ""
     assert target_win.resolve(path) is path
 
 
-def mock_expand_env(path, user_sid: str | None = None) -> str:
+def mock_expand_env(path: str, user_sid: str | None = None) -> str:
     return path
 
 
-def mock_user_env(user) -> OrderedDict[str, str]:
+def mock_user_env(user: str | None) -> OrderedDict[str, str]:
     path_envs = {
         None: OrderedDict(
             (("%path%", "sysvol/windows/syswow64"),),
@@ -149,7 +150,9 @@ def mock_user_env(user) -> OrderedDict[str, str]:
         ),
     ],
 )
-def test_resolver_plugin_resolve_windows(target_win, path, extended_win_fs, user, resolved_path) -> None:
+def test_resolver_plugin_resolve_windows(
+    target_win: Target, path: str, extended_win_fs: VirtualFilesystem, user: str | None, resolved_path: str
+) -> None:
     resolver_plugin = ResolverPlugin(target_win)
     target_win.pathext  # This will load the EnvironmentVariablePlugin
     env_plugin = next(plugin for plugin in target_win._plugins if type(plugin).__name__ == "EnvironmentVariablePlugin")
@@ -184,6 +187,6 @@ def test_resolver_plugin_resolve_windows(target_win, path, extended_win_fs, user
         ),
     ],
 )
-def test_resolver_plugin_resolve_default(target_unix, path, user, resolved_path):
+def test_resolver_plugin_resolve_default(target_unix: Target, path: str, user: str, resolved_path: str):
     resolver_plugin = ResolverPlugin(target_unix)
     assert resolver_plugin.resolve_default(path, user_id=user) == resolved_path


### PR DESCRIPTION
Detects:
- Persistence through startup folders (templates, executables)
- COM addins 
- VSTO addins by parsing ClickOnce Deployment manifests
- Web addins by inspecting WEF cache and parsing manifests

Limitations:
- Office for Mac is not supported
- Supports Microsoft Office 2016 and later
- Manifests which are wof compressed are unreadable

Bonus:
- Fix issue in resolver where user environment was not taken into account when expanding paths
- Fix issue where partial path resolution resolved to directories.
- Added convenience functions for querying registry 