### PR TITLE
Improve target-diff tool

### DIFF
--- a/dissect/target/helpers/fsutil.py
+++ b/dissect/target/helpers/fsutil.py
@@ -562,12 +562,14 @@ def open_decompress(
     return file
 
 
-def reverse_read(fh: io.BytesIO, chunk_size: int = 1024 * 10, reverse_chunk: bool = True) -> Iterator[bytes]:
+def reverse_read(
+    fh: io.BytesIO, chunk_size: int = io.DEFAULT_BUFFER_SIZE, reverse_chunk: bool = True
+) -> Iterator[bytes]:
     """Like iterating over chunks of a ``BytesIO`` file-like object, but starting from the end of the file.
 
     Args:
         fh: The file-like object (opened in binary mode) to read from.
-        chunk_size: The chunk size to use for iterating over bytes (default: 10KB).
+        chunk_size: The chunk size to use for iterating over bytes (default: 8KB).
         reverse_chunk: Whether we should reverse the bytes of each chunk (default: True).
 
         Returns:

--- a/dissect/target/helpers/fsutil.py
+++ b/dissect/target/helpers/fsutil.py
@@ -572,8 +572,8 @@ def reverse_read(
         chunk_size: The chunk size to use for iterating over bytes (default: 8KB).
         reverse_chunk: Whether we should reverse the bytes of each chunk (default: True).
 
-        Returns:
-            An iterator of byte chunks, starting from the end of the file-like object and moving to the start.
+    Returns:
+        An iterator of byte chunks, starting from the end of the file-like object and moving to the start.
     """
 
     offset = fh.seek(0, io.SEEK_END)

--- a/dissect/target/helpers/fsutil.py
+++ b/dissect/target/helpers/fsutil.py
@@ -87,6 +87,7 @@ __all__ = [
     "PureDissectPath",
     "relpath",
     "resolve_link",
+    "reverse_read",
     "reverse_readlines",
     "split",
     "splitdrive",
@@ -559,6 +560,29 @@ def open_decompress(
         return path.open(mode, encoding=encoding, errors=errors, newline=newline)
 
     return file
+
+
+def reverse_read(fh: io.BytesIO, chunk_size: int = 1024 * 10, reverse_chunk: bool = True) -> Iterator[bytes]:
+    """Like iterating over a ``BytesIO`` file-like object, but starting from the end of the file.
+
+    Args:
+        fh: The file-like object (opened in binary mode) to read from.
+        chunk_size: The chunk size to use for iterating over bytes (default: 10KB).
+        reverse_chunk: Whether we should reverse the bytes of each read chunk (default: True).
+
+        Returns:
+            An iterator of reversed bytes.
+    """
+
+    offset = fh.seek(0, io.SEEK_END)
+
+    while offset > 0:
+        if offset < chunk_size:
+            chunk_size = offset
+        offset -= chunk_size
+        fh.seek(offset)
+        buf = fh.read(chunk_size)
+        yield bytes(reversed(buf)) if reverse_chunk else buf
 
 
 def reverse_readlines(fh: TextIO, chunk_size: int = 1024 * 1024 * 8) -> Iterator[str]:

--- a/dissect/target/helpers/fsutil.py
+++ b/dissect/target/helpers/fsutil.py
@@ -563,9 +563,9 @@ def open_decompress(
 
 
 def reverse_read(
-    fh: io.BytesIO, chunk_size: int = io.DEFAULT_BUFFER_SIZE, reverse_chunk: bool = True
+    fh: BinaryIO, chunk_size: int = io.DEFAULT_BUFFER_SIZE, reverse_chunk: bool = True
 ) -> Iterator[bytes]:
-    """Like iterating over chunks of a ``BytesIO`` file-like object, but starting from the end of the file.
+    """Like iterating over chunks of a binary file-like object, but starting from the end of the file.
 
     Args:
         fh: The file-like object (opened in binary mode) to read from.

--- a/dissect/target/helpers/fsutil.py
+++ b/dissect/target/helpers/fsutil.py
@@ -563,15 +563,15 @@ def open_decompress(
 
 
 def reverse_read(fh: io.BytesIO, chunk_size: int = 1024 * 10, reverse_chunk: bool = True) -> Iterator[bytes]:
-    """Like iterating over a ``BytesIO`` file-like object, but starting from the end of the file.
+    """Like iterating over chunks of a ``BytesIO`` file-like object, but starting from the end of the file.
 
     Args:
         fh: The file-like object (opened in binary mode) to read from.
         chunk_size: The chunk size to use for iterating over bytes (default: 10KB).
-        reverse_chunk: Whether we should reverse the bytes of each read chunk (default: True).
+        reverse_chunk: Whether we should reverse the bytes of each chunk (default: True).
 
         Returns:
-            An iterator of reversed bytes.
+            An iterator of byte chunks, starting from the end of the file-like object and moving to the start.
     """
 
     offset = fh.seek(0, io.SEEK_END)

--- a/dissect/target/helpers/fsutil.py
+++ b/dissect/target/helpers/fsutil.py
@@ -562,9 +562,7 @@ def open_decompress(
     return file
 
 
-def reverse_read(
-    fh: BinaryIO, chunk_size: int = io.DEFAULT_BUFFER_SIZE, reverse_chunk: bool = True
-) -> Iterator[bytes]:
+def reverse_read(fh: BinaryIO, chunk_size: int = io.DEFAULT_BUFFER_SIZE, reverse_chunk: bool = True) -> Iterator[bytes]:
     """Like iterating over chunks of a binary file-like object, but starting from the end of the file.
 
     Args:

--- a/dissect/target/tools/diff.py
+++ b/dissect/target/tools/diff.py
@@ -243,15 +243,15 @@ class TargetComparison:
             chunk_count = 0
 
             while True:
-                chunk_a = next(chunks_a, None)
-                chunk_b = next(chunks_b, None)
+                chunk_a = next(chunks_a, b"")
+                chunk_b = next(chunks_b, b"")
                 chunk_count += 1
 
                 if chunk_a != chunk_b:
                     # We immediately break after discovering a difference in file contents
                     # This means that we won't return a full diff of the file, merely the first block where a difference
                     # is observed. The chunk is not reversed, so the difference is human-readable.
-                    content_difference = list(diff_bytes(unified_diff, [chunk_a or b""], [chunk_b or ""]))
+                    content_difference = list(diff_bytes(unified_diff, [chunk_a], [chunk_b]))
                     differential_entry = DifferentialEntry(
                         entry_path,
                         src_entry.name,
@@ -266,7 +266,7 @@ class TargetComparison:
                     unchanged.append(src_entry)
                     break
 
-                if chunk_a is None or len(chunk_a) == 0:
+                if not chunk_a == 0:
                     # End of file
                     unchanged.append(src_entry)
                     break

--- a/dissect/target/tools/diff.py
+++ b/dissect/target/tools/diff.py
@@ -266,7 +266,7 @@ class TargetComparison:
                     unchanged.append(src_entry)
                     break
 
-                if not chunk_a == 0:
+                if not chunk_a:
                     # End of file
                     unchanged.append(src_entry)
                     break

--- a/tests/helpers/test_fsutil.py
+++ b/tests/helpers/test_fsutil.py
@@ -722,6 +722,21 @@ def test_reverse_readlines() -> None:
     ]
 
 
+def test_reverse_read() -> None:
+    """test if we read the bytes of a file in reverse succesfully."""
+    fs = VirtualFilesystem()
+
+    fs.map_file_fh("file", io.BytesIO(b"1234567890"))
+    assert list(fsutil.reverse_read(fs.path("file").open("rb"), chunk_size=2)) == [b"09", b"87", b"65", b"43", b"21"]
+
+    fs.map_file_fh("large_emoji", io.BytesIO(("🐱" * 10_000).encode()))
+    content = list(fsutil.reverse_read(fs.path("large_emoji").open("rb")))
+    assert len(content) == 4
+    assert len(content[0]) == 1024 * 10
+    assert len(content[-1]) == 9280
+    assert b"".join(content) == bytes(reversed(("🐱" * 10_000).encode()))
+
+
 @pytest.fixture
 def xattrs() -> dict[str, bytes]:
     return {"some_key": b"some_value"}

--- a/tests/helpers/test_fsutil.py
+++ b/tests/helpers/test_fsutil.py
@@ -731,9 +731,9 @@ def test_reverse_read() -> None:
 
     fs.map_file_fh("large_emoji", io.BytesIO(("🐱" * 10_000).encode()))
     content = list(fsutil.reverse_read(fs.path("large_emoji").open("rb")))
-    assert len(content) == 4
-    assert len(content[0]) == 1024 * 10
-    assert len(content[-1]) == 9280
+    assert len(content) == 5
+    assert len(content[0]) == 1024 * 8
+    assert len(content[-1]) == 7232
     assert b"".join(content) == bytes(reversed(("🐱" * 10_000).encode()))
 
 

--- a/tests/tools/test_diff.py
+++ b/tests/tools/test_diff.py
@@ -52,7 +52,7 @@ def target_unix_factory(tmp_path: Path) -> TargetUnixFactory:
 
 
 @pytest.fixture
-def src_target(target_unix_factory) -> Iterator[Target]:
+def src_target(target_unix_factory: TargetUnixFactory) -> Iterator[Target]:
     target, fs_unix = target_unix_factory.new("src_target")
 
     passwd_contents = PASSWD_CONTENTS + "\nsrc_user:x:1001:1001:src_user:/home/src_user:/bin/bash"
@@ -72,7 +72,7 @@ def src_target(target_unix_factory) -> Iterator[Target]:
 
 
 @pytest.fixture
-def dst_target(target_unix_factory) -> Iterator[Target]:
+def dst_target(target_unix_factory: TargetUnixFactory) -> Iterator[Target]:
     target, fs_unix = target_unix_factory.new("dst_target")
 
     passwd_contents = PASSWD_CONTENTS + "\ndst_user:x:1002:1002:dst_user:/home/dst_user:/bin/bash"
@@ -223,7 +223,9 @@ def test_differentiate_plugins(src_target: Target, dst_target: Target) -> None:
     assert deleted[0].record.hostname == "src_target"
 
 
-def test_shell_ls(src_target: Target, dst_target: Target, capsys, monkeypatch) -> None:
+def test_shell_ls(
+    src_target: Target, dst_target: Target, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(fsutils, "LS_COLORS", {})
 
     cli = DifferentialCli(src_target, dst_target, deep=True)
@@ -248,7 +250,9 @@ def test_shell_ls(src_target: Target, dst_target: Target, capsys, monkeypatch) -
     assert captured.out == "\n".join(expected) + "\n"
 
 
-def test_shell_find(src_target: Target, dst_target: Target, capsys, monkeypatch) -> None:
+def test_shell_find(
+    src_target: Target, dst_target: Target, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(fsutils, "LS_COLORS", {})
 
     cli = DifferentialCli(src_target, dst_target, deep=True)
@@ -275,7 +279,7 @@ def test_shell_find(src_target: Target, dst_target: Target, capsys, monkeypatch)
     assert captured.out == "\n".join(expected) + "\n"
 
 
-def test_shell_cat(src_target: Target, dst_target: Target, capsys) -> None:
+def test_shell_cat(src_target: Target, dst_target: Target, capsys: pytest.CaptureFixture) -> None:
     cli = DifferentialCli(src_target, dst_target, deep=True)
 
     cli.onecmd("cat /changes/unchanged")
@@ -296,7 +300,7 @@ def test_shell_cat(src_target: Target, dst_target: Target, capsys) -> None:
     assert captured.out == "Hello From Destination Target\n"
 
 
-def test_shell_plugin(src_target: Target, dst_target: Target, capsys) -> None:
+def test_shell_plugin(src_target: Target, dst_target: Target, capsys: pytest.CaptureFixture) -> None:
     cli = DifferentialCli(src_target, dst_target, deep=True)
 
     cli.onecmd("plugin users")
@@ -307,7 +311,7 @@ def test_shell_plugin(src_target: Target, dst_target: Target, capsys) -> None:
     assert "differential/record/deleted" in captured.out
 
 
-def test_target_diff_shell(capsys, monkeypatch) -> None:
+def test_target_diff_shell(capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
     with monkeypatch.context() as m:
         m.setattr(fsutils, "LS_COLORS", {})
         m.setenv("NO_COLOR", "1")
@@ -333,7 +337,7 @@ def test_target_diff_shell(capsys, monkeypatch) -> None:
         assert "unrecognized arguments" not in err
 
 
-def test_target_diff_fs(capsys, monkeypatch) -> None:
+def test_target_diff_fs(capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
     with monkeypatch.context() as m:
         src_target_path = absolute_path("_data/tools/diff/src.tar")
         dst_target_path = absolute_path("_data/tools/diff/dst.tar")
@@ -346,7 +350,7 @@ def test_target_diff_fs(capsys, monkeypatch) -> None:
         assert "differential/file/deleted" in out
 
 
-def test_target_diff_query(capsys, monkeypatch) -> None:
+def test_target_diff_query(capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
     with monkeypatch.context() as m:
         src_target_path = absolute_path("_data/tools/diff/src.tar")
         dst_target_path = absolute_path("_data/tools/diff/dst.tar")
@@ -359,7 +363,7 @@ def test_target_diff_query(capsys, monkeypatch) -> None:
         assert "differential/record/deleted" in out
 
 
-def test_target_diff_fs_reverse_read(target_unix_factory) -> None:
+def test_target_diff_fs_reverse_read(target_unix_factory: TargetUnixFactory) -> None:
     """test if we detect the difference in an appended file correctly."""
 
     src_target, fs_src = target_unix_factory.new("src_target")


### PR DESCRIPTION
This PR addresses the following in `target-diff`:
1. We now read changed files (in deep mode) in reverse instead of from the beginning. We could add a feature flag for this if desired, e.g. `--read-mode`. We feel reverse should be the default since most files are appended instead of prepended.
2. The `--exclude` parameter did not function as one would expect, this is now changed.