### PR TITLE
Add workaround for ANSI codes target-shell tests

### DIFF
--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -1583,11 +1583,12 @@ def main() -> int:
     # PyPy < 3.10.14 readline is stuck in Python 2.7
     if platform.python_implementation() == "PyPy":
         major, minor, patch = tuple(map(int, platform.python_version_tuple()))
-        if major <= 3 and minor <= 10 and patch < 14:
+        if major < 3 or (major == 3 and (minor < 10 or (minor == 10 and patch < 14))):
             print(
                 "Note for users of PyPy < 3.10.14:\n"
                 "Autocomplete might not work due to an outdated version of pyrepl/readline.py\n"
-                "To fix this, please update your version of PyPy."
+                "To fix this, please update your version of PyPy.",
+                file=sys.stderr,
             )
 
     try:

--- a/tests/tools/test_shell.py
+++ b/tests/tools/test_shell.py
@@ -49,7 +49,7 @@ INPUT_STREAM = f"""
     last line
 """
 
-if HAS_PEXPECT:
+if HAS_PEXPECT and platform.system() != "Windows":
 
     class AnsiExpecter(pexpect.expect.Expecter):
         ANSI_ESCAPE = re.compile(rb"\x07|\x08|\x0d|\x7f|\x1b[@-_][0-?]*[ -/]*[@-~]")
@@ -435,10 +435,6 @@ def test_shell_hostname_escaping(
 
 
 @pytest.mark.skipif(not HAS_PEXPECT, reason="requires pexpect")
-@pytest.mark.skipif(
-    platform.python_implementation() == "PyPy",
-    reason="PyPy's prompt contains too much ANSI escape codes",
-)
 @pytest.mark.skipif(
     platform.system() == "Windows",
     reason="pexpect.spawn not available on Windows",

--- a/tests/tools/test_shell.py
+++ b/tests/tools/test_shell.py
@@ -441,7 +441,10 @@ def test_shell_prompt_tab_autocomplete() -> None:
         child.send("\t\t")
 
         # expect the files in /etc/ to be printed
-        child.expect(r"hosts\s+localtime\s+network/\s+os-release\s+passwd\s+shadow\s+timezone\s*\n", timeout=5)
+        child.expect(
+            r"hosts\s+localtime\s+network\/\s+os-release\s+passwd\s+shadow\s+timezone\s*ubuntu:\/\$ ls \/etc\/",
+            timeout=5,
+        )
 
         # send newline to just list everything in /etc/
         child.send("\n")


### PR DESCRIPTION
Should fix #1111. Only tested locally on uv cpython 3.12 and 3.13 so far, curious to see if the regular CI test environments still pass.