### PR TITLE
Support systemd drop files

### DIFF
--- a/dissect/target/filesystems/config.py
+++ b/dissect/target/filesystems/config.py
@@ -9,7 +9,6 @@ from dissect.target.exceptions import ConfigurationParsingError, FileNotFoundErr
 from dissect.target.filesystem import FilesystemEntry, VirtualFilesystem
 from dissect.target.helpers import fsutil
 from dissect.target.helpers.configutil import ConfigurationParser, parse
-from dissect.target.helpers.fsutil import TargetPath
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -123,7 +122,7 @@ class ConfigurationFilesystem(VirtualFilesystem):
         entry = file_entry
         config_parser = None
         try:
-            target_path = TargetPath(entry.fs, entry.path)
+            target_path = entry.fs.path(entry.path)
             config_parser = parse(target_path, *args, **kwargs)
         except ConfigurationParsingError as e:
             # If a parsing error gets created, it should return the `entry`

--- a/dissect/target/filesystems/config.py
+++ b/dissect/target/filesystems/config.py
@@ -9,6 +9,7 @@ from dissect.target.exceptions import ConfigurationParsingError, FileNotFoundErr
 from dissect.target.filesystem import FilesystemEntry, VirtualFilesystem
 from dissect.target.helpers import fsutil
 from dissect.target.helpers.configutil import ConfigurationParser, parse
+from dissect.target.helpers.fsutil import TargetPath
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -122,7 +123,8 @@ class ConfigurationFilesystem(VirtualFilesystem):
         entry = file_entry
         config_parser = None
         try:
-            config_parser = parse(entry, *args, **kwargs)
+            target_path = TargetPath(entry.fs, entry.path)
+            config_parser = parse(target_path, *args, **kwargs)
         except ConfigurationParsingError as e:
             # If a parsing error gets created, it should return the `entry`
             log.debug("Error when parsing %s with message '%s'", entry.path, e)

--- a/dissect/target/helpers/configutil.py
+++ b/dissect/target/helpers/configutil.py
@@ -9,7 +9,6 @@ from collections import deque
 from collections.abc import ItemsView, Iterable, Iterator, KeysView
 from configparser import ConfigParser, MissingSectionHeaderError
 from dataclasses import dataclass
-from fnmatch import fnmatch
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -22,14 +21,12 @@ from typing import (
 from defusedxml import ElementTree
 
 from dissect.target.exceptions import ConfigurationParsingError, FileNotFoundError
-from dissect.target.helpers.fsutil import TargetPath
+from dissect.target.helpers.utils import to_list
 
 if TYPE_CHECKING:
     from types import TracebackType
 
     from typing_extensions import Self
-
-    from dissect.target.filesystem import FilesystemEntry
 
 try:
     from ruamel.yaml import YAML
@@ -54,9 +51,8 @@ log = logging.getLogger(__name__)
 
 
 def _update_dictionary(current: dict[str, Any], key: str, value: Any) -> None:
-    if prev_value := current.get(key):
-        if isinstance(prev_value, dict):
-            # We can assume the value would be a dict too here.
+    if (prev_value := current.get(key)) is not None:  #  "" is a value
+        if isinstance(prev_value, dict) and isinstance(value, dict):
             prev_value.update(value)
             return
 
@@ -179,6 +175,43 @@ class ConfigurationParser:
 
         if not isinstance(self.parsed_data, dict):
             self.parsed_data = self._collapse_dict(self.parsed_data, False)
+
+    def merge(self, other: ConfigurationParser) -> ConfigurationParser:
+        """Merge the contents of another parser into this one.
+        On conflict, the values of the other parser will be used.
+
+        Args:
+            other: The other parser to merge.
+
+        Returns:
+            The merged parser.
+        """
+
+        self._merge(self.parsed_data, other.parsed_data)
+        return self
+
+    def _merge(self, dict1: dict, dict2: dict) -> dict:
+        for key, value2 in dict2.items():
+            value1 = dict1.get(key)
+            if value1 is None:
+                # Result does not have key yet, add it
+                dict1[key] = value2
+                continue
+
+            collapse = self.collapse_all or self._collapse_check(key)
+
+            if collapse:
+                if isinstance(value1, dict) and isinstance(value2, dict):
+                    self._merge(value1, value2)  # There should only be one, merge both
+                else:
+                    dict1[key] = value2
+            else:
+                combined = to_list(value1) + to_list(value2)
+                # None resets list to empty
+                combined = combined[combined.index("") + 1 :] if "" in combined else combined
+                dict1[key] = combined
+
+        return dict1
 
     def keys(self) -> KeysView:
         return self.parsed_data.keys()
@@ -568,13 +601,26 @@ class ScopeManager:
 
     def push(self, name: str, keep_prev: bool = False) -> Literal[True]:
         """Push a new key to the :attr:`_current` dictionary and return that we did."""
-        child = self._current.get(name, {})
-
+        child = self._current.get(name)
+        new_child = {}
         parent = self._current
-        self._parents[id(child)] = parent
-        parent[name] = child
+        if isinstance(child, dict):
+            # A second scope with the same name, turn the existing one into a list and append a new one
+            parent[name] = [child, new_child]
+            child = parent[name]
+        elif isinstance(child, list):
+            # Multiple scopes with the same name, append a new one to the list
+            child.append(new_child)
+        elif isinstance(child, str):
+            # Child is not a scope but a scalar value, do nothing
+            pass
+        else:
+            # Create a new scope
+            parent[name] = new_child
+
+        self._parents[id(new_child)] = parent
         self._set_prev(keep_prev)
-        self._current = child
+        self._current = new_child
         return True
 
     def pop(self, keep_prev: bool = False) -> bool:
@@ -888,7 +934,7 @@ KNOWN_FILES: dict[str, type[ConfigurationParser]] = {
 }
 
 
-def parse(path: FilesystemEntry | TargetPath | Path, hint: str | None = None, *args, **kwargs) -> ConfigurationParser:
+def parse(path: Path, hint: str | None = None, *args, **kwargs) -> ConfigurationParser:
     """Parses the content of an ``path`` or ``entry`` to a dictionary.
 
     Args:
@@ -903,42 +949,63 @@ def parse(path: FilesystemEntry | TargetPath | Path, hint: str | None = None, *a
         FileNotFoundError: If the ``path`` is not a file.
     """
 
-    entry = path
-    if isinstance(path, TargetPath):
-        entry = path.get()
-
-    if not isinstance(entry, Path) and not entry.is_file(follow_symlinks=True):
+    if not path.is_file():
         raise FileNotFoundError(f"Could not parse {path} as a dictionary.")
 
     options = ParserOptions(*args, **kwargs)
 
-    return parse_config(entry, hint, options)
+    return parse_config(path, hint, options)
 
 
 def parse_config(
-    entry: FilesystemEntry | Path,
+    entry: Path,
     hint: str | None = None,
     options: ParserOptions | None = None,
 ) -> ConfigurationParser:
     parser_type = _select_parser(entry, hint)
 
     parser = parser_type.create_parser(options)
-    with entry.open("rb") if isinstance(entry, Path) else entry.open() as fh:
+    with entry.open("rb") as fh:
         open_file = io.TextIOWrapper(fh, encoding="utf-8") if not isinstance(parser, Bin) else io.BytesIO(fh.read())
         parser.read_file(open_file)
+
+    if isinstance(parser, SystemD) and isinstance(entry, Path):
+        return _parse_drop_files(entry, options, parser)
 
     return parser
 
 
-def _select_parser(entry: FilesystemEntry, hint: str | None = None) -> ParserConfig:
+def _parse_drop_files(
+    pathOrEntry: Path, options: ParserOptions, main_parser: ConfigurationParser
+) -> ConfigurationParser:
+    if not isinstance(pathOrEntry, Path):
+        return main_parser
+
+    drop_folder = pathOrEntry.with_name(pathOrEntry.name + ".d")
+    if not drop_folder.exists():
+        return main_parser
+    drop_files = sorted(drop_folder.glob("*.conf"))
+
+    for drop_file in drop_files:
+        if not drop_file.is_file():
+            continue
+
+        drop_file_parser = ParserConfig(SystemD).create_parser(options)
+        with drop_file.open("rb") as fh:
+            open_drop_file = io.TextIOWrapper(fh, encoding="utf-8")
+            drop_file_parser.read_file(open_drop_file)
+            main_parser.merge(drop_file_parser)
+
+    return main_parser
+
+
+def _select_parser(path: Path, hint: str | None = None) -> ParserConfig:
     if hint and (parser_type := CONFIG_MAP.get(hint)):
         return parser_type
 
     for match, value in MATCH_MAP.items():
-        if fnmatch(entry.path, f"{match}"):
+        if path.match(f"{match}"):
             return value
 
-    extension = entry.path.rsplit(".", 1)[-1]
-
-    extention_parser = CONFIG_MAP.get(extension, ParserConfig(Default))
-    return KNOWN_FILES.get(entry.name, extention_parser)
+    extention_parser = CONFIG_MAP.get(path.suffix.lstrip("."), ParserConfig(Default))
+    return KNOWN_FILES.get(path.name, extention_parser)

--- a/tests/_data/plugins/os/unix/linux/systemd.network/20-wired-static.network
+++ b/tests/_data/plugins/os/unix/linux/systemd.network/20-wired-static.network
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2644524e0f127e1ce21751b32fa0d166405dd488fe435f4b7eb08faf7e4a8048
-size 132
+oid sha256:775b4bf34861a174c73d6dd90c156805305d9d22df53d2473b8fa1923d11f008
+size 166

--- a/tests/_data/plugins/os/unix/linux/systemd.network/30-wired-static-complex.network.d/10-override.conf
+++ b/tests/_data/plugins/os/unix/linux/systemd.network/30-wired-static-complex.network.d/10-override.conf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1adf450a1fb41386c8f880d17c292dbf62b12eebb8468f955171c5241d0d2b4
+size 94

--- a/tests/_data/plugins/os/unix/linux/systemd.network/30-wired-static-complex.network.d/20-override.conf
+++ b/tests/_data/plugins/os/unix/linux/systemd.network/30-wired-static-complex.network.d/20-override.conf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37ea95ee96de6585b2e6226a2ab63e57d458ba9d34919e50bef1755a58d46bc2
+size 72

--- a/tests/helpers/test_configutil.py
+++ b/tests/helpers/test_configutil.py
@@ -106,6 +106,17 @@ def test_custom_comments(comment_string: str, comment_prefixes: tuple[str, ...])
         ),
         (
             """
+            key value1
+              key2 value2a
+              key3 value3a
+            key value1
+              key2 value2b
+              key3 value3b
+            """,
+            {"key value1": [{"key2": "value2a", "key3": "value3a"}, {"key2": "value2b", "key3": "value3b"}]},
+        ),
+        (
+            """
             key value
               key2 value2
               key3 value3


### PR DESCRIPTION
Fixes:
-  `_select_parser` could be invoked with a `Path`, while it expects a `FileSystemEntry`. Additionally, there were multiple code paths in `parse` and `parse_config` to support `TargetPath`, `Path`, and `File` objects. Removed the dependence on `FileSystemEntry` by converting entries to `TargetPath` in the config file system.
- Systemd network parser did not collapse singleton values
- When multiple sections with the same name are encountered, the resulting key is a list of those sections:
Example:
```
key value1
   key2 value2a
key value1
   key2 value2b
   key3 value3b
```
  
 now parses as  `{"key value1": [{"key2": "value2a"}, {"key2": "value2b", "key3": "value3b"}]}`. Previously, this parsed as `{"key value1": {"key2": ["value2a", "value2b"], "key3": "value3b"}}`, where the parallel lists could become misaligned.

Supports:
- Drop files when invoking parse with a systemd file
- Empty value now clears corresponding key when merging systemd files.


