### PR TITLE
Include OSPlugin functions in `find_functions` output

### DIFF
--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -1015,7 +1015,7 @@ def _filter_compatible(
 
         try:
             if issubclass(plugincls, OSPlugin):
-                if issubclass(plugincls, target._os_plugin):
+                if issubclass(target._os_plugin, plugincls):
                     compatible.add(descriptor.qualname)
                     yield descriptor
                 else:

--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -685,15 +685,19 @@ def _module_path(cls: type[Plugin] | str) -> str:
     return module.replace(MODULE_PATH, "").lstrip(".")
 
 
+@functools.lru_cache(256)
 def _os_match(osfilter: type[OSPlugin], module_path: str) -> bool:
     """Check if the a plugin is compatible with the given OS filter."""
-    if issubclass(osfilter, default._os.DefaultOSPlugin):
+    module_parts = module_path.split(".")
+
+    # DefaultOSPlugin is "compatible" with everything, even other `os.*` modules (except `_os`)
+    if issubclass(osfilter, default._os.DefaultOSPlugin) and (len(module_parts) < 2 or module_parts[-2] != "_os"):
         return True
 
     os_parts = _module_path(osfilter).split(".")[:-1]
 
     obj = _get_plugins().__ostree__
-    for plugin_part, os_part in zip_longest(module_path.split("."), os_parts):
+    for plugin_part, os_part in zip_longest(module_parts, os_parts):
         if plugin_part not in obj:
             break
 
@@ -792,7 +796,7 @@ def lookup(
         value for key, value in function_index.items() if osfilter is None or _os_match(osfilter, key)
     )
 
-    yield from sorted(entries, key=lambda x: x.module.count("."), reverse=True)
+    yield from sorted(entries, key=lambda desc: desc.module.count("."), reverse=True)
 
 
 def load(desc: FunctionDescriptor | PluginDescriptor) -> type[Plugin]:
@@ -836,17 +840,18 @@ def failed() -> list[FailureDescriptor]:
 
 
 @functools.cache
-def _generate_long_paths() -> dict[str, list[FunctionDescriptor]]:
-    """Generate a dictionary of all long paths to their function descriptors for regular and OS functions."""
-    paths = {}
-    functions = _get_plugins().__functions__
-    for value in chain(functions.__regular__.values(), functions.__os__.values()):
-        for descriptor in value.values():
-            # Namespace plugins are callable so exclude the explicit __call__ method
-            if descriptor.method_name == "__call__":
-                continue
+def _generate_long_paths(os_filter: type[OSPlugin]) -> dict[str, list[FunctionDescriptor]]:
+    """Generate a dictionary of all long paths to their function descriptors for the given functions."""
+    __regular__ = functions(os_filter, index="__regular__")
+    __os__ = functions(os_filter, index="__os__")
 
-            paths.setdefault(descriptor.path, []).append(descriptor)
+    paths = {}
+    for descriptor in chain(__regular__, __os__):
+        # Namespace plugins are callable so exclude the explicit __call__ method
+        if descriptor.method_name == "__call__":
+            continue
+
+        paths.setdefault(descriptor.path, []).append(descriptor)
 
     return paths
 
@@ -885,23 +890,18 @@ def find_functions(
         exact_os_match = pattern in os_functions
 
         if exact_match or exact_os_match:
-            if matches := list(_filter_exact_match(pattern, os_filter, exact_match, exact_os_match)):
-                found.extend(matches)
-            else:
-                invalid_functions.add(pattern)
+            matches = list(_filter_exact_match(pattern, os_filter, "__os__" if exact_os_match else "__regular__"))
         else:
             # If we don't have an exact function match, do a slower treematch
-            if matches := list(_filter_tree_match(pattern, os_filter, show_hidden=show_hidden)):
-                found.extend(matches)
-            else:
-                invalid_functions.add(pattern)
+            matches = list(_filter_tree_match(pattern, os_filter, show_hidden=show_hidden))
 
-    if compatibility and target is not None:
-        result = list(_filter_compatible(found, target, ignore_load_errors))
-    else:
-        result = found
+        if matches:
+            found.extend(matches)
+        else:
+            invalid_functions.add(pattern)
 
-    return result, invalid_functions
+    result = _filter_compatible(found, target, ignore_load_errors) if compatibility and target is not None else found
+    return list(result), invalid_functions
 
 
 def find_functions_by_record_field_type(
@@ -942,28 +942,19 @@ def find_functions_by_record_field_type(
 
 
 def _filter_exact_match(
-    pattern: str, os_filter: type[OSPlugin] | None, exact_match: bool, exact_os_match: bool
+    pattern: str,
+    os_filter: type[OSPlugin] | None,
+    index: str = "__regular__",
 ) -> Iterator[FunctionDescriptor]:
-    if exact_match:
-        descriptors = lookup(pattern, os_filter)
-    elif exact_os_match:
-        descriptors = lookup(pattern, os_filter, index="__os__")
-
-    for descriptor in descriptors:
-        if not descriptor.exported:
-            continue
-
-        yield descriptor
+    descriptors = lookup(pattern, os_filter, index=index)
+    yield from (descriptor for descriptor in descriptors if descriptor.exported)
 
 
 def _filter_tree_match(
     pattern: str, os_filter: type[OSPlugin] | None, show_hidden: bool = False
 ) -> Iterator[FunctionDescriptor]:
-    """Perform a slow filter tree match for the given pattern on all ``__regular__``
-    and ``__os__`` :class:`FunctionDescriptor` instances.
-    """
-
-    path_lookup = _generate_long_paths()
+    """Perform a slow tree match on all ``__regular__`` and ``__os__`` :class:`FunctionDescriptor` instances."""
+    path_lookup = _generate_long_paths(os_filter)
 
     # Change the treematch pattern into an fnmatch-able pattern to give back all functions from the sub-tree
     # (if there is a subtree).
@@ -977,17 +968,16 @@ def _filter_tree_match(
     if not has_glob_magic(pattern):
         search_pattern += "*"
 
+    result: list[FunctionDescriptor] = []
     for path in fnmatch.filter(path_lookup.keys(), search_pattern):
         for descriptor in path_lookup[path]:
             # Skip plugins that don't want to be found by wildcards
             if not descriptor.exported or (not show_hidden and not descriptor.findable):
                 continue
 
-            # Skip plugins that do not match our OS
-            if os_filter and not _os_match(os_filter, descriptor.path):
-                continue
+            result.append(descriptor)
 
-            yield descriptor
+    yield from sorted(result, key=lambda desc: desc.module.count("."), reverse=True)
 
 
 def _filter_compatible(
@@ -1021,12 +1011,11 @@ def _filter_compatible(
                 else:
                     incompatible.add(descriptor.qualname)
                     continue
+            elif plugincls(target).is_compatible():
+                compatible.add(descriptor.qualname)
+                yield descriptor
             else:
-                if plugincls(target).is_compatible():
-                    compatible.add(descriptor.qualname)
-                    yield descriptor
-                else:
-                    incompatible.add(descriptor.qualname)
+                incompatible.add(descriptor.qualname)
         except Exception:
             incompatible.add(descriptor.qualname)
 

--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -960,7 +960,7 @@ def _filter_tree_match(
     pattern: str, os_filter: type[OSPlugin] | None, show_hidden: bool = False
 ) -> Iterator[FunctionDescriptor]:
     """Perform a slow filter tree match for the given pattern on all ``__regular__``
-    and ``__os`` :class:`FunctionDescriptor` instances.
+    and ``__os__`` :class:`FunctionDescriptor` instances.
     """
 
     path_lookup = _generate_long_paths()

--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -1014,11 +1014,19 @@ def _filter_compatible(
             raise
 
         try:
-            if plugincls(target).is_compatible():
-                compatible.add(descriptor.qualname)
-                yield descriptor
+            if issubclass(plugincls, OSPlugin):
+                if issubclass(plugincls, target._os_plugin):
+                    compatible.add(descriptor.qualname)
+                    yield descriptor
+                else:
+                    incompatible.add(descriptor.qualname)
+                    continue
             else:
-                incompatible.add(descriptor.qualname)
+                if plugincls(target).is_compatible():
+                    compatible.add(descriptor.qualname)
+                    yield descriptor
+                else:
+                    incompatible.add(descriptor.qualname)
         except Exception:
             incompatible.add(descriptor.qualname)
 

--- a/dissect/target/tools/utils.py
+++ b/dissect/target/tools/utils.py
@@ -227,6 +227,8 @@ def list_plugins(
             print(generate_functions_json(collected), end="")
         else:
             print(generate_functions_overview(collected, include_docs=fargs.print_docs))
+    elif json:
+        print("{", end="")
 
     # No real targets specified, show the available loaders
     if not targets:

--- a/dissect/target/tools/utils.py
+++ b/dissect/target/tools/utils.py
@@ -27,7 +27,6 @@ from dissect.target.plugin import (
 )
 from dissect.target.plugins.general.plugins import (
     _get_default_functions,
-    _get_os_functions,
     generate_functions_json,
     generate_functions_overview,
 )
@@ -202,31 +201,26 @@ def list_plugins(
     include_children: bool = False,
     json: bool = False,
 ) -> None:
-    collected = set()
-    if targets or patterns:
-        collected.update(_get_os_functions())
-
+    functions = None
     if targets:
         for target in Target.open_all(targets, include_children):
-            funcs, _ = find_functions(patterns or "*", target, compatibility=True, show_hidden=True)
-            collected.update(funcs)
+            functions, _ = find_functions(patterns or "*", target, compatibility=True, show_hidden=True)
     elif patterns:
-        funcs, _ = find_functions(patterns, Target(), show_hidden=True)
-        collected.update(funcs)
+        functions, _ = find_functions(patterns, Target(), show_hidden=True)
     else:
-        collected.update(_get_default_functions())
+        functions = _get_default_functions()
 
     target = Target()
     fparser = generate_argparse_for_method(target.plugins, usage_tmpl=USAGE_FORMAT_TMPL)
     fargs, _ = fparser.parse_known_args()
 
     # Display in a user friendly manner
-    if collected:
+    if functions:
         if json:
             print('{"plugins": ', end="")
-            print(generate_functions_json(collected), end="")
+            print(generate_functions_json(functions), end="")
         else:
-            print(generate_functions_overview(collected, include_docs=fargs.print_docs))
+            print(generate_functions_overview(functions, include_docs=fargs.print_docs))
     elif json:
         print("{", end="")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from dissect.target.filesystems.tar import TarFilesystem
 from dissect.target.helpers import keychain
 from dissect.target.helpers.fsutil import TargetPath
 from dissect.target.helpers.regutil import VirtualHive, VirtualKey, VirtualValue
-from dissect.target.plugin import _generate_long_paths
+from dissect.target.plugin import _generate_long_paths, _os_match
 from dissect.target.plugins.os.default._os import DefaultOSPlugin
 from dissect.target.plugins.os.unix._os import UnixPlugin
 from dissect.target.plugins.os.unix.bsd.citrix._os import CitrixPlugin
@@ -88,6 +88,7 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
 @pytest.fixture(autouse=True)
 def clear_caches() -> None:
     _generate_long_paths.cache_clear()
+    _os_match.cache_clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/plugins/os/windows/test_cim.py
+++ b/tests/plugins/os/windows/test_cim.py
@@ -24,7 +24,7 @@ def test_cim_plugin(target_win: Target, fs_win: VirtualFilesystem) -> None:
     assert len([record for record in target_win.cim() if record.filter_query]) == 3
 
 
-"""
+r"""
 Result of the WMI query on the system used to generate the test data
 
 ## __FilterToConsumerBinding
@@ -260,4 +260,4 @@ SourceName               : Service Control Manager
 UNCServerName            :
 PSComputerName           : DESKTOP-O8964S4
 ```
-"""  # noqa : W605 E501
+"""  # noqa: E501

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -370,7 +370,7 @@ class MockOSWarpPlugin(OSPlugin):
 @pytest.mark.parametrize(
     ("search", "assert_num_found"),
     [
-        ("*", 2),  # Found with tree search using wildcard, excluding OS plugins and unfindable
+        ("*", 3),  # Found with tree search using wildcard, excluding unfindable plugins
         ("test.x13.*", 1),  # Found with tree search using wildcard, expands to test.x13.f3
         ("test.x13", 1),  # Found with tree search, same as above, because users expect +*
         ("test.x13.f3", 1),
@@ -380,13 +380,13 @@ class MockOSWarpPlugin(OSPlugin):
         ("test.???.??", 1),  # Found with tree search, using question marks
         ("x13", 0),  # Not Found: Part of namespace but no match
         ("Warp.*", 0),  # Not Found: Namespace != Module so 0
-        ("os.warp._os.f6", 0),  # OS plugins are excluded from tree search
+        ("os.warp._os.f6", 1),  # OS plugins are included in tree search
         ("f6", 1),  # Found with direct match
         ("f22", 1),  # Unfindable has no effect on direct match
         ("Warp.f3", 1),  # Found with namespace + function
         ("f3", 1),  # Found direct match
-        ("os.*", 1),  # Found matching os.f3
-        ("os", 1),  # No tree search for "os" because it's a direct match
+        ("os.*", 2),  # Found matching os.f3
+        ("os", 2),  # No tree search for "os" because it's a direct match
     ],
 )
 def test_find_functions(target: MagicMock, plugins: dict, search: str, assert_num_found: int) -> None:
@@ -1298,8 +1298,8 @@ def test_exported_plugin_format(descriptor: FunctionDescriptor) -> None:
     References:
         - https://docs.dissect.tools/en/latest/contributing/style-guide.html
     """
-    # Ignore DefaultOSPlugin and NamespacePlugin instances
-    if descriptor.cls.__base__ is NamespacePlugin or descriptor.cls is DefaultOSPlugin:
+    # Ignore DefaultOSPlugin, NamespacePlugin and OSPlugin instances
+    if issubclass(descriptor.cls, (NamespacePlugin, OSPlugin)) or descriptor.cls is DefaultOSPlugin:
         return
 
     # Plugin method should specify what it returns

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -6,7 +6,7 @@ import textwrap
 from functools import reduce
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 from docutils.core import publish_string

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -46,6 +46,7 @@ from dissect.target.plugins.os.default._os import DefaultOSPlugin
 from dissect.target.plugins.os.unix.linux._os import LinuxPlugin
 from dissect.target.plugins.os.unix.linux.debian._os import DebianPlugin
 from dissect.target.plugins.os.unix.linux.fortios._os import FortiOSPlugin
+from dissect.target.plugins.os.windows._os import WindowsPlugin
 from dissect.target.target import Target
 
 if TYPE_CHECKING:
@@ -277,159 +278,6 @@ def test_plugin_directory(mock_plugins: PluginRegistry, tmp_path: Path) -> None:
             exports=["my_function", "__call__"],
         ),
     }
-
-
-class MockOSWarpPlugin(OSPlugin):
-    __exports__ = ("f6",)  # OS exports f6
-    __register__ = False
-    __name__ = "warp"
-
-    def __init__(self):
-        pass
-
-    def f3(self) -> str:
-        return "F3"
-
-    def f6(self) -> str:
-        return "F6"
-
-
-@patch(
-    "dissect.target.plugin._get_plugins",
-    return_value=PluginRegistry(
-        __functions__=FunctionDescriptorLookup(
-            __regular__={
-                "Warp.f3": {
-                    "test.x13.x13": FunctionDescriptor(
-                        name="Warp.f3",
-                        namespace="Warp",
-                        path="test.x13.f3",
-                        exported=True,
-                        internal=False,
-                        findable=True,
-                        alias=False,
-                        output="record",
-                        method_name="f3",
-                        module="test.x13",
-                        qualname="x13",
-                    )
-                },
-                "f3": {
-                    "os.f3": FunctionDescriptor(
-                        name="f3",
-                        namespace=None,
-                        path="os.f3",
-                        exported=True,
-                        internal=False,
-                        findable=True,
-                        alias=False,
-                        output="record",
-                        method_name="f3",
-                        module="os",
-                        qualname="f3",
-                    )
-                },
-                "f22": {
-                    "test.x69.x69": FunctionDescriptor(
-                        name="f22",
-                        namespace=None,
-                        path="test.x69.f22",
-                        exported=True,
-                        internal=False,
-                        findable=False,
-                        alias=False,
-                        output="record",
-                        method_name="f22",
-                        module="test.x69",
-                        qualname="x69",
-                    )
-                },
-            },
-            __os__={
-                "f6": {
-                    "os.warp._os.warp": FunctionDescriptor(
-                        name="f6",
-                        namespace=None,
-                        path="os.warp._os.f6",
-                        exported=True,
-                        internal=False,
-                        findable=True,
-                        alias=False,
-                        output="record",
-                        method_name="f6",
-                        module="os.warp._os",
-                        qualname="warp",
-                    )
-                }
-            },
-        ),
-        __ostree__={"os": {"warp": {}}},
-    ),
-)
-@patch("dissect.target.Target", create=True)
-@pytest.mark.parametrize(
-    ("search", "assert_num_found"),
-    [
-        ("*", 3),  # Found with tree search using wildcard, excluding unfindable plugins
-        ("test.x13.*", 1),  # Found with tree search using wildcard, expands to test.x13.f3
-        ("test.x13", 1),  # Found with tree search, same as above, because users expect +*
-        ("test.x13.f3", 1),
-        ("test.*", 1),  # Found with tree search
-        ("test.[!x]*", 0),  # Not Found with tree search, all in test not starting with x (no x13)
-        ("test.[!y]*", 1),  # Found with tree search, all in test not starting with y (so x13 is ok)
-        ("test.???.??", 1),  # Found with tree search, using question marks
-        ("x13", 0),  # Not Found: Part of namespace but no match
-        ("Warp.*", 0),  # Not Found: Namespace != Module so 0
-        ("os.warp._os.f6", 1),  # OS plugins are included in tree search
-        ("f6", 1),  # Found with direct match
-        ("f22", 1),  # Unfindable has no effect on direct match
-        ("Warp.f3", 1),  # Found with namespace + function
-        ("f3", 1),  # Found direct match
-        ("os.*", 2),  # Found matching os.f3
-        ("os", 2),  # No tree search for "os" because it's a direct match
-    ],
-)
-def test_find_functions(target: MagicMock, plugins: dict, search: str, assert_num_found: int) -> None:
-    target._os_plugin = MockOSWarpPlugin
-    target._os_plugin.__module__ = "dissect.target.plugins.os.warp._os"
-
-    found, _ = find_functions(search, target)
-    assert len(found) == assert_num_found
-
-
-def test_find_functions_windows(target_win: Target) -> None:
-    found, _ = find_functions("services", target_win)
-
-    assert len(found) == 1
-    assert found[0].name == "services"
-    assert found[0].path == "os.windows.services.services"
-
-
-def test_find_functions_linux(target_linux: Target) -> None:
-    found, _ = find_functions("services", target_linux)
-
-    assert len(found) == 1
-    assert found[0].name == "services"
-    assert found[0].path == "os.unix.linux.services.services"
-
-
-def test_find_functions_compatible_check(target_linux: Target) -> None:
-    """Test if we correctly check for compatibility in ``find_functions`` and ``_filter_compatible``."""
-
-    found, _ = find_functions("*", target_linux, compatibility=True)
-    assert "os.unix.log.messages.syslog.syslog" not in [f"{f.path}.{f.name}" for f in found]
-
-    with patch("dissect.target.plugins.apps.browser.chrome.ChromePlugin.check_compatible", return_value=None):
-        found, _ = find_functions("*", target_linux, compatibility=True)
-        functions = [f.path for f in found]
-        assert "apps.browser.chrome.cookies" in functions
-        assert "apps.browser.chrome.history" in functions
-
-
-@pytest.mark.benchmark
-def test_benchmark_functions_compatible_check(target_unix_users: Target, benchmark: BenchmarkFixture) -> None:
-    """Benchmark ``_filter_compatible`` performance."""
-    benchmark(lambda: find_functions("*", target_unix_users, compatibility=True))
 
 
 TestRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
@@ -703,238 +551,574 @@ def test_incompatible_plugin(target_bare: Target) -> None:
         target_bare.add_plugin(_TestIncompatiblePlugin)
 
 
+# A realistic slimmed down mock of a PluginRegistry
 MOCK_PLUGINS = PluginRegistry(
-    __functions__=FunctionDescriptorLookup(
-        __regular__={
-            "mail": {
-                "apps.mail.MailPlugin": FunctionDescriptor(
-                    name="mail",
-                    namespace=None,
-                    path="apps.mail.mail",
-                    exported=True,
-                    internal=False,
-                    findable=True,
-                    alias=False,
-                    output="record",
-                    method_name="mail",
-                    module="apps.mail",
-                    qualname="MailPlugin",
-                )
-            },
-            "app1": {
-                "os.apps.app1.App1Plugin": FunctionDescriptor(
-                    name="app1",
-                    namespace=None,
-                    path="os.apps.app1.app1",
-                    exported=True,
-                    internal=False,
-                    findable=True,
-                    alias=False,
-                    output="record",
-                    method_name="app1",
-                    module="os.apps.app1",
-                    qualname="App1Plugin",
-                )
-            },
-            "app2": {
-                "os.apps.app2.App2Plugin": FunctionDescriptor(
-                    name="app2",
-                    namespace=None,
-                    path="os.apps.app2.app2",
-                    exported=True,
-                    internal=False,
-                    findable=True,
-                    alias=False,
-                    output="record",
-                    method_name="app2",
-                    module="os.apps.app2",
-                    qualname="App2Plugin",
-                ),
-                "os.fooos.apps.app2.App2Plugin": FunctionDescriptor(
-                    name="app2",
-                    namespace=None,
-                    path="os.fooos.apps.app2.app2",
-                    exported=True,
-                    internal=False,
-                    findable=True,
-                    alias=False,
-                    output="record",
-                    method_name="app2",
-                    module="os.fooos.apps.app2",
-                    qualname="App2Plugin",
-                ),
-            },
-            "foo_app": {
-                "os.fooos.apps.foo_app.FooAppPlugin": FunctionDescriptor(
-                    name="foo_app",
-                    namespace=None,
-                    path="os.fooos.apps.foo_app.foo_app",
-                    exported=True,
-                    internal=False,
-                    findable=True,
-                    alias=False,
-                    output="record",
-                    method_name="foo_app",
-                    module="os.foos.apps.foo_app",
-                    qualname="FooAppPlugin",
-                )
-            },
-            "bar_app": {
-                "os.fooos.apps.bar_app.BarAppPlugin": FunctionDescriptor(
-                    name="bar_app",
-                    namespace=None,
-                    path="os.fooos.apps.bar_app.bar_app",
-                    exported=True,
-                    internal=False,
-                    findable=True,
-                    alias=False,
-                    output="record",
-                    method_name="bar_app",
-                    module="os.foos.apps.bar_app",
-                    qualname="BarAppPlugin",
-                )
-            },
-            "foobar": {
-                "os.fooos.foobar.FooBarPlugin": FunctionDescriptor(
-                    name="foobar",
-                    namespace=None,
-                    path="os.fooos.foobar.foobar",
-                    exported=True,
-                    internal=False,
-                    findable=True,
-                    alias=False,
-                    output="record",
-                    method_name="foobar",
-                    module="os.foos.foobar",
-                    qualname="FooBarPlugin",
-                )
-            },
-        },
-        __os__={
-            "generic_os": {
-                "os._os.GenericOS": FunctionDescriptor(
-                    name="generic_os",
-                    namespace=None,
-                    path="os._os.generic_os",
-                    exported=True,
-                    internal=False,
-                    findable=True,
-                    alias=False,
-                    output="record",
-                    method_name="generic_os",
-                    module="os._os",
-                    qualname="GenericOS",
-                )
-            },
-            "foo_os": {
-                "os.fooos._os.FooOS": FunctionDescriptor(
-                    name="foo_os",
-                    namespace=None,
-                    path="os.fooos._os.foo_os",
-                    exported=True,
-                    internal=False,
-                    findable=True,
-                    alias=False,
-                    output="record",
-                    method_name="foo_os",
-                    module="os.fooos._os",
-                    qualname="FooOS",
-                )
-            },
-        },
-    ),
     __plugins__=PluginDescriptorLookup(
         __regular__={
-            "apps.mail.MailPlugin": PluginDescriptor(
-                module="apps.mail",
-                qualname="MailPlugin",
+            # Non-OS, regular
+            "general.osinfo.OSInfoPlugin": PluginDescriptor(
+                module="dissect.target.plugins.general.osinfo",
+                qualname="OSInfoPlugin",
                 namespace=None,
-                path="apps.mail",
+                path="general.osinfo",
                 findable=True,
-                functions=["mail"],
-                exports=["mail"],
+                functions=["osinfo"],
+                exports=["osinfo"],
             ),
-            "os.apps.app1.App1Plugin": PluginDescriptor(
-                module="os.apps.app1",
-                qualname="App1Plugin",
-                namespace=None,
-                path="os.apps.app1",
-                findable=True,
-                functions=["app1"],
-                exports=["app1"],
+            # Non-OS, with namespace
+            "apps.chat.chat.ChatPlugin": PluginDescriptor(
+                module="dissect.target.plugins.apps.chat.chat",
+                qualname="ChatPlugin",
+                namespace="chat",
+                path="apps.chat.chat",
+                findable=False,
+                functions=["history", "__call__"],
+                exports=["history", "__call__"],
             ),
-            "os.apps.app2.App2Plugin": PluginDescriptor(
-                module="os.apps.app2",
-                qualname="App2Plugin",
-                namespace=None,
-                path="os.apps.app2",
+            "apps.chat.msn.MSNPlugin": PluginDescriptor(
+                module="dissect.target.plugins.apps.chat.msn",
+                qualname="MSNPlugin",
+                namespace="msn",
+                path="apps.chat.msn",
                 findable=True,
-                functions=["app2"],
-                exports=["app2"],
+                functions=["history", "__call__"],
+                exports=["history", "__call__"],
             ),
-            "os.fooos.apps.app2.App2Plugin": PluginDescriptor(
-                module="os.fooos.apps.app2",
-                qualname="App2Plugin",
+            # OS, regular
+            "os.windows.generic.GenericPlugin": PluginDescriptor(
+                module="dissect.target.plugins.os.windows.generic",
+                qualname="GenericPlugin",
                 namespace=None,
-                path="os.fooos.apps.app2",
+                path="os.windows.generic",
                 findable=True,
-                functions=["app2"],
-                exports=["app2"],
+                functions=["domain"],
+                exports=["domain"],
             ),
-            "os.fooos.apps.foo_app.FooAppPlugin": PluginDescriptor(
-                module="os.fooos.apps.foo_app",
-                qualname="FooAppPlugin",
+            "os.unix.cronjobs.CronjobPlugin": PluginDescriptor(
+                module="dissect.target.plugins.os.unix.cronjobs",
+                qualname="CronjobPlugin",
                 namespace=None,
-                path="os.fooos.apps.foo_app",
+                path="os.unix.cronjobs",
                 findable=True,
-                functions=["foo_app"],
-                exports=["foo_app"],
+                functions=["cronjobs"],
+                exports=["cronjobs"],
             ),
-            "os.fooos.apps.bar_app.BarAppPlugin": PluginDescriptor(
-                module="os.fooos.apps.bar_app",
-                qualname="BarAppPlugin",
+            "os.windows.regf.runkeys.RunKeysPlugin": PluginDescriptor(
+                module="dissect.target.plugins.os.windows.regf.runkeys",
+                qualname="RunKeysPlugin",
                 namespace=None,
-                path="os.fooos.apps.bar_app",
+                path="os.windows.regf.runkeys",
                 findable=True,
-                functions=["bar_app"],
-                exports=["bar_app"],
+                functions=["runkeys"],
+                exports=["runkeys"],
             ),
-            "os.fooos.foobar.FooBarPlugin": PluginDescriptor(
-                module="os.fooos.foobar",
-                qualname="FooBarPlugin",
+            # OS, shared name
+            "os.unix.linux.services.ServicesPlugin": PluginDescriptor(
+                module="dissect.target.plugins.os.unix.linux.services",
+                qualname="ServicesPlugin",
                 namespace=None,
-                path="os.fooos.foobar",
+                path="os.unix.linux.services",
                 findable=True,
-                functions=["foobar"],
-                exports=["foobar"],
+                functions=["initd", "services", "systemd"],
+                exports=["services"],
+            ),
+            "os.windows.services.ServicesPlugin": PluginDescriptor(
+                module="dissect.target.plugins.os.windows.services",
+                qualname="ServicesPlugin",
+                namespace=None,
+                path="os.windows.services",
+                findable=True,
+                functions=["services"],
+                exports=["services"],
+            ),
+            # OS, with default
+            "os.default.locale.LocalePlugin": PluginDescriptor(
+                module="dissect.target.plugins.os.default.locale",
+                qualname="LocalePlugin",
+                namespace=None,
+                path="os.default.locale",
+                findable=True,
+                functions=["timezone"],
+                exports=["timezone"],
+            ),
+            "os.unix.locale.UnixLocalePlugin": PluginDescriptor(
+                module="dissect.target.plugins.os.unix.locale",
+                qualname="UnixLocalePlugin",
+                namespace=None,
+                path="os.unix.locale",
+                findable=True,
+                functions=["timezone"],
+                exports=["timezone"],
+            ),
+            "os.unix.linux.fortios.locale.FortiOSLocalePlugin": PluginDescriptor(
+                module="dissect.target.plugins.os.unix.linux.fortios.locale",
+                qualname="FortiOSLocalePlugin",
+                namespace=None,
+                path="os.unix.linux.fortios.locale",
+                findable=True,
+                functions=["timezone"],
+                exports=["timezone"],
+            ),
+            "os.windows.locale.WindowsLocalePlugin": PluginDescriptor(
+                module="dissect.target.plugins.os.windows.locale",
+                qualname="WindowsLocalePlugin",
+                namespace=None,
+                path="os.windows.locale",
+                findable=True,
+                functions=["timezone"],
+                exports=["timezone"],
             ),
         },
         __os__={
-            "os._os.GenericOS": PluginDescriptor(
-                module="os._os",
-                qualname="GenericOS",
+            "os.default._os.DefaultOSPlugin": PluginDescriptor(
+                module="dissect.target.plugins.os.default._os",
+                qualname="DefaultOSPlugin",
                 namespace=None,
-                path="os._os",
+                path="os.default._os",
                 findable=True,
-                functions=["generic_os"],
-                exports=["generic_os"],
+                functions=["hostname", "os", "os_tree"],
+                exports=["hostname", "os"],
             ),
-            "os.fooos._os.FooOS": PluginDescriptor(
-                module="os.fooos._os",
-                qualname="FooOS",
+            "os.unix._os.UnixPlugin": PluginDescriptor(
+                module="dissect.target.plugins.os.unix._os",
+                qualname="UnixPlugin",
                 namespace=None,
-                path="os.fooos._os",
+                path="os.unix._os",
                 findable=True,
-                functions=["foo_os"],
-                exports=["foo_os"],
+                functions=["hostname", "domain", "os", "os_tree"],
+                exports=["hostname", "domain", "os"],
+            ),
+            "os.unix.linux._os.LinuxPlugin": PluginDescriptor(
+                module="dissect.target.plugins.os.unix.linux._os",
+                qualname="LinuxPlugin",
+                namespace=None,
+                path="os.unix.linux._os",
+                findable=True,
+                functions=["hostname", "domain", "os", "os_tree"],
+                exports=["hostname", "domain", "os"],
+            ),
+            "os.unix.linux.fortios._os.FortiOSPlugin": PluginDescriptor(
+                module="dissect.target.plugins.os.unix.linux.fortios._os",
+                qualname="FortiOSPlugin",
+                namespace=None,
+                path="os.unix.linux.fortios._os",
+                findable=True,
+                functions=["hostname", "domain", "os", "os_tree"],
+                exports=["hostname", "domain", "os"],
+            ),
+            "os.windows._os.WindowsPlugin": PluginDescriptor(
+                module="dissect.target.plugins.os.windows._os",
+                qualname="WindowsPlugin",
+                namespace=None,
+                path="os.windows._os",
+                findable=True,
+                functions=["hostname", "os", "os_tree"],
+                exports=["hostname", "os"],
             ),
         },
+        __child__={},
+    ),
+    __functions__=FunctionDescriptorLookup(
+        __regular__={
+            # Non-OS, regular
+            "osinfo": {
+                "general.osinfo.OSInfoPlugin": FunctionDescriptor(
+                    name="osinfo",
+                    namespace=None,
+                    path="general.osinfo.osinfo",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="record",
+                    method_name="osinfo",
+                    module="dissect.target.plugins.general.osinfo",
+                    qualname="OSInfoPlugin",
+                )
+            },
+            # Non-OS, with namespace
+            "chat": {
+                "apps.chat.chat.ChatPlugin": FunctionDescriptor(
+                    name="chat",
+                    namespace="chat",
+                    path="apps.chat.chat",
+                    exported=True,
+                    internal=False,
+                    findable=False,
+                    alias=False,
+                    output="record",
+                    method_name="__call__",
+                    module="dissect.target.plugins.apps.chat.chat",
+                    qualname="ChatPlugin",
+                )
+            },
+            "chat.history": {
+                "apps.chat.chat.ChatPlugin": FunctionDescriptor(
+                    name="chat.history",
+                    namespace="chat",
+                    path="apps.chat.chat.history",
+                    exported=True,
+                    internal=False,
+                    findable=False,
+                    alias=False,
+                    output="record",
+                    method_name="history",
+                    module="dissect.target.plugins.apps.chat.chat",
+                    qualname="ChatPlugin",
+                )
+            },
+            "msn": {
+                "apps.chat.msn.MSNPlugin": FunctionDescriptor(
+                    name="msn",
+                    namespace="msn",
+                    path="apps.chat.msn",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="record",
+                    method_name="__call__",
+                    module="dissect.target.plugins.apps.chat.msn",
+                    qualname="MSNPlugin",
+                )
+            },
+            "msn.history": {
+                "apps.chat.msn.MSNPlugin": FunctionDescriptor(
+                    name="msn.history",
+                    namespace="msn",
+                    path="apps.chat.msn.history",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="record",
+                    method_name="history",
+                    module="dissect.target.plugins.apps.chat.msn",
+                    qualname="MSNPlugin",
+                )
+            },
+            # OS, regular
+            "domain": {
+                "os.windows.generic.GenericPlugin": FunctionDescriptor(
+                    name="domain",
+                    namespace=None,
+                    path="os.windows.generic.domain",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="domain",
+                    module="dissect.target.plugins.os.windows.generic",
+                    qualname="GenericPlugin",
+                )
+            },
+            "cronjobs": {
+                "os.unix.cronjobs.CronjobPlugin": FunctionDescriptor(
+                    name="cronjobs",
+                    namespace=None,
+                    path="os.unix.cronjobs.cronjobs",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="record",
+                    method_name="cronjobs",
+                    module="dissect.target.plugins.os.unix.cronjobs",
+                    qualname="CronjobPlugin",
+                )
+            },
+            "runkeys": {
+                "os.windows.regf.runkeys.RunKeysPlugin": FunctionDescriptor(
+                    name="runkeys",
+                    namespace=None,
+                    path="os.windows.regf.runkeys.runkeys",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="record",
+                    method_name="runkeys",
+                    module="dissect.target.plugins.os.windows.regf.runkeys",
+                    qualname="RunKeysPlugin",
+                )
+            },
+            # OS, shared name
+            "services": {
+                "os.windows.services.ServicesPlugin": FunctionDescriptor(
+                    name="services",
+                    namespace=None,
+                    path="os.windows.services.services",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="record",
+                    method_name="services",
+                    module="dissect.target.plugins.os.windows.services",
+                    qualname="ServicesPlugin",
+                ),
+                "os.unix.linux.services.ServicesPlugin": FunctionDescriptor(
+                    name="services",
+                    namespace=None,
+                    path="os.unix.linux.services.services",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="record",
+                    method_name="services",
+                    module="dissect.target.plugins.os.unix.linux.services",
+                    qualname="ServicesPlugin",
+                ),
+            },
+            # OS, with default
+            "timezone": {
+                "os.default.locale.LocalePlugin": FunctionDescriptor(
+                    name="timezone",
+                    namespace=None,
+                    path="os.default.locale.timezone",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="timezone",
+                    module="dissect.target.plugins.os.default.locale",
+                    qualname="LocalePlugin",
+                ),
+                "os.unix.locale.UnixLocalePlugin": FunctionDescriptor(
+                    name="timezone",
+                    namespace=None,
+                    path="os.unix.locale.timezone",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="timezone",
+                    module="dissect.target.plugins.os.unix.locale",
+                    qualname="UnixLocalePlugin",
+                ),
+                "os.unix.linux.fortios.locale.FortiOSLocalePlugin": FunctionDescriptor(
+                    name="timezone",
+                    namespace=None,
+                    path="os.unix.linux.fortios.locale.timezone",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="timezone",
+                    module="dissect.target.plugins.os.unix.linux.fortios.locale",
+                    qualname="FortiOSLocalePlugin",
+                ),
+                "os.windows.locale.WindowsLocalePlugin": FunctionDescriptor(
+                    name="timezone",
+                    namespace=None,
+                    path="os.windows.locale.timezone",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="timezone",
+                    module="dissect.target.plugins.os.windows.locale",
+                    qualname="WindowsLocalePlugin",
+                ),
+            },
+        },
+        __os__={
+            "hostname": {
+                "os.default._os.DefaultOSPlugin": FunctionDescriptor(
+                    name="hostname",
+                    namespace=None,
+                    path="os.default._os.hostname",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="hostname",
+                    module="dissect.target.plugins.os.default._os",
+                    qualname="DefaultOSPlugin",
+                ),
+                "os.unix._os.UnixPlugin": FunctionDescriptor(
+                    name="hostname",
+                    namespace=None,
+                    path="os.unix._os.hostname",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="hostname",
+                    module="dissect.target.plugins.os.unix._os",
+                    qualname="UnixPlugin",
+                ),
+                "os.unix.linux._os.LinuxPlugin": FunctionDescriptor(
+                    name="hostname",
+                    namespace=None,
+                    path="os.unix.linux._os.hostname",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="hostname",
+                    module="dissect.target.plugins.os.unix.linux._os",
+                    qualname="LinuxPlugin",
+                ),
+                "os.unix.linux.fortios._os.FortiOSPlugin": FunctionDescriptor(
+                    name="hostname",
+                    namespace=None,
+                    path="os.unix.linux.fortios._os.hostname",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="hostname",
+                    module="dissect.target.plugins.os.unix.linux.fortios._os",
+                    qualname="FortiOSPlugin",
+                ),
+                "os.windows._os.WindowsPlugin": FunctionDescriptor(
+                    name="hostname",
+                    namespace=None,
+                    path="os.windows._os.hostname",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="hostname",
+                    module="dissect.target.plugins.os.windows._os",
+                    qualname="WindowsPlugin",
+                ),
+            },
+            "os": {
+                "os.default._os.DefaultOSPlugin": FunctionDescriptor(
+                    name="os",
+                    namespace=None,
+                    path="os.default._os.os",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="os",
+                    module="dissect.target.plugins.os.default._os",
+                    qualname="DefaultOSPlugin",
+                ),
+                "os.unix._os.UnixPlugin": FunctionDescriptor(
+                    name="os",
+                    namespace=None,
+                    path="os.unix._os.os",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="os",
+                    module="dissect.target.plugins.os.unix._os",
+                    qualname="UnixPlugin",
+                ),
+                "os.unix.linux._os.LinuxPlugin": FunctionDescriptor(
+                    name="os",
+                    namespace=None,
+                    path="os.unix.linux._os.os",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="os",
+                    module="dissect.target.plugins.os.unix.linux._os",
+                    qualname="LinuxPlugin",
+                ),
+                "os.unix.linux.fortios._os.FortiOSPlugin": FunctionDescriptor(
+                    name="os",
+                    namespace=None,
+                    path="os.unix.linux.fortios._os.os",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="os",
+                    module="dissect.target.plugins.os.unix.linux.fortios._os",
+                    qualname="FortiOSPlugin",
+                ),
+                "os.windows._os.WindowsPlugin": FunctionDescriptor(
+                    name="os",
+                    namespace=None,
+                    path="os.windows._os.os",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="os",
+                    module="dissect.target.plugins.os.windows._os",
+                    qualname="WindowsPlugin",
+                ),
+            },
+            "domain": {
+                "os.unix._os.UnixPlugin": FunctionDescriptor(
+                    name="domain",
+                    namespace=None,
+                    path="os.unix._os.domain",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="domain",
+                    module="dissect.target.plugins.os.unix._os",
+                    qualname="UnixPlugin",
+                ),
+                "os.unix.linux._os.LinuxPlugin": FunctionDescriptor(
+                    name="domain",
+                    namespace=None,
+                    path="os.unix.linux._os.domain",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="domain",
+                    module="dissect.target.plugins.os.unix.linux._os",
+                    qualname="LinuxPlugin",
+                ),
+                "os.unix.linux.fortios._os.FortiOSPlugin": FunctionDescriptor(
+                    name="domain",
+                    namespace=None,
+                    path="os.unix.linux.fortios._os.domain",
+                    exported=True,
+                    internal=False,
+                    findable=True,
+                    alias=False,
+                    output="default",
+                    method_name="domain",
+                    module="dissect.target.plugins.os.unix.linux.fortios._os",
+                    qualname="FortiOSPlugin",
+                ),
+            },
+        },
+        __child__={},
     ),
     __ostree__={
         "os": {
-            "fooos": {},
+            "default": {},
+            "unix": {
+                "linux": {
+                    "fortios": {},
+                }
+            },
+            "windows": {},
         }
     },
+    __failed__=[],
 )
 
 
@@ -945,49 +1129,81 @@ MOCK_PLUGINS = PluginRegistry(
             None,
             "__regular__",
             [
-                "apps.mail",
-                "os.apps.app1",
-                "os.apps.app2",
-                "os.fooos.apps.app2",
-                "os.fooos.apps.bar_app",
-                "os.fooos.apps.foo_app",
-                "os.fooos.foobar",
+                "dissect.target.plugins.general.osinfo",
+                "dissect.target.plugins.apps.chat.chat",
+                "dissect.target.plugins.apps.chat.msn",
+                "dissect.target.plugins.os.windows.generic",
+                "dissect.target.plugins.os.unix.cronjobs",
+                "dissect.target.plugins.os.windows.regf.runkeys",
+                "dissect.target.plugins.os.windows.services",
+                "dissect.target.plugins.os.unix.linux.services",
+                "dissect.target.plugins.os.default.locale",
+                "dissect.target.plugins.os.unix.locale",
+                "dissect.target.plugins.os.unix.linux.fortios.locale",
+                "dissect.target.plugins.os.windows.locale",
             ],
         ),
         (
             None,
             "__os__",
             [
-                "os._os",
-                "os.fooos._os",
+                "dissect.target.plugins.os.default._os",
+                "dissect.target.plugins.os.unix._os",
+                "dissect.target.plugins.os.unix.linux._os",
+                "dissect.target.plugins.os.unix.linux.fortios._os",
+                "dissect.target.plugins.os.windows._os",
             ],
         ),
         (
-            "os._os",
+            "os.unix._os",
             "__regular__",
             [
-                "apps.mail",
-                "os.apps.app1",
-                "os.apps.app2",
+                "dissect.target.plugins.general.osinfo",
+                "dissect.target.plugins.apps.chat.chat",
+                "dissect.target.plugins.apps.chat.msn",
+                "dissect.target.plugins.os.unix.cronjobs",
+                "dissect.target.plugins.os.unix.locale",
             ],
         ),
         (
-            "os.fooos._os",
+            "os.unix.linux.fortios._os",
             "__regular__",
             [
-                "apps.mail",
-                "os.apps.app1",
-                "os.apps.app2",
-                "os.fooos.apps.app2",
-                "os.fooos.apps.bar_app",
-                "os.fooos.apps.foo_app",
-                "os.fooos.foobar",
+                "dissect.target.plugins.general.osinfo",
+                "dissect.target.plugins.apps.chat.chat",
+                "dissect.target.plugins.apps.chat.msn",
+                "dissect.target.plugins.os.unix.cronjobs",
+                "dissect.target.plugins.os.unix.locale",
+                "dissect.target.plugins.os.unix.linux.services",
+                "dissect.target.plugins.os.unix.linux.fortios.locale",
             ],
         ),
         (
-            "bar",
+            "os.windows._os",
             "__regular__",
-            ["apps.mail"],
+            [
+                "dissect.target.plugins.general.osinfo",
+                "dissect.target.plugins.apps.chat.chat",
+                "dissect.target.plugins.apps.chat.msn",
+                "dissect.target.plugins.os.windows.generic",
+                "dissect.target.plugins.os.windows.regf.runkeys",
+                "dissect.target.plugins.os.windows.services",
+                "dissect.target.plugins.os.windows.locale",
+            ],
+        ),
+        (
+            "os.bar._os",
+            "__regular__",
+            [
+                "dissect.target.plugins.general.osinfo",
+                "dissect.target.plugins.apps.chat.chat",
+                "dissect.target.plugins.apps.chat.msn",
+            ],
+        ),
+        (
+            "os.windows._os",
+            "__os__",
+            [],
         ),
     ],
 )
@@ -1006,7 +1222,7 @@ def test_plugins(
 
         plugin_descriptors = plugins(osfilter=osfilter, index=index)
 
-        assert sorted([desc.module for desc in plugin_descriptors]) == sorted(expected_plugins)
+        assert sorted(desc.module for desc in plugin_descriptors) == sorted(expected_plugins)
 
 
 def test_plugins_default_plugin(target_default: Target) -> None:
@@ -1029,6 +1245,128 @@ def test_plugins_default_plugin(target_default: Target) -> None:
     default_os_plugin_desc = plugins(osfilter=target_default._os_plugin, index="__os__")
 
     assert len(list(default_os_plugin_desc)) == 1
+
+
+@pytest.mark.parametrize(
+    ("os_plugin", "pattern", "expected_paths"),
+    [
+        # Direct match
+        (DefaultOSPlugin, "osinfo", ["general.osinfo.osinfo"]),
+        # Direct match with namespace, regardless of `findable` status
+        (DefaultOSPlugin, "chat.history", ["apps.chat.chat.history"]),
+        (DefaultOSPlugin, "msn.history", ["apps.chat.msn.history"]),
+        # Find with tree search using wildcard
+        (DefaultOSPlugin, "general.*", ["general.osinfo.osinfo"]),
+        # Find with tree search using implicit wildcard
+        (DefaultOSPlugin, "general.osinfo", ["general.osinfo.osinfo"]),
+        # Find with exact tree match
+        (DefaultOSPlugin, "general.osinfo.osinfo", ["general.osinfo.osinfo"]),
+        # Find with tree search using more complicated patterns
+        (DefaultOSPlugin, "general.[!o]*", []),
+        (DefaultOSPlugin, "general.[!x]*", ["general.osinfo.osinfo"]),
+        (DefaultOSPlugin, "general.??????.??????", ["general.osinfo.osinfo"]),
+        # Namespaces do not match
+        (DefaultOSPlugin, "chat.*", []),
+        # Part of module paths do not match
+        (DefaultOSPlugin, "generic", []),
+        # OS direct match only matches within the same OS plugin
+        (DefaultOSPlugin, "hostname", ["os.default._os.hostname"]),
+        (WindowsPlugin, "hostname", ["os.windows._os.hostname"]),
+        (LinuxPlugin, "hostname", ["os.unix.linux._os.hostname", "os.unix._os.hostname"]),
+        # OS tree search only matches within the same OS plugin
+        (DefaultOSPlugin, "os.windows._os.hostname", []),
+        (WindowsPlugin, "os.default._os.hostname", []),
+        (DefaultOSPlugin, "os.*.hostname", ["os.default._os.hostname"]),
+        (WindowsPlugin, "os.*.hostname", ["os.windows._os.hostname"]),
+        # # "os" hits the direct match, not the tree search
+        (DefaultOSPlugin, "os", ["os.default._os.os"]),
+        (WindowsPlugin, "os", ["os.windows._os.os"]),
+        # Wildcard matches all regular functions and OS functions (within the same OS)
+        (
+            DefaultOSPlugin,
+            "*",
+            [
+                "os.unix.linux.fortios.locale.timezone",
+                "os.windows.regf.runkeys.runkeys",
+                "os.unix.linux.services.services",
+                "apps.chat.msn.history",
+                "os.windows.generic.domain",
+                "os.unix.cronjobs.cronjobs",
+                "os.windows.services.services",
+                "os.default.locale.timezone",
+                "os.unix.locale.timezone",
+                "os.windows.locale.timezone",
+                "os.default._os.hostname",
+                "os.default._os.os",
+                "general.osinfo.osinfo",
+            ],
+        ),
+        (
+            WindowsPlugin,
+            "*",
+            [
+                "os.windows.regf.runkeys.runkeys",
+                "apps.chat.msn.history",
+                "os.windows.generic.domain",
+                "os.windows.services.services",
+                "os.windows.locale.timezone",
+                "os.windows._os.hostname",
+                "os.windows._os.os",
+                "general.osinfo.osinfo",
+            ],
+        ),
+        # Some OS functions only exist on certain OS plugins
+        (LinuxPlugin, "os.*.domain", ["os.unix.linux._os.domain", "os.unix._os.domain"]),
+        # # Some plugins have complicated paths (i.e. LocalePlugin)
+        (LinuxPlugin, "timezone", ["os.unix.locale.timezone"]),
+        (FortiOSPlugin, "timezone", ["os.unix.linux.fortios.locale.timezone", "os.unix.locale.timezone"]),
+        # Some plugins have overlapping names (i.e. "services")
+        (FortiOSPlugin, "services", ["os.unix.linux.services.services"]),
+        (WindowsPlugin, "services", ["os.windows.services.services"]),
+    ],
+)
+def test_find_functions(os_plugin: type[OSPlugin], pattern: str, expected_paths: list[str]) -> None:
+    with patch("dissect.target.plugin._get_plugins", return_value=MOCK_PLUGINS):
+        target = Target()
+        target._os_plugin = os_plugin
+
+        found, _ = find_functions(pattern, target)
+        assert [desc.path for desc in found] == expected_paths
+
+
+def test_find_functions_windows(target_win: Target) -> None:
+    found, _ = find_functions("services", target_win)
+
+    assert len(found) == 1
+    assert found[0].name == "services"
+    assert found[0].path == "os.windows.services.services"
+
+
+def test_find_functions_linux(target_linux: Target) -> None:
+    found, _ = find_functions("services", target_linux)
+
+    assert len(found) == 1
+    assert found[0].name == "services"
+    assert found[0].path == "os.unix.linux.services.services"
+
+
+def test_find_functions_compatible_check(target_linux: Target) -> None:
+    """Test if we correctly check for compatibility in ``find_functions`` and ``_filter_compatible``."""
+
+    found, _ = find_functions("*", target_linux, compatibility=True)
+    assert "os.unix.log.messages.syslog.syslog" not in [f"{f.path}.{f.name}" for f in found]
+
+    with patch("dissect.target.plugins.apps.browser.chrome.ChromePlugin.check_compatible", return_value=None):
+        found, _ = find_functions("*", target_linux, compatibility=True)
+        functions = [f.path for f in found]
+        assert "apps.browser.chrome.cookies" in functions
+        assert "apps.browser.chrome.history" in functions
+
+
+@pytest.mark.benchmark
+def test_benchmark_functions_compatible_check(target_unix_users: Target, benchmark: BenchmarkFixture) -> None:
+    """Benchmark ``_filter_compatible`` performance."""
+    benchmark(lambda: find_functions("*", target_unix_users, compatibility=True))
 
 
 def test_function_aliases(target_default: Target) -> None:

--- a/tests/tools/test_query.py
+++ b/tests/tools/test_query.py
@@ -374,7 +374,8 @@ def test_list_json_target_filter(capsys: pytest.CaptureFixture, monkeypatch: pyt
                 "-j",
             ],
         )
-        target_query()
+        with pytest.raises(SystemExit, check=lambda r: r.code == 0):
+            target_query()
         out, _ = capsys.readouterr()
 
     output = json.loads(out)

--- a/tests/tools/test_query.py
+++ b/tests/tools/test_query.py
@@ -361,6 +361,54 @@ def test_list_json(capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatc
     }
 
 
+def test_list_json_target_filter(capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test if target-query --list "*" --json <target> returns functions we expect it to."""
+
+    with monkeypatch.context() as m:
+        m.setattr(
+            "sys.argv",
+            [
+                "target-query",
+                "-l=*",
+                str(absolute_path("_data/loaders/containerimage/alpine.tar")),
+                "-j",
+            ],
+        )
+        target_query()
+        out, _ = capsys.readouterr()
+
+    output = json.loads(out)
+
+    # test the generic structure of the returned dictionary.
+    assert isinstance(output, dict), "Could not load JSON output of 'target-query --list --json'"
+    assert output["plugins"], "Expected a dictionary of plugins"
+    assert not output.get("loaders"), "Did not expect a dictionary of loaders"
+    assert not output["plugins"].get("failed"), "Some plugin(s) failed to initialize"
+
+    def get_plugin(plugins: list[dict], needle: str) -> dict | bool:
+        match = [p for p in plugins["plugins"]["loaded"] if p["name"] == needle]
+        return match[0] if match else False
+
+    # general plugin
+    users_plugin = get_plugin(output, "users")
+    assert users_plugin == {
+        "name": "users",
+        "description": "Yield unix user records from passwd files or syslog session logins.",
+        "output": "record",
+        "arguments": [
+            {
+                "name": "--sessions",
+                "help": "Parse syslog for recent user sessions",
+                "default": False,
+                "required": False,
+                "type": "bool",
+            }
+        ],
+        "alias": False,
+        "path": "os.unix._os.users",
+    }
+
+
 def test_record_stream_write_exception_handling(
     caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/tools/test_query.py
+++ b/tests/tools/test_query.py
@@ -386,8 +386,8 @@ def test_list_json_target_filter(capsys: pytest.CaptureFixture, monkeypatch: pyt
     assert not output.get("loaders"), "Did not expect a dictionary of loaders"
     assert not output["plugins"].get("failed"), "Some plugin(s) failed to initialize"
 
-    def get_plugin(plugins: list[dict], needle: str) -> dict | bool:
-        match = [p for p in plugins["plugins"]["loaded"] if p["name"] == needle]
+    def get_plugin(plugins: list[dict], name: str) -> dict | bool:
+        match = [p for p in plugins["plugins"]["loaded"] if p["name"] == name]
         return match[0] if match else False
 
     # general plugin

--- a/tests/tools/test_query.py
+++ b/tests/tools/test_query.py
@@ -391,6 +391,12 @@ def test_list_json_target_filter(capsys: pytest.CaptureFixture, monkeypatch: pyt
 
     # general plugin
     users_plugin = get_plugin(output, "users")
+    assert isinstance(users_plugin, dict)
+
+    # We expect path to be "os.unix.linux._os.users"
+    # https://github.com/fox-it/dissect.target/issues/1178
+    users_plugin.pop("path")
+
     assert users_plugin == {
         "name": "users",
         "description": "Yield unix user records from passwd files or syslog session logins.",
@@ -405,7 +411,6 @@ def test_list_json_target_filter(capsys: pytest.CaptureFixture, monkeypatch: pyt
             }
         ],
         "alias": False,
-        "path": "os.unix.linux._os.users",
     }
 
 

--- a/tests/tools/test_query.py
+++ b/tests/tools/test_query.py
@@ -405,7 +405,7 @@ def test_list_json_target_filter(capsys: pytest.CaptureFixture, monkeypatch: pyt
             }
         ],
         "alias": False,
-        "path": "os.unix._os.users",
+        "path": "os.unix.linux._os.users",
     }
 
 

--- a/tests/tools/test_query.py
+++ b/tests/tools/test_query.py
@@ -370,7 +370,7 @@ def test_list_json_target_filter(capsys: pytest.CaptureFixture, monkeypatch: pyt
             [
                 "target-query",
                 "-l=*",
-                str(absolute_path("_data/loaders/containerimage/alpine.tar")),
+                str(absolute_path("_data/loaders/containerimage/alpine-docker.tar")),
                 "-j",
             ],
         )
@@ -394,11 +394,8 @@ def test_list_json_target_filter(capsys: pytest.CaptureFixture, monkeypatch: pyt
     users_plugin = get_plugin(output, "users")
     assert isinstance(users_plugin, dict)
 
-    # We expect path to be "os.unix.linux._os.users"
-    # https://github.com/fox-it/dissect.target/issues/1178
-    users_plugin.pop("path")
-
     assert users_plugin == {
+        "path": "os.unix.linux._os.users",
         "name": "users",
         "description": "Yield unix user records from passwd files or syslog session logins.",
         "output": "record",


### PR DESCRIPTION
This PR fixes a (slightly different) regression of https://github.com/fox-it/dissect.target/issues/421.

Since the plugin internals refactor #889 only `__regular__` plugins are returned when invoking `find_functions` (-> `_generate_long_paths`). Previously `OSPlugin` specific functions were also returned.

See the added test for steps how to reproduce using `target-query -l "*" <target>`.