### PR TITLE
Improve UNIX domain parsing

### DIFF
--- a/dissect/target/plugins/os/unix/_os.py
+++ b/dissect/target/plugins/os/unix/_os.py
@@ -169,10 +169,14 @@ class UnixPlugin(OSPlugin):
 
     @export(property=True)
     def domain(self) -> str | None:
-        if self._domain is None or self._domain == "localhost":
-            # fall back to /etc/hosts file
-            return self._hosts_dict.get("hostname")
-        return self._domain
+        if self._domain and "localhost" not in self._domain:
+            return self._domain
+
+        # fall back to /etc/hosts file
+        if "localhost" not in (domain := self._hosts_dict.get("hostname", "")):
+            return domain or None
+
+        return None
 
     @export(property=True)
     def os(self) -> str:

--- a/tests/plugins/os/unix/test__os.py
+++ b/tests/plugins/os/unix/test__os.py
@@ -109,7 +109,9 @@ def test_mount_volume_name_regression(fs_unix: VirtualFilesystem) -> None:
     [
         (b"", b"", "localhost", None),
         (b"", b"127.0.0.1 mydomain", "mydomain", "mydomain"),
-        (b"", b"127.0.0.1 localhost", "localhost", "localhost"),
+        (b"", b"127.0.0.1 localhost", "localhost", None),
+        (b"hostname", b"127.0.0.1 localhost\n::1 ip6-localhost", "hostname", None),
+        (b"hostname.example.internal", b"127.0.0.1 localhost\n::1 ip6-localhost", "hostname", "example.internal"),
         (b"myhost", b"", "myhost", None),
         (b"myhost.mydomain", b"", "myhost", "mydomain"),
         (b"myhost", b"127.0.0.1 mydomain", "myhost", "mydomain"),
@@ -132,8 +134,10 @@ def test_parse_domain(
     fs_unix.map_file_fh("/etc/hosts", BytesIO(hosts_content))
     target_unix.add_plugin(UnixPlugin)
 
-    assert target_unix.hostname == expected_hostname
-    assert target_unix.domain == expected_domain
+    assert target_unix.hostname == expected_hostname, (
+        f"Expected hostname {expected_hostname!r} but got {target_unix.hostname!r}"
+    )
+    assert target_unix.domain == expected_domain, f"Expected domain {expected_domain!r} but got {target_unix.domain!r}"
 
 
 @pytest.mark.parametrize(
@@ -167,8 +171,8 @@ def test_parse_hostname_string(
 
     hostname, domain = target_unix._os._parse_hostname_string()
 
-    assert hostname == expected_hostname
-    assert domain == expected_domain
+    assert hostname == expected_hostname, f"Expected hostname {expected_hostname!r} but got {hostname!r}"
+    assert domain == expected_domain, f"Expected domain {expected_domain!r} but got {domain!r}"
 
 
 def test_users(target_unix_users: Target) -> None:


### PR DESCRIPTION
In succession of #1079, this PR aims to fix UNIX domain parsing by filtering "domains" such as `localhost` and `ip6-localhost` which are commonly found in `/etc/hosts`.