### PR TITLE
Revert "Fix ANSI color prompt in target-shell"

### DIFF
--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -99,7 +99,6 @@ class ExtendedCmd(cmd.Cmd):
 
     def __init__(self, cyber: bool = False):
         cmd.Cmd.__init__(self)
-        self.use_rawinput = False
         self.debug = False
         self.cyber = cyber
         self.identchars += "."


### PR DESCRIPTION
Reverts fox-it/dissect.target#1004

Reverting this commit as it breaks auto-completion, see: #1036