### PR TITLE
Improve Linux detection

### DIFF
--- a/dissect/target/plugins/os/unix/_os.py
+++ b/dissect/target/plugins/os/unix/_os.py
@@ -48,7 +48,7 @@ class UnixPlugin(OSPlugin):
 
     @classmethod
     def detect(cls, target: Target) -> Filesystem | None:
-        """If the ``/var`` and ``/etc`` folders exist on a filesystem it is treated as a Unix-like filesystem."""
+        # If the ``/var`` and ``/etc`` folders exist on a filesystem it is treated as a Unix-like filesystem
         for fs in target.filesystems:
             if fs.exists("/var") and fs.exists("/etc"):
                 return fs

--- a/dissect/target/plugins/os/unix/_os.py
+++ b/dissect/target/plugins/os/unix/_os.py
@@ -48,6 +48,7 @@ class UnixPlugin(OSPlugin):
 
     @classmethod
     def detect(cls, target: Target) -> Filesystem | None:
+        """If the ``/var`` and ``/etc`` folders exist on a filesystem it is treated as a Unix-like filesystem."""
         for fs in target.filesystems:
             if fs.exists("/var") and fs.exists("/etc"):
                 return fs

--- a/dissect/target/plugins/os/unix/linux/_os.py
+++ b/dissect/target/plugins/os/unix/linux/_os.py
@@ -46,6 +46,7 @@ class LinuxPlugin(UnixPlugin, LinuxNetworkManager):
             "/boot/initrd.img",
             "/boot/vmlinuz",
             "/boot/vmlinux",
+            "/opt",  # Backwards compatibility for previous Linux detection.
         }
 
         for fs in target.filesystems:

--- a/dissect/target/plugins/os/unix/linux/_os.py
+++ b/dissect/target/plugins/os/unix/linux/_os.py
@@ -50,7 +50,7 @@ class LinuxPlugin(UnixPlugin, LinuxNetworkManager):
         }
 
         for fs in target.filesystems:
-            # We explicitly exclude filesystems that look more like a MacOS or Windows sysvol.
+            # We explicitly exclude filesystems that look more like a macOS or Windows sysvol.
             if MacPlugin.detect(target) or WindowsPlugin.detect(target):
                 continue
 

--- a/dissect/target/plugins/os/unix/linux/_os.py
+++ b/dissect/target/plugins/os/unix/linux/_os.py
@@ -25,11 +25,41 @@ class LinuxPlugin(UnixPlugin, LinuxNetworkManager):
 
     @classmethod
     def detect(cls, target: Target) -> Filesystem | None:
+        """Detect a Linux-like filesystem.
+
+        These days there is little difference in the filesystem format used by Unix and Linux. Both implementations use
+        the Filesystem Hierarchy Standard (FHS). We can differentiate between Unix and Linux by checking for specific
+        Linux kernel-only files not present on actual Unix filesystems (e.g. BSD, Solaris, IBM AIX and HP-UX).
+
+        Resources:
+            - https://refspecs.linuxfoundation.org/fhs.shtml
+            - https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard
+        """
+
+        # NOTE: dirs like /opt, /mnt, /media, /tmp and /proc are not Linux-specific.
+        LINUX_PATHS = {
+            "/run",
+            "/sys",
+            "/etc/kernel",
+            "/etc/sysctl.conf",
+            "/var/log/kern.log",
+            "/boot/initrd.img",
+            "/boot/vmlinuz",
+            "/boot/vmlinux",
+        }
+
         for fs in target.filesystems:
-            if (
-                (fs.exists("/var") and fs.exists("/etc") and fs.exists("/opt"))
-                or (fs.exists("/sys/module") or fs.exists("/proc/sys"))
-            ) and not (MacPlugin.detect(target) or WindowsPlugin.detect(target)):
+            # We explicitly exclude filesystems that look more like a MacOS or Windows sysvol.
+            if MacPlugin.detect(target) or WindowsPlugin.detect(target):
+                continue
+
+            # Dirs /var and /etc make this a Unix-like system (see UnixPlugin.detect),
+            # while Linux-kernel specific files make it a Linux filesystem.
+            if fs.exists("/var") and fs.exists("/etc") and any(fs.exists(p) for p in LINUX_PATHS):
+                return fs
+
+            # This filesystem could be a volatile collection of a Linux system.
+            if fs.exists("/sys/module") or fs.exists("/proc/sys"):
                 return fs
 
     @export(property=True)


### PR DESCRIPTION
This PR aims to improve the detection of Linux-like filesystems in dissect.

On a side note, certain functionality in the `unix` space is actually `linux` specific (e.g. user parsing, fstab parsing, hostname parsing). Fixing this disambiguation and mixed shared functionality between `unix` and `linux` OS plugins is something for another time perhaps.