### PR TITLE
Let QCow2Container init to pass fh directly as Path

### DIFF
--- a/dissect/target/containers/qcow2.py
+++ b/dissect/target/containers/qcow2.py
@@ -22,10 +22,7 @@ class QCow2Container(Container):
         *args,
         **kwargs,
     ):
-        f = fh
-        if not hasattr(fh, "read"):
-            f = fh.open("rb")
-        self.qcow2 = qcow2.QCow2(f, data_file, backing_file)
+        self.qcow2 = qcow2.QCow2(fh, data_file, backing_file)
 
         super().__init__(fh, self.qcow2.size, *args, **kwargs)
 


### PR DESCRIPTION
This PR is related to [this PR](https://github.com/fox-it/dissect.hypervisor/pull/52).

Pass the original `fh` parameter directly to QCow2 constructor, relying on QCow2 to handle Path or file-like objects. 
This allows QCow2 to automatically resolve backing files if they are required.

The change can be end2end tested by attempting to run `target-info` or `target-query` on a qcow2 snapshot with a backing-file.

I've tested against a standalone qcow2 image to check if backwards comp is maintained and against a qcow2 snapshot with a backing-file.

Fixes #1154

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
