### PR TITLE
cam.registry assumed wrong part of path as device

### DIFF
--- a/dissect/target/plugins/os/windows/cam.py
+++ b/dissect/target/plugins/os/windows/cam.py
@@ -362,7 +362,7 @@ class CamPlugin(Plugin):
             # HKLM\\...\\CapabilityAccessManager\\ConsentStore\\webcam\\C:#Program Files#Mozilla Firefox#firefox.exe
             # However, sometimes there is an additional subfolder such as "NonPackaged" in between. Example:
             # HKLM\\...\\CapabilityAccessManager\\ConsentStore\\webcam\\NonPackaged\\C:#...#Mozilla Firefox#firefox.exe
-            # Code below determines the location of 'ConsentStore' in the path and grabs the sub-folder.
+            # Code below determines the location of 'ConsentStore' (always present) in the path and grabs the sub-folder.
             path_list = key.path.split("\\")
             device = path_list[path_list.index("ConsentStore") + 1]
 

--- a/dissect/target/plugins/os/windows/cam.py
+++ b/dissect/target/plugins/os/windows/cam.py
@@ -360,7 +360,11 @@ class CamPlugin(Plugin):
 
             # The "device" is derived from the subkey (webcam in this case) of ConsentStore example:
             # HKLM\\...\\CapabilityAccessManager\\ConsentStore\\webcam\\C:#Program Files#Mozilla Firefox#firefox.exe
-            device = key.path.split("\\")[-2]
+            # However, sometimes there is an additional subfolder such as "NonPackaged" in between. Example:
+            # HKLM\\...\\CapabilityAccessManager\\ConsentStore\\webcam\\NonPackaged\\C:#...#Mozilla Firefox#firefox.exe
+            # Code below determines the location of 'ConsentStore' in the path and grabs the sub-folder.
+            path_list = key.path.split("\\")
+            device = path_list[path_list.index("ConsentStore") + 1]
 
             # The application/or path of the application using the device is the key.name itself:
             # C:#Program Files#Mozilla Firefox#firefox.exe

--- a/dissect/target/plugins/os/windows/cam.py
+++ b/dissect/target/plugins/os/windows/cam.py
@@ -362,7 +362,7 @@ class CamPlugin(Plugin):
             # HKLM\\...\\CapabilityAccessManager\\ConsentStore\\webcam\\C:#Program Files#Mozilla Firefox#firefox.exe
             # However, sometimes there is an additional subfolder such as "NonPackaged" in between. Example:
             # HKLM\\...\\CapabilityAccessManager\\ConsentStore\\webcam\\NonPackaged\\C:#...#Mozilla Firefox#firefox.exe
-            # Code below determines the location of 'ConsentStore' (always present) in the path and grabs the sub-folder.
+            # Code below determines the index of 'ConsentStore' (always present) in the path and grabs the sub-folder.
             path_list = key.path.split("\\")
             device = path_list[path_list.index("ConsentStore") + 1]
 

--- a/tests/plugins/os/windows/test_cam.py
+++ b/tests/plugins/os/windows/test_cam.py
@@ -99,7 +99,7 @@ def test_cam_registry(target_win_users: Target, hive_hku: VirtualHive, hive_hklm
     microsoft_camera_key.add_value("LastUsedTimeStart", VirtualValue(hive_hku, "LastUsedTimeStart", 133784711366495858))
     microsoft_camera_key.add_value("LastUsedTimeStop", VirtualValue(hive_hku, "LastUsedTimeStop", 133784711515887950))
 
-    firefox_key = VirtualKey(hive_hku, f"{hive_hku}\\{hku_cam_key.path}\\C:#Program Files#Mozilla Firefox#firefox.exe")
+    firefox_key = VirtualKey(hive_hku, f"{hive_hku}\\{hku_cam_key.path}\\NonPackaged\\C:#Program Files#Mozilla Firefox#firefox.exe")
     firefox_key.add_value("LastUsedTimeStart", VirtualValue(hive_hku, "LastUsedTimeStart", 133788466426086184))
     firefox_key.add_value("LastUsedTimeStop", VirtualValue(hive_hku, "LastUsedTimeStop", 133788466774490036))
 

--- a/tests/plugins/os/windows/test_cam.py
+++ b/tests/plugins/os/windows/test_cam.py
@@ -99,7 +99,9 @@ def test_cam_registry(target_win_users: Target, hive_hku: VirtualHive, hive_hklm
     microsoft_camera_key.add_value("LastUsedTimeStart", VirtualValue(hive_hku, "LastUsedTimeStart", 133784711366495858))
     microsoft_camera_key.add_value("LastUsedTimeStop", VirtualValue(hive_hku, "LastUsedTimeStop", 133784711515887950))
 
-    firefox_key = VirtualKey(hive_hku, f"{hive_hku}\\{hku_cam_key.path}\\NonPackaged\\C:#Program Files#Mozilla Firefox#firefox.exe")
+    firefox_key = VirtualKey(
+        hive_hku, f"{hive_hku}\\{hku_cam_key.path}\\NonPackaged\\C:#Program Files#Mozilla Firefox#firefox.exe"
+    )
     firefox_key.add_value("LastUsedTimeStart", VirtualValue(hive_hku, "LastUsedTimeStart", 133788466426086184))
     firefox_key.add_value("LastUsedTimeStop", VirtualValue(hive_hku, "LastUsedTimeStop", 133788466774490036))
 


### PR DESCRIPTION
PR to fix the issue: 

https://github.com/fox-it/dissect.target/issues/1156

Resolved by identifying the parent of the 'device'-key to work around this problem. 