### PR TITLE
Check for optional dependencies

### DIFF
--- a/dissect/target/filesystems/cb.py
+++ b/dissect/target/filesystems/cb.py
@@ -18,7 +18,6 @@ try:
     from cbc_sdk.live_response_api import LiveResponseError, LiveResponseSession
 
     HAS_CARBON_BLACK = True
-
 except ImportError:
     HAS_CARBON_BLACK = False
 

--- a/dissect/target/filesystems/cb.py
+++ b/dissect/target/filesystems/cb.py
@@ -5,7 +5,6 @@ from datetime import datetime, timezone
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any, BinaryIO
 
-from cbc_sdk.live_response_api import LiveResponseError, LiveResponseSession
 from dissect.util import ts
 
 from dissect.target.exceptions import FileNotFoundError, NotADirectoryError
@@ -14,6 +13,14 @@ from dissect.target.helpers import fsutil
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+try:
+    from cbc_sdk.live_response_api import LiveResponseError, LiveResponseSession
+
+    HAS_CARBON_BLACK = True
+
+except ImportError:
+    HAS_CARBON_BLACK = False
 
 CB_TIMEFORMAT = "%Y-%m-%dT%H:%M:%S%fZ"
 
@@ -28,6 +35,9 @@ class CbFilesystem(Filesystem):
     __type__ = "cb"
 
     def __init__(self, session: LiveResponseSession, prefix: str, *args, **kwargs):
+        if not HAS_CARBON_BLACK:
+            raise ImportError("Please install 'carbon-black-cloud-sdk-python' to use CbFilesystem.")
+
         self.session = session
         self.prefix = prefix.lower()
 

--- a/dissect/target/filesystems/cb.py
+++ b/dissect/target/filesystems/cb.py
@@ -36,7 +36,9 @@ class CbFilesystem(Filesystem):
 
     def __init__(self, session: LiveResponseSession, prefix: str, *args, **kwargs):
         if not HAS_CARBON_BLACK:
-            raise ImportError("Please install 'carbon-black-cloud-sdk-python' to use CbFilesystem.")
+            raise ImportError(
+                "Required dependency 'carbon-black-cloud-sdk-python' is missing, install with 'pip install dissect.target[cb]"  # noqa: E501
+            )
 
         self.session = session
         self.prefix = prefix.lower()

--- a/dissect/target/filesystems/cb.py
+++ b/dissect/target/filesystems/cb.py
@@ -37,7 +37,7 @@ class CbFilesystem(Filesystem):
     def __init__(self, session: LiveResponseSession, prefix: str, *args, **kwargs):
         if not HAS_CARBON_BLACK:
             raise ImportError(
-                "Required dependency 'carbon-black-cloud-sdk-python' is missing, install with 'pip install dissect.target[cb]"  # noqa: E501
+                "Required dependency 'carbon-black-cloud-sdk-python' is missing, install with 'pip install dissect.target[cb]'"  # noqa: E501
             )
 
         self.session = session

--- a/dissect/target/filesystems/smb.py
+++ b/dissect/target/filesystems/smb.py
@@ -5,16 +5,6 @@ import stat
 from typing import TYPE_CHECKING, BinaryIO
 
 from dissect.util.stream import AlignedStream
-from impacket.nt_errors import STATUS_NOT_A_DIRECTORY
-from impacket.smb import ATTR_DIRECTORY, SharedFile
-from impacket.smb3structs import (
-    FILE_ATTRIBUTE_NORMAL,
-    FILE_NON_DIRECTORY_FILE,
-    FILE_OPEN,
-    FILE_READ_DATA,
-    FILE_SHARE_READ,
-)
-from impacket.smbconnection import SessionError, SMBConnection
 
 from dissect.target.exceptions import (
     FileNotFoundError,
@@ -28,6 +18,23 @@ from dissect.target.helpers import fsutil
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+try:
+    from impacket.nt_errors import STATUS_NOT_A_DIRECTORY
+    from impacket.smb import ATTR_DIRECTORY, SharedFile
+    from impacket.smb3structs import (
+        FILE_ATTRIBUTE_NORMAL,
+        FILE_NON_DIRECTORY_FILE,
+        FILE_OPEN,
+        FILE_READ_DATA,
+        FILE_SHARE_READ,
+    )
+    from impacket.smbconnection import SessionError, SMBConnection
+
+    HAS_IMPACKET = True
+
+except ImportError:
+    HAS_IMPACKET = False
+
 log = logging.getLogger(__name__)
 
 
@@ -38,6 +45,12 @@ class SmbFilesystem(Filesystem):
 
     def __init__(self, conn: SMBConnection, share_name: str, *args, **kwargs):
         super().__init__(None, *args, **kwargs, alt_separator="\\", case_sensitive=False)
+
+        if not HAS_IMPACKET:
+            raise ImportError(
+                "Required dependency 'impacket' is missing, install with 'pip install dissect.target[smb]'"
+            )
+
         self.conn = conn
         self.share_name = share_name
 

--- a/dissect/target/filesystems/smb.py
+++ b/dissect/target/filesystems/smb.py
@@ -31,7 +31,6 @@ try:
     from impacket.smbconnection import SessionError, SMBConnection
 
     HAS_IMPACKET = True
-
 except ImportError:
     HAS_IMPACKET = False
 

--- a/dissect/target/loaders/cb.py
+++ b/dissect/target/loaders/cb.py
@@ -55,7 +55,7 @@ class CbLoader(Loader):
 
         if not HAS_CARBON_BLACK:
             raise ImportError(
-                "Required dependency 'carbon-black-cloud-sdk-python' is missing, install with 'pip install dissect.target[cb]"  # noqa: E501
+                "Required dependency 'carbon-black-cloud-sdk-python' is missing, install with 'pip install dissect.target[cb]'"  # noqa: E501
             )
 
         self.host = self.parsed_path.path.strip("/")

--- a/dissect/target/loaders/cb.py
+++ b/dissect/target/loaders/cb.py
@@ -4,13 +4,6 @@ import ipaddress
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-try:
-    from cbc_sdk.errors import CredentialError
-    from cbc_sdk.platform import Device
-    from cbc_sdk.rest_api import CBCloudAPI
-except ImportError:
-    raise ImportError("Please install 'carbon-black-cloud-sdk-python' to use the 'cb://' target.")
-
 from dissect.util import ts
 
 from dissect.target.exceptions import (
@@ -39,6 +32,15 @@ if TYPE_CHECKING:
 
     from dissect.target.target import Target
 
+try:
+    from cbc_sdk.errors import CredentialError
+    from cbc_sdk.platform import Device
+    from cbc_sdk.rest_api import CBCloudAPI
+
+    HAS_CARBON_BLACK = True
+except ImportError:
+    HAS_CARBON_BLACK = False
+
 
 class CbLoader(Loader):
     """Use Carbon Black endpoints as targets using Live Response.
@@ -50,6 +52,9 @@ class CbLoader(Loader):
 
     def __init__(self, path: Path, parsed_path: ParseResult | None = None):
         super().__init__(path, parsed_path=parsed_path, resolve=False)
+
+        if not HAS_CARBON_BLACK:
+            raise ImportError("Please install 'carbon-black-cloud-sdk-python' to use the 'cb://' target.")
 
         self.host = self.parsed_path.path.strip("/")
         instance = self.parsed_path.hostname

--- a/dissect/target/loaders/cb.py
+++ b/dissect/target/loaders/cb.py
@@ -54,7 +54,9 @@ class CbLoader(Loader):
         super().__init__(path, parsed_path=parsed_path, resolve=False)
 
         if not HAS_CARBON_BLACK:
-            raise ImportError("Please install 'carbon-black-cloud-sdk-python' to use the 'cb://' target.")
+            raise ImportError(
+                "Required dependency 'carbon-black-cloud-sdk-python' is missing, install with 'pip install dissect.target[cb]"  # noqa: E501
+            )
 
         self.host = self.parsed_path.path.strip("/")
         instance = self.parsed_path.hostname

--- a/dissect/target/loaders/mqtt.py
+++ b/dissect/target/loaders/mqtt.py
@@ -18,7 +18,6 @@ from struct import pack, unpack_from
 from threading import Thread
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, TypeVar
 
-import paho.mqtt.client as mqtt
 from dissect.util.stream import AlignedStream
 
 from dissect.target.containers.raw import RawContainer
@@ -30,6 +29,14 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from dissect.target.target import Target
+
+try:
+    import paho.mqtt.client as mqtt
+
+    HAS_PAHO = True
+
+except ImportError:
+    HAS_PAHO = False
 
 log = logging.getLogger(__name__)
 
@@ -298,6 +305,9 @@ class Broker:
         self.username = username
         self.password = password
         self.command = kwargs.get("command")
+
+        if not HAS_PAHO:
+            raise ImportError("Required dependency 'paho' is missing, install with 'pip install dissect.target[mqtt]'")
 
     def clear_cache(self) -> None:
         self.index = {}

--- a/dissect/target/loaders/mqtt.py
+++ b/dissect/target/loaders/mqtt.py
@@ -34,7 +34,6 @@ try:
     import paho.mqtt.client as mqtt
 
     HAS_PAHO = True
-
 except ImportError:
     HAS_PAHO = False
 

--- a/dissect/target/loaders/smb.py
+++ b/dissect/target/loaders/smb.py
@@ -40,7 +40,6 @@ try:
     from impacket.smbconnection import SessionError, SMBConnection
 
     HAS_IMPACKET = True
-
 except ImportError:
     HAS_IMPACKET = False
 
@@ -180,7 +179,6 @@ class SmbLoader(Loader):
                     mount_name = share_name.lower().replace("$", ":")
 
                 target.fs.mount(mount_name, smb_filesystem)
-
             except SessionError as e:
                 target.log.warning("Failed to mount share '%s', reason: %s", share_name, e)
 

--- a/dissect/target/loaders/smb.py
+++ b/dissect/target/loaders/smb.py
@@ -93,7 +93,7 @@ class SmbLoader(Loader):
 
         if not HAS_IMPACKET:
             raise ImportError(
-                "Required dependency 'impacket' is missing, install with 'pip install dissect.target[smb]"
+                "Required dependency 'impacket' is missing, install with 'pip install dissect.target[smb]'"
             )
 
         if parsed_path is None:

--- a/dissect/target/loaders/smb.py
+++ b/dissect/target/loaders/smb.py
@@ -7,9 +7,6 @@ from typing import TYPE_CHECKING
 
 from dissect.regf import regf
 from dissect.util import ts
-from impacket.dcerpc.v5 import rpcrt, rrp, scmr, transport
-from impacket.dcerpc.v5.rpcrt import DCERPCException
-from impacket.smbconnection import SessionError, SMBConnection
 
 from dissect.target.exceptions import (
     LoaderError,
@@ -36,6 +33,16 @@ if TYPE_CHECKING:
     from impacket.dcerpc.v5.srvs import SHARE_INFO_1
 
     from dissect.target.target import Target
+
+try:
+    from impacket.dcerpc.v5 import rpcrt, rrp, scmr, transport
+    from impacket.dcerpc.v5.rpcrt import DCERPCException
+    from impacket.smbconnection import SessionError, SMBConnection
+
+    HAS_IMPACKET = True
+
+except ImportError:
+    HAS_IMPACKET = False
 
 
 class SmbLoader(Loader):
@@ -83,6 +90,11 @@ class SmbLoader(Loader):
 
     def __init__(self, path: Path, parsed_path: ParseResult | None = None):
         super().__init__(path, parsed_path=parsed_path, resolve=False)
+
+        if not HAS_IMPACKET:
+            raise ImportError(
+                "Required dependency 'impacket' is missing, install with 'pip install dissect.target[smb]"
+            )
 
         if parsed_path is None:
             raise LoaderError("Missing URI connection details")

--- a/tests/filesystems/test_cb.py
+++ b/tests/filesystems/test_cb.py
@@ -10,6 +10,9 @@ from dissect.target.exceptions import NotADirectoryError
 
 def test_cb_filesystem_windows(monkeypatch: pytest.MonkeyPatch) -> None:
     with monkeypatch.context() as m:
+        if "dissect.target.filesystems.cb" in sys.modules:
+            m.delitem(sys.modules, "dissect.target.filesystems.cb")
+
         mock_cbc_sdk = MagicMock()
         m.setitem(sys.modules, "cbc_sdk", mock_cbc_sdk)
         m.setitem(sys.modules, "cbc_sdk.live_response_api", mock_cbc_sdk.live_response_api)

--- a/tests/filesystems/test_smb.py
+++ b/tests/filesystems/test_smb.py
@@ -10,6 +10,9 @@ from dissect.target.exceptions import NotADirectoryError
 
 def test_smb_filesystem_windows(monkeypatch: pytest.MonkeyPatch) -> None:
     with monkeypatch.context() as m:
+        if "dissect.target.filesystems.smb" in sys.modules:
+            m.delitem(sys.modules, "dissect.target.filesystems.smb")
+
         mock_impacket = MagicMock()
         m.setitem(sys.modules, "impacket", mock_impacket)
         m.setitem(sys.modules, "impacket.nt_errors", mock_impacket.nt_errors)

--- a/tests/loaders/test_cb.py
+++ b/tests/loaders/test_cb.py
@@ -23,6 +23,8 @@ def mock_cbc_sdk(monkeypatch: pytest.MonkeyPatch) -> Iterator[MagicMock]:
         # function that is running.
         if "dissect.target.loaders.cb" in sys.modules:
             m.delitem(sys.modules, "dissect.target.loaders.cb")
+        if "dissect.target.filesystems.cb" in sys.modules:
+            m.delitem(sys.modules, "dissect.target.filesystems.cb")
 
         mock_cbc_sdk = MagicMock()
         m.setitem(sys.modules, "cbc_sdk", mock_cbc_sdk)

--- a/tests/loaders/test_smb.py
+++ b/tests/loaders/test_smb.py
@@ -18,6 +18,8 @@ def mock_impacket(monkeypatch: pytest.MonkeyPatch) -> Iterator[MagicMock]:
     with monkeypatch.context() as m:
         if "dissect.target.loaders.smb" in sys.modules:
             m.delitem(sys.modules, "dissect.target.loaders.smb")
+        if "dissect.target.filesystems.smb" in sys.modules:
+            m.delitem(sys.modules, "dissect.target.filesystems.smb")
 
         mock_impacket = MagicMock()
         m.setitem(sys.modules, "impacket", mock_impacket)


### PR DESCRIPTION
This PR removes debug stacktraces from `target-* -vv` stderr output  from Carbon Black, SMB and MQTT loaders and filesystems. This change will cause several mocks to fail in the tests, unsure how we should fix those.