### PR TITLE
Parse dynamic configuration data from /proc/net

### DIFF
--- a/tests/_data/plugins/os/unix/linux/proc/if_inet6
+++ b/tests/_data/plugins/os/unix/linux/proc/if_inet6
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:275137270d2efb6e76efbf34cf63dfa48eea36121d9d9842fd45a7d0ab5a8c26
+size 109

--- a/tests/_data/plugins/os/unix/linux/proc/route
+++ b/tests/_data/plugins/os/unix/linux/proc/route
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:020cbf204604dca49dd02b3a94c955c1cfef4336bb8051c689db3709779d1192
+size 640

--- a/tests/_data/plugins/os/unix/linux/proc/tcp
+++ b/tests/_data/plugins/os/unix/linux/proc/tcp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:689655c4f6e84e0c2fffd8988291da1a9876fa1ff0939fd60e15ff45c4e70c3b
+size 4800


### PR DESCRIPTION
In addition to the static configuration data of network manager and systemd, this parser adds dynamic data based on /proc/net. 

This means there might be duplicate records on interface name, one with a source from the static parsers, and one from the dynamic parser.
