### PR TITLE
Add other Windows Defender quarantine file stream IDs

### DIFF
--- a/dissect/target/plugins/os/windows/defender/quarantine.py
+++ b/dissect/target/plugins/os/windows/defender/quarantine.py
@@ -203,13 +203,30 @@ def recover_quarantined_file_streams(fh: BinaryIO, filename: str) -> Iterator[tu
         except EOFError:
             break
         data = buf.read(stream.Size)
-        if stream.StreamId == STREAM_ID.SECURITY_DATA:
-            yield (f"{filename}.security_descriptor", data)
-        elif stream.StreamId == STREAM_ID.DATA:
+
+        if stream.StreamId == STREAM_ID.DATA:
             yield (filename, data)
+        elif stream.StreamId == STREAM_ID.EA_DATA:
+            yield (f"{filename}.ea_data", data)
+        elif stream.StreamId == STREAM_ID.SECURITY_DATA:
+            yield (f"{filename}.security_descriptor", data)
         elif stream.StreamId == STREAM_ID.ALTERNATE_DATA:
             sanitized_stream_name = "".join(x for x in stream.StreamName if x.isalnum())
             yield (f"{filename}.{sanitized_stream_name}", data)
+        elif stream.StreamId == STREAM_ID.LINK:
+            yield (f"{filename}.link", data)
+        elif stream.StreamId == STREAM_ID.PROPERTY_DATA:
+            yield (f"{filename}.property_data", data)
+        elif stream.StreamId == STREAM_ID.OBJECT_ID:
+            yield (f"{filename}.object_id", data)
+        elif stream.StreamId == STREAM_ID.REPARSE_DATA:
+            yield (f"{filename}.reparse_data", data)
+        elif stream.StreamId == STREAM_ID.SPARSE_BLOCK:
+            yield (f"{filename}.sparse_block", data)
+        elif stream.StreamId == STREAM_ID.TXFS_DATA:
+            yield (f"{filename}.txfs_data", data)
+        elif stream.StreamId == STREAM_ID.GHOSTED_FILE_EXTENTS:
+            yield (f"{filename}.ghosted_file_extents", data)
         else:
             raise ValueError(f"Unexpected Stream ID {stream.StreamId}")
 

--- a/tests/plugins/os/windows/test_defender.py
+++ b/tests/plugins/os/windows/test_defender.py
@@ -377,6 +377,30 @@ def test_defender_mplogs_lines(target_win: Target, fs_win: VirtualFilesystem, tm
             "security_descriptor",
         ),
         (
+            STREAM_ID.LINK,
+            "link",
+        ),
+        (
+            STREAM_ID.PROPERTY_DATA,
+            "property_data",
+        ),
+        (
+            STREAM_ID.OBJECT_ID,
+            "object_id",
+        ),
+        (
+            STREAM_ID.REPARSE_DATA,
+            "reparse_data",
+        ),
+        (
+            STREAM_ID.SPARSE_BLOCK,
+            "sparse_block",
+        ),
+        (
+            STREAM_ID.TXFS_DATA,
+            "txfs_data",
+        ),
+        (
             STREAM_ID.GHOSTED_FILE_EXTENTS,
             "ghosted_file_extents",
         ),


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->

This PR adds the handling of the other valid stream IDs as described by https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-bkup/71b49aa4-1f4f-4e1b-84a4-56f560002cf6 for the Dissect Windows Defender quarantine implementation. Now all valid values are caught and invalid values should raise an exception. I couldn't find any test cases already, so I didn't add/alter test cases.

Resolves #1107.