### PR TITLE
Lower target mount cache

### DIFF
--- a/dissect/target/filesystems/config.py
+++ b/dissect/target/filesystems/config.py
@@ -9,7 +9,6 @@ from dissect.target.exceptions import ConfigurationParsingError, FileNotFoundErr
 from dissect.target.filesystem import FilesystemEntry, VirtualFilesystem
 from dissect.target.helpers import fsutil
 from dissect.target.helpers.configutil import ConfigurationParser, parse
-from dissect.target.helpers.fsutil import TargetPath
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/dissect/target/filesystems/config.py
+++ b/dissect/target/filesystems/config.py
@@ -9,6 +9,7 @@ from dissect.target.exceptions import ConfigurationParsingError, FileNotFoundErr
 from dissect.target.filesystem import FilesystemEntry, VirtualFilesystem
 from dissect.target.helpers import fsutil
 from dissect.target.helpers.configutil import ConfigurationParser, parse
+from dissect.target.helpers.fsutil import TargetPath
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/dissect/target/helpers/mount.py
+++ b/dissect/target/helpers/mount.py
@@ -29,7 +29,7 @@ else:
 
 log = logging.getLogger(__name__)
 
-CACHE_SIZE = 128 * 1024
+CACHE_SIZE = 64 * 1024  # Tuned for ~0.7GB of memory usage on extFS
 
 
 class DissectMount(Operations):

--- a/dissect/target/helpers/mount.py
+++ b/dissect/target/helpers/mount.py
@@ -29,7 +29,7 @@ else:
 
 log = logging.getLogger(__name__)
 
-CACHE_SIZE = 1024 * 1024
+CACHE_SIZE = 128 * 1024
 
 
 class DissectMount(Operations):

--- a/dissect/target/plugins/os/windows/tasks/job.py
+++ b/dissect/target/plugins/os/windows/tasks/job.py
@@ -204,8 +204,7 @@ class AtTask:
 
         # check which prio bit is set
         for key in self.at_data.task_prio.fields:
-            value = getattr(self.at_data.task_prio, key)
-            if value:
+            if getattr(self.at_data.task_prio, key):
                 self.priority = key
 
     def get_actions(self) -> Iterator[TargetRecordDescriptor]:

--- a/dissect/target/plugins/os/windows/tasks/job.py
+++ b/dissect/target/plugins/os/windows/tasks/job.py
@@ -203,7 +203,8 @@ class AtTask:
         self.data = self.at_data.user_data
 
         # check which prio bit is set
-        for key, value in self.at_data.task_prio._values.items():
+        for key in self.at_data.task_prio.fields:
+            value = getattr(self.at_data.task_prio, key)
             if value:
                 self.priority = key
 


### PR DESCRIPTION
Although there were multiple factors contributing to the high memory usage of target.mount, the cache size was a bit too generous. 

Significantly lowered the cache size