### PR TITLE
Fix compatible plugins filter (2)

### DIFF
--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -966,6 +966,7 @@ def _filter_compatible(
             plugincls = load(descriptor)
         except Exception:
             if ignore_load_errors:
+                incompatible.add(descriptor.qualname)
                 continue
             raise
 

--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -955,6 +955,13 @@ def _filter_compatible(
     incompatible = set()
 
     for descriptor in descriptors:
+        if descriptor.qualname in compatible:
+            yield descriptor
+            continue
+
+        if descriptor.qualname in incompatible:
+            continue
+
         try:
             plugincls = load(descriptor)
         except Exception:
@@ -962,19 +969,12 @@ def _filter_compatible(
                 continue
             raise
 
-        if plugincls in compatible:
-            yield descriptor
-            continue
-
-        if plugincls in incompatible:
-            continue
-
         try:
             if plugincls(target).is_compatible():
-                compatible.add(plugincls)
+                compatible.add(descriptor.qualname)
                 yield descriptor
         except Exception:
-            incompatible.add(plugincls)
+            incompatible.add(descriptor.qualname)
             continue
 
 

--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -960,8 +960,8 @@ def _filter_compatible(
                 continue
             raise
 
-        if plugincls not in seen:
-            seen.add(plugincls)
+        if descriptor.path not in seen:
+            seen.add(descriptor.path)
             try:
                 if plugincls(target).is_compatible():
                     yield descriptor

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -412,7 +412,7 @@ def test_find_functions_compatible_check(target_linux: Target) -> None:
     found, _ = find_functions("*", target_linux, compatibility=True)
     assert "os.unix.log.messages.syslog.syslog" not in [f"{f.path}.{f.name}" for f in found]
 
-    with (patch("dissect.target.plugins.apps.browser.chrome.ChromePlugin.check_compatible", return_value=None)):
+    with patch("dissect.target.plugins.apps.browser.chrome.ChromePlugin.check_compatible", return_value=None):
         found, _ = find_functions("*", target_linux, compatibility=True)
         functions = [f.path for f in found]
         assert "apps.browser.chrome.cookies" in functions

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -408,8 +408,15 @@ def test_find_functions_linux(target_linux: Target) -> None:
 
 def test_find_functions_compatible_check(target_linux: Target) -> None:
     """test if we correctly check for compatibility in ``find_functions`` and ``_filter_compatible``."""
+
     found, _ = find_functions("*", target_linux, compatibility=True)
     assert "os.unix.log.messages.syslog.syslog" not in [f"{f.path}.{f.name}" for f in found]
+
+    with (patch("dissect.target.plugins.apps.browser.chrome.ChromePlugin.check_compatible", return_value=None)):
+        found, _ = find_functions("*", target_linux, compatibility=True)
+        functions = [f.path for f in found]
+        assert "apps.browser.chrome.cookies" in functions
+        assert "apps.browser.chrome.history" in functions
 
 
 TestRecord = create_extended_descriptor([UserRecordDescriptorExtension])(


### PR DESCRIPTION
This PR fixes the `find_plugins` function with `compatibility=True` for plugin classes with multiple exported functions. Previously only the first descriptor was yielded and any other descriptors of the same plugin class were ignored.

This solution introduces a slightly slower `_filter_compatible` function. We could also keep `seen: set[Plugin]` and iterate over `plugincls.__functions__` once the plugin is determined to be compatible, but that might not work as intended for namespace plugins and regular plugins with multiple function exports.