### PR TITLE
Fix compatible plugins filter

### DIFF
--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -963,12 +963,10 @@ def _filter_compatible(
         if plugincls not in seen:
             seen.add(plugincls)
             try:
-                if not plugincls(target).is_compatible():
-                    continue
+                if plugincls(target).is_compatible():
+                    yield descriptor
             except Exception:
                 continue
-
-        yield descriptor
 
 
 def generate() -> dict[str, Any]:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -407,7 +407,7 @@ def test_find_functions_linux(target_linux: Target) -> None:
 
 
 def test_find_functions_compatible_check(target_linux: Target) -> None:
-    """test if we correctly check for compatibility in `find_functions` and `_filter_compatible`."""
+    """test if we correctly check for compatibility in ``find_functions`` and ``_filter_compatible``."""
     found, _ = find_functions("*", target_linux, compatibility=True)
     assert "os.unix.log.messages.syslog.syslog" not in [f"{f.path}.{f.name}" for f in found]
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -406,6 +406,12 @@ def test_find_functions_linux(target_linux: Target) -> None:
     assert found[0].path == "os.unix.linux.services.services"
 
 
+def test_find_functions_compatible_check(target_linux: Target) -> None:
+    """test if we correctly check for compatibility in `find_functions` and `_filter_compatible`."""
+    found, _ = find_functions("*", target_linux, compatibility=True)
+    assert "os.unix.log.messages.syslog.syslog" not in [f"{f.path}.{f.name}" for f in found]
+
+
 TestRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
     "application/test",
     [


### PR DESCRIPTION
This PR fixes the `find_plugins` function with `compatibility=True`. Previously descriptors were yielded if they were not seen before, regardless of their compatibility.