### PR TITLE
Remove paho from mqqt unit test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ full = [
     "zstandard",
 ]
 dev = [
-    "dissect.target[full,mqtt,yara]",
+    "dissect.target[full,yara]",
     "dissect.archive[dev]>=1.0.dev,<2.0.dev",
     "dissect.btrfs[dev]>=1.0.dev,<2.0.dev",
     "dissect.cim[dev]>=3.0.dev,<4.0.dev",


### PR DESCRIPTION
We remove an import at the top, but now have to import the unit under test in the test itself.

Closes #926 