### PR TITLE
Fix file header detection in open_decompress

### DIFF
--- a/dissect/target/helpers/fsutil.py
+++ b/dissect/target/helpers/fsutil.py
@@ -512,10 +512,12 @@ def open_decompress(
         An binary or text IO stream, depending on the mode with which the file was opened.
 
     Example:
-        bytes_buf = open_decompress(Path("/dir/file.gz")).read()
+        .. code-block:: python
 
-        for line in open_decompress(Path("/dir/file.gz"), "rt"):
-            print(line)
+            bytes_buf = open_decompress(Path("/dir/file.gz")).read()
+
+            for line in open_decompress(Path("/dir/file.gz"), "rt"):
+                print(line)
     """
     if path and fileobj:
         raise ValueError("path and fileobj are mutually exclusive")

--- a/dissect/target/helpers/fsutil.py
+++ b/dissect/target/helpers/fsutil.py
@@ -527,6 +527,7 @@ def open_decompress(
         file = path.open("rb")
     else:
         file = fileobj
+        file.seek(0)
 
     magic = file.read(5)
     file.seek(0)

--- a/tests/helpers/test_fsutil.py
+++ b/tests/helpers/test_fsutil.py
@@ -646,8 +646,11 @@ def test_pure_dissect_path__from_parts_no_fs_exception() -> None:
 )
 def test_open_decompress(file_name: str, compressor: Callable, content: bytes) -> None:
     vfs = VirtualFilesystem()
-    vfs.map_file_fh(file_name, io.BytesIO(compressor(content)))
+    fh = io.BytesIO(compressor(content))
+    vfs.map_file_fh(file_name, fh)
     assert fsutil.open_decompress(vfs.path(file_name)).read() == content
+    fh.seek(2)
+    assert fsutil.open_decompress(fileobj=fh).read() == content
 
 
 def test_open_decompress_text_modes() -> None:


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->

Previously file header could be misread if fileobj position was not at start, leading to incorrect file format detection. Now explicitly seek to beginning before reading the magic file header bytes.

Also fixed the example in the docstring of `open_decompress` so that it renders it as a code block.

fixes #999 