### PR TITLE
Fix crash in unix users plugins if GID or UID is empty

### DIFF
--- a/dissect/target/plugins/os/unix/_os.py
+++ b/dissect/target/plugins/os/unix/_os.py
@@ -85,13 +85,12 @@ class UnixPlugin(OSPlugin):
                     current_user = (pwent.get(0), pwent.get(5), pwent.get(6))
                     if current_user in seen_users:
                         continue
-
                     seen_users.add(current_user)
                     yield UnixUserRecord(
                         name=pwent.get(0),
                         passwd=pwent.get(1),
-                        uid=pwent.get(2),
-                        gid=pwent.get(3),
+                        uid=pwent.get(2) if pwent.get(2) != "" else None,
+                        gid=pwent.get(3) if pwent.get(3) != "" else None,
                         gecos=pwent.get(4),
                         home=posix_path(pwent.get(5)),
                         shell=pwent.get(6),


### PR DESCRIPTION
This PR fix an issue while processing /etc/passwd entry where gid or uid id null.
This kind OS issue could also be fixed more generally in flow, by checking if entry is empty before coercing into an int, but I'm not sure if this would be the expected comportment for all entries.

fix #995
