### PR TITLE
Improve Linux services parsing

### DIFF
--- a/dissect/target/helpers/configutil.py
+++ b/dissect/target/helpers/configutil.py
@@ -726,7 +726,7 @@ class SystemD(Indentation):
     ) -> bool:
         scope_char = ("[", "]")
         changed = False
-        if line.startswith(scope_char):
+        if line.lstrip().startswith(scope_char):
             if not manager.is_root():
                 changed = manager.pop()
             stripped_characters = "".join(scope_char)

--- a/dissect/target/plugins/os/unix/linux/services.py
+++ b/dissect/target/plugins/os/unix/linux/services.py
@@ -59,7 +59,7 @@ class ServicesPlugin(Plugin):
                     continue
 
                 try:
-                    parsed_config = configutil.parse(service_file, hint="ini")
+                    parsed_config = configutil.parse(service_file, hint="systemd")
                     config = {}
                     types = []
                     for segment, configuration in parsed_config.items():

--- a/tests/plugins/os/unix/linux/test_services.py
+++ b/tests/plugins/os/unix/linux/test_services.py
@@ -46,7 +46,7 @@ def test_services(target_unix_users: Target, fs_unix: VirtualFilesystem) -> None
         "Unit_Requires": "foo.service bar.service",
         "Service_Type": "simple",
         "Service_ExecStart": (
-            "/bin/bash -c 'exec /usr/bin/example param1 --param2=value2 -P3value3 -param4 value4; \\\nexit 0'"
+            "/bin/bash -c 'exec /usr/bin/example param1 --param2=value2 -P3value3 -param4 value4; exit 0'"
         ),
         "Service_SyslogIdentifier": "example-service",
         "Service_TimeoutStopSec": "5",


### PR DESCRIPTION
This PR improves Linux services parsing by switching to the configutil parser instead of using the etc plugin. We now also check if if a segment contains any configuration before attempting to parse it.