### PR TITLE
Allow glob in path argument of target-fs

### DIFF
--- a/dissect/target/tools/fs.py
+++ b/dissect/target/tools/fs.py
@@ -156,13 +156,16 @@ def main() -> int:
         log.debug("", exc_info=e)
         return 1
 
-    path = target.fs.path(args.path)
+    glob_path = str(args.path).lstrip("/")
 
-    if not path.exists():
+    found = False
+    for path in target.fs.path("/").glob(glob_path):
+        args.handler(target, path, args)
+        found = True
+
+    if not found:
         print("[!] Path doesn't exist")
         return 1
-
-    args.handler(target, path, args)
 
     return 0
 


### PR DESCRIPTION
This PR adds support for globs in the `path` argument of `target-fs`, this way we can for example extract all EVTX files from a collect by running `target-fs <target> cp "**/*.evtx"` or all syslog files by running `target-fs <target> cp /var/log/syslog*`

Fixes #1002 