### PR TITLE
Raise a NotADirectoryError inside the NFSFilesystemEntry.get when it is a file

### DIFF
--- a/dissect/target/filesystems/nfs.py
+++ b/dissect/target/filesystems/nfs.py
@@ -5,7 +5,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, BinaryIO, Callable, TypeVar
 
 from dissect.util.stream import AlignedStream
-
+from dissect.target.exceptions import NotADirectoryError
 from dissect.target.filesystem import Filesystem, FilesystemEntry
 from dissect.target.helpers import fsutil
 from dissect.target.helpers.nfs.client.mount import Client as MountClient
@@ -147,6 +147,9 @@ class NfsFilesystemEntry(FilesystemEntry):
         return self._backing_attributes
 
     def get(self, path: str) -> NfsFilesystemEntry:
+        if self.is_file():
+            raise NotADirectoryError
+
         return self.fs.get(path, relentry=self)
 
     def is_file(self, follow_symlinks: bool = True) -> bool:

--- a/dissect/target/filesystems/nfs.py
+++ b/dissect/target/filesystems/nfs.py
@@ -149,7 +149,7 @@ class NfsFilesystemEntry(FilesystemEntry):
 
     def get(self, path: str) -> NfsFilesystemEntry:
         """Get a new filesystem entry relative to this entry"""
-        if self.is_file():
+        if not self.is_dir():
             raise NotADirectoryError
 
         return self.fs.get(path, relentry=self)

--- a/dissect/target/filesystems/nfs.py
+++ b/dissect/target/filesystems/nfs.py
@@ -5,6 +5,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, BinaryIO, Callable, TypeVar
 
 from dissect.util.stream import AlignedStream
+
 from dissect.target.exceptions import NotADirectoryError
 from dissect.target.filesystem import Filesystem, FilesystemEntry
 from dissect.target.helpers import fsutil
@@ -147,6 +148,7 @@ class NfsFilesystemEntry(FilesystemEntry):
         return self._backing_attributes
 
     def get(self, path: str) -> NfsFilesystemEntry:
+        """Get a new filesystem entry relative to this entry"""
         if self.is_file():
             raise NotADirectoryError
 

--- a/tests/filesystems/test_nfs.py
+++ b/tests/filesystems/test_nfs.py
@@ -73,6 +73,7 @@ def test_get_subdirectory(nfs_filesystem: NfsFilesystem, mock_nfs_client: MagicM
 
 
 def test_get_from_entry(mock_nfs_client: MagicMock, nfs_filesystem_entry: NfsFilesystemEntry) -> None:
+    nfs_filesystem_entry._attributes.type = FileType.DIR
     mock_nfs_client.lookup.return_value = MagicMock(
         object=FileHandle(opaque=b"subdir_handle"), obj_attributes=MagicMock()
     )


### PR DESCRIPTION
This is to avoid an nfs lookup error when you try to enter a target over
an nfs3 connection. Loaders attempt to check for files inside this path,
where it tries to do a dir lookup on a file and it crashes.

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
