### PR TITLE
Clear cached functions on every test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from dissect.target.filesystem import Filesystem, VirtualFilesystem, VirtualSyml
 from dissect.target.filesystems.tar import TarFilesystem
 from dissect.target.helpers.fsutil import TargetPath
 from dissect.target.helpers.regutil import VirtualHive, VirtualKey, VirtualValue
+from dissect.target.plugin import _generate_long_paths
 from dissect.target.plugins.os.default._os import DefaultPlugin
 from dissect.target.plugins.os.unix._os import UnixPlugin
 from dissect.target.plugins.os.unix.bsd.citrix._os import CitrixPlugin
@@ -44,6 +45,11 @@ if not pathlib.Path(data_dir).is_dir():
         "the dissect.target GitHub repository at:\n"
         "https://github.com/fox-it/dissect.target"
     )
+
+
+@pytest.fixture(autouse=True)
+def clear_caches() -> None:
+    _generate_long_paths.cache_clear()
 
 
 def make_mock_target(tmp_path: pathlib.Path) -> Iterator[Target]:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -27,7 +27,6 @@ from dissect.target.plugin import (
     PluginDescriptorLookup,
     PluginRegistry,
     _find_py_files,
-    _generate_long_paths,
     _save_plugin_import_failure,
     alias,
     environment_variable_paths,
@@ -49,11 +48,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from flow.record import Record
-
-
-@pytest.fixture(autouse=True)
-def clear_caches() -> None:
-    _generate_long_paths.cache_clear()
 
 
 def test_save_plugin_import_failure() -> None:

--- a/tests/tools/test_query.py
+++ b/tests/tools/test_query.py
@@ -52,10 +52,10 @@ def test_list(capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch) ->
     ],
 )
 def test_invalid_functions(
-    capsys: pytest.CaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
     given_funcs: list[str],
     expected_invalid_funcs: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
 ) -> None:
     with monkeypatch.context() as m:
         m.setattr(
@@ -105,10 +105,10 @@ def test_invalid_functions(
     ],
 )
 def test_invalid_excluded_functions(
-    capsys: pytest.CaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
     given_funcs: list[str],
     expected_invalid_funcs: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
 ) -> None:
     with monkeypatch.context() as m:
         m.setattr(


### PR DESCRIPTION
After we enabled test randomization, sometimes we get a test failure on`tests/tools/test_query.py::test_invalid_functions` and `tests/tools/test_query.py::test_invalid_excluded_functions` (https://github.com/fox-it/dissect.target/actions/runs/14494203513/job/40657657729?pr=1108)

However, I can't reproduce even with the same seed. I have a suspicion that a cached `_generate_long_paths` is the issue, so I moved the clearing of that cache from just the `test_plugin.py` file to every test in the suite.