### PR TITLE
Add support for kernel log entries in syslog

### DIFF
--- a/dissect/target/plugins/os/unix/log/helpers.py
+++ b/dissect/target/plugins/os/unix/log/helpers.py
@@ -15,9 +15,9 @@ RE_TS_ISO = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}\+\d{2}:\d{2
 RE_LINE = re.compile(
     r"""
     \d{2}:\d{2}\s                           # First match on the similar ending of the different timestamps
-    (?:\S+)\s                               # The hostname, but do not capture it
-    (?P<service>\S+?)(\[(?P<pid>\d+)\])?:    # The service / daemon with optionally the PID between brackets
-    \s*(?P<message>.+?)\s*$                 # The log message stripped from spaces left and right
+    ((?:\S+)\s)?                            # The hostname (optional), but do not capture it
+    (?P<service>\S+?)(\[(?P<pid>\d+?)\])?:  # The service / daemon with optionally the PID between brackets
+    (\s*(?P<message>.+?)\s*)?$              # The log message stripped from spaces left and right
     """,
     re.VERBOSE,
 )

--- a/dissect/target/plugins/os/unix/log/messages.py
+++ b/dissect/target/plugins/os/unix/log/messages.py
@@ -87,7 +87,7 @@ class MessagesPlugin(Plugin):
                 match = RE_LINE.search(line)
 
                 if not match:
-                    self.target.log.warning("Unable to parse message line in %s: '%s'", log_file, line)
+                    self.target.log.warning("Unable to parse message line in %s: %r", log_file, line)
                     continue
 
                 yield MessagesRecord(

--- a/dissect/target/plugins/os/unix/log/messages.py
+++ b/dissect/target/plugins/os/unix/log/messages.py
@@ -87,8 +87,7 @@ class MessagesPlugin(Plugin):
                 match = RE_LINE.search(line)
 
                 if not match:
-                    self.target.log.warning("Unable to parse message line in %s", log_file)
-                    self.target.log.debug("Line %s", line)
+                    self.target.log.warning("Unable to parse message line in %s: '%s'", log_file, line)
                     continue
 
                 yield MessagesRecord(


### PR DESCRIPTION
Some Linux systems can include kernel ring buffer log messages in their syslogs. This PR adds support for those log lines.