### PR TITLE
Improve Apache log format detection

### DIFF
--- a/dissect/target/plugins/apps/webserver/apache.py
+++ b/dissect/target/plugins/apps/webserver/apache.py
@@ -563,7 +563,7 @@ class ApachePlugin(WebserverPlugin):
 def clean_value(value: str | None) -> str | None:
     """Clean the given value by replacing empty strings and ``"-"`` with ``None``."""
 
-    if not value or value == "-":
+    if value in ("-", ""):
         return None
 
     return value

--- a/tests/plugins/apps/webserver/test_citrix.py
+++ b/tests/plugins/apps/webserver/test_citrix.py
@@ -57,7 +57,7 @@ def test_access_logs(target_citrix: Target, fs_bsd: VirtualFilesystem) -> None:
     assert citrix_netscaler_headers_combined_response_log.method == "GET"
     assert citrix_netscaler_headers_combined_response_log.uri == "/"
     assert citrix_netscaler_headers_combined_response_log.protocol == "HTTP/1.1"
-    assert citrix_netscaler_headers_combined_response_log.referer == "-"
+    assert citrix_netscaler_headers_combined_response_log.referer is None
     assert (
         citrix_netscaler_headers_combined_response_log.useragent
         == "Mozilla/5.0 (Windows NT 10.0; Win64; x64); AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 "
@@ -73,7 +73,7 @@ def test_access_logs(target_citrix: Target, fs_bsd: VirtualFilesystem) -> None:
     assert citrix_netscaler_headers_combined_response_log.method == "GET"
     assert citrix_netscaler_headers_combined_response_log.uri == "/"
     assert citrix_netscaler_headers_combined_response_log.protocol == "HTTP/1.1"
-    assert citrix_netscaler_headers_combined_response_log.referer == "-"
+    assert citrix_netscaler_headers_combined_response_log.referer is None
     assert citrix_netscaler_headers_combined_response_log.useragent == "curl/7.78.0"
     assert citrix_netscaler_headers_combined_response_log.response_time_ms == 39
     assert citrix_netscaler_headers_combined_response_log.pid == 82775


### PR DESCRIPTION
This PR improves the Apache access log parser. The `RE_ACCESS_COMMON_PATTERN` now supports empty `method`, `uri` and `protocol` values (e.g. `"-"`). Empty Apache values (`-`) are now cast to `None` as well. For context see the modified and added tests.