### PR TITLE
Search additional paths for home directories

### DIFF
--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -1263,7 +1263,7 @@ class OSPlugin(Plugin):
         """Yields miscellaneous user paths and user keys.
 
         Example:
-            ("%windir%/ServiceProfiles/LocalService", ("sid", "S-1-5-19"))
+            ("c:/Windows/ServiceProfiles/LocalService", ("sid", "S-1-5-19"))
         """
 
         # Consider moving this to the UsersPlugin class, and create separate UsersPlugin subclasses for each OS

--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -1160,6 +1160,8 @@ class OSPlugin(Plugin):
     methods with the same ``@classmethod`` or ``@export(...)`` annotation.
     """
 
+    _misc_home_dirs: tuple[tuple[str, str | None]] = ()
+
     def __init_subclass__(cls, **kwargs):
         # Note that cls is the subclass
         super().__init_subclass__(**kwargs)

--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -1259,6 +1259,15 @@ class OSPlugin(Plugin):
         raise NotImplementedError
 
     @internal
+    def misc_home_dirs(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
+        """Return a generator home directories and a user key.
+
+        Example output: ("%windir%/ServiceProfiles/LocalService", ("sid", "S-1-5-19"))
+        """
+
+        raise NotImplementedError
+
+    @internal
     def os_tree(self) -> list[str]:
         """Returns the :func:`os` value of this and all the OS plugin parents."""
         result: list[str] = []

--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -1160,8 +1160,6 @@ class OSPlugin(Plugin):
     methods with the same ``@classmethod`` or ``@export(...)`` annotation.
     """
 
-    _misc_home_dirs: tuple[tuple[str, str | None]] = ()
-
     def __init_subclass__(cls, **kwargs):
         # Note that cls is the subclass
         super().__init_subclass__(**kwargs)

--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -1259,12 +1259,15 @@ class OSPlugin(Plugin):
         raise NotImplementedError
 
     @internal
-    def misc_home_dirs(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
-        """Return a generator home directories and a user key.
+    def misc_user_paths(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
+        """Yields miscellaneous user paths and user keys.
 
-        Example output: ("%windir%/ServiceProfiles/LocalService", ("sid", "S-1-5-19"))
+        Example:
+            ("%windir%/ServiceProfiles/LocalService", ("sid", "S-1-5-19"))
         """
 
+        # Consider moving this to the UserPlugin class, and create separate UserPlugin subclasses for each OS
+        # when the mechanism becomes more complex.
         raise NotImplementedError
 
     @internal

--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -1266,8 +1266,8 @@ class OSPlugin(Plugin):
             ("%windir%/ServiceProfiles/LocalService", ("sid", "S-1-5-19"))
         """
 
-        # Consider moving this to the UserPlugin class, and create separate UserPlugin subclasses for each OS
-        # when the mechanism becomes more complex.
+        # Consider moving this to the UsersPlugin class, and create separate UsersPlugin subclasses for each OS
+        # when the machinery concerning users and user_paths becomes more complex.
         raise NotImplementedError
 
     @internal

--- a/dissect/target/plugins/general/users.py
+++ b/dissect/target/plugins/general/users.py
@@ -102,10 +102,10 @@ class UsersPlugin(InternalPlugin):
             if any(seen_path.samefile(misc_home_dir) for seen_path in seen) or not user_criterion:
                 continue
 
-            if (user := self.find(**{user_criterion[0]: user_criterion[1]})) is None:
+            if (user_details := self.find(**{user_criterion[0]: user_criterion[1]})) is None:
                 continue
 
-            yield UserDetails(user=UnixUserRecord(name=misc_home_dir), home_path=misc_home_dir)
+            yield UserDetails(user=user_details.user, home_path=misc_home_dir)
             seen.add(misc_home_dir)
 
     @cached_property

--- a/dissect/target/plugins/general/users.py
+++ b/dissect/target/plugins/general/users.py
@@ -96,7 +96,7 @@ class UsersPlugin(InternalPlugin):
             self.target.log.debug("", exc_info=e)
 
         # Iterate over misc home directories
-        for misc_home_dir, user_criterion in self.target.misc_home_dirs:
+        for misc_home_dir, user_criterion in self.target.misc_home_dirs():
             # We skip the entry if no user can be found.
             # We cannot use set membership check here because of https://github.com/fox-it/dissect.target/issues/1203
             if any(seen_path.samefile(misc_home_dir) for seen_path in seen) or not user_criterion:
@@ -123,7 +123,7 @@ class UsersPlugin(InternalPlugin):
             self.target.log.debug("", exc_info=e)
 
         # Iterate over misc home directories
-        for misc_home_dir, _ in self.target.misc_home_dirs:
+        for misc_home_dir, _ in self.target.misc_home_dirs():
             # We cannot use set membership check here because of https://github.com/fox-it/dissect.target/issues/1203
             if not any(seen_path.samefile(misc_home_dir) for seen_path in seen):
                 yield misc_home_dir

--- a/dissect/target/plugins/general/users.py
+++ b/dissect/target/plugins/general/users.py
@@ -92,11 +92,11 @@ class UsersPlugin(InternalPlugin):
                         seen.add(user_details.home_path)
                         yield user_details
         except Exception as e:
-            self.target.log.warning("Failed to retrieve user details, falling back to hardcoded locations.")
+            self.target.log.warning("Failed to retrieve user details, falling back to hardcoded locations")
             self.target.log.debug("", exc_info=e)
 
         # Iterate over misc home directories
-        for misc_home_dir, user_criterion in self.target.misc_home_dirs():
+        for misc_home_dir, user_criterion in self.target.misc_user_paths():
             # We skip the entry if no user can be found.
             # We cannot use set membership check here because of https://github.com/fox-it/dissect.target/issues/1203
             if any(seen_path.samefile(misc_home_dir) for seen_path in seen) or not user_criterion:
@@ -110,7 +110,7 @@ class UsersPlugin(InternalPlugin):
 
     @cached_property
     def all_home_dirs(self) -> Iterator[TargetPath]:
-        """Return all home directories of users."""
+        """Return all home directories of users, including miscellaneous user directories that may not be linked to discovered local users."""  # noqa: E501
 
         seen: set[TargetPath] = set()
         try:
@@ -119,11 +119,11 @@ class UsersPlugin(InternalPlugin):
                     yield home_path
                     seen.add(home_path)
         except Exception as e:
-            self.target.log.warning("Failed to retrieve user details, falling back to hardcoded locations.")
+            self.target.log.warning("Failed to retrieve user details, falling back to hardcoded locations")
             self.target.log.debug("", exc_info=e)
 
         # Iterate over misc home directories
-        for misc_home_dir, _ in self.target.misc_home_dirs():
+        for misc_home_dir, _ in self.target.misc_user_paths():
             # We cannot use set membership check here because of https://github.com/fox-it/dissect.target/issues/1203
             if not any(seen_path.samefile(misc_home_dir) for seen_path in seen):
                 yield misc_home_dir

--- a/dissect/target/plugins/general/users.py
+++ b/dissect/target/plugins/general/users.py
@@ -109,7 +109,7 @@ class UsersPlugin(InternalPlugin):
             seen.add(misc_home_dir)
 
     @cached_property
-    def all_home_dirs(self) -> Iterator[TargetPath]:
+    def all_home_paths(self) -> Iterator[TargetPath]:
         """Return all home directories of users, including miscellaneous user directories that may not be linked to discovered local users."""  # noqa: E501
 
         seen: set[TargetPath] = set()

--- a/dissect/target/plugins/os/default/_os.py
+++ b/dissect/target/plugins/os/default/_os.py
@@ -52,10 +52,6 @@ class DefaultOSPlugin(OSPlugin):
 
     @internal
     def misc_home_dirs(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
-        """Return a generator home directories and a user key.
-
-        Example output: ("%windir%/ServiceProfiles/LocalService", ("sid", "S-1-5-19"))
-        """
         yield from ()
 
     @export(property=True)

--- a/dissect/target/plugins/os/default/_os.py
+++ b/dissect/target/plugins/os/default/_os.py
@@ -51,7 +51,7 @@ class DefaultOSPlugin(OSPlugin):
         yield from ()
 
     @internal
-    def misc_home_dirs(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
+    def misc_user_paths(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
         yield from ()
 
     @export(property=True)

--- a/dissect/target/plugins/os/default/_os.py
+++ b/dissect/target/plugins/os/default/_os.py
@@ -51,6 +51,10 @@ class DefaultOSPlugin(OSPlugin):
         yield from ()
 
     @export(property=True)
+    def misc_home_dirs(self) -> Iterator[tuple[tuple[str, tuple[str, str] | None]]]:
+        yield from ()
+
+    @export(property=True)
     def os(self) -> str:
         return "default"
 

--- a/dissect/target/plugins/os/default/_os.py
+++ b/dissect/target/plugins/os/default/_os.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from dissect.target.helpers.record import EmptyRecord
-from dissect.target.plugin import OSPlugin, export
+from dissect.target.plugin import OSPlugin, export, internal
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -50,8 +50,12 @@ class DefaultOSPlugin(OSPlugin):
     def users(self) -> Iterator[Record]:
         yield from ()
 
-    @export(property=True)
-    def misc_home_dirs(self) -> Iterator[tuple[tuple[str, tuple[str, str] | None]]]:
+    @internal
+    def misc_home_dirs(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
+        """Return a generator home directories and a user key.
+
+        Example output: ("%windir%/ServiceProfiles/LocalService", ("sid", "S-1-5-19"))
+        """
         yield from ()
 
     @export(property=True)

--- a/dissect/target/plugins/os/unix/_os.py
+++ b/dissect/target/plugins/os/unix/_os.py
@@ -161,10 +161,10 @@ class UnixPlugin(OSPlugin):
 
     @internal
     def misc_home_dirs(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
-        if (root_path := self.target.resolve("root")).exists():
+        if (root_path := self.target.fs.path("root")).exists():
             yield (root_path, ("uid", 0))
 
-        if (home_path := self.target.resolve("home")).exists():
+        if (home_path := self.target.fs.path("home")).exists():
             yield from ((entry, None) for entry in home_path.iterdir() if entry.is_dir())
 
     @export(property=True)

--- a/dissect/target/plugins/os/unix/_os.py
+++ b/dissect/target/plugins/os/unix/_os.py
@@ -160,6 +160,14 @@ class UnixPlugin(OSPlugin):
                 )
 
     @export(property=True)
+    def misc_home_dirs(self) -> Iterator[tuple[tuple[str, tuple[str, str] | None]]]:
+        if (root_path := self.target.resolve("root")).exists():
+            yield (root_path, ("uid", 0))
+
+        if (home_path := self.target.resolve("home")).exists():
+            yield from ((entry, None) for entry in home_path.iterdir() if entry.is_dir())
+
+    @export(property=True)
     def architecture(self) -> str | None:
         return self._get_architecture(self.os)
 

--- a/dissect/target/plugins/os/unix/_os.py
+++ b/dissect/target/plugins/os/unix/_os.py
@@ -17,7 +17,7 @@ from dissect.target.helpers.record import UnixUserRecord
 from dissect.target.helpers.sunrpc.client import LocalPortPolicy, auth_unix
 from dissect.target.helpers.utils import parse_options_string
 from dissect.target.loaders.local import LocalLoader
-from dissect.target.plugin import OperatingSystem, OSPlugin, arg, export
+from dissect.target.plugin import OperatingSystem, OSPlugin, arg, export, internal
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -159,8 +159,8 @@ class UnixPlugin(OSPlugin):
                     _target=self.target,
                 )
 
-    @export(property=True)
-    def misc_home_dirs(self) -> Iterator[tuple[tuple[str, tuple[str, str] | None]]]:
+    @internal
+    def misc_home_dirs(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
         if (root_path := self.target.resolve("root")).exists():
             yield (root_path, ("uid", 0))
 

--- a/dissect/target/plugins/os/unix/_os.py
+++ b/dissect/target/plugins/os/unix/_os.py
@@ -161,10 +161,10 @@ class UnixPlugin(OSPlugin):
 
     @internal
     def misc_user_paths(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
-        if (root_path := self.target.fs.path("root")).exists():
+        if (root_path := self.target.fs.path("/root")).exists():
             yield (root_path, ("uid", 0))
 
-        if (home_path := self.target.fs.path("home")).exists():
+        if (home_path := self.target.fs.path("/home")).exists():
             yield from ((entry, None) for entry in home_path.iterdir() if entry.is_dir())
 
     @export(property=True)

--- a/dissect/target/plugins/os/unix/_os.py
+++ b/dissect/target/plugins/os/unix/_os.py
@@ -160,7 +160,7 @@ class UnixPlugin(OSPlugin):
                 )
 
     @internal
-    def misc_home_dirs(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
+    def misc_user_paths(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
         if (root_path := self.target.fs.path("root")).exists():
             yield (root_path, ("uid", 0))
 

--- a/dissect/target/plugins/os/unix/bsd/darwin/_os.py
+++ b/dissect/target/plugins/os/unix/bsd/darwin/_os.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from dissect.target.plugin import export
+from dissect.target.plugin import internal
 from dissect.target.plugins.os.unix.bsd._os import BsdPlugin
 
 if TYPE_CHECKING:
@@ -34,8 +34,8 @@ class DarwinPlugin(BsdPlugin):
                 return fs
         return None
 
-    @export(property=True)
-    def misc_home_dirs(self) -> Iterator[tuple[tuple[str, tuple[str, str] | None]]]:
+    @internal
+    def misc_home_dirs(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
         yield from super().misc_home_dirs()
 
         if (user_path := self.target.resolve("Users")).exists():

--- a/dissect/target/plugins/os/unix/bsd/darwin/_os.py
+++ b/dissect/target/plugins/os/unix/bsd/darwin/_os.py
@@ -38,7 +38,7 @@ class DarwinPlugin(BsdPlugin):
     def misc_home_dirs(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
         yield from super().misc_home_dirs()
 
-        if (user_path := self.target.resolve("Users")).exists():
+        if (user_path := self.target.fs.path("Users")).exists():
             yield from ((entry, None) for entry in user_path.iterdir() if entry.is_dir())
 
 

--- a/dissect/target/plugins/os/unix/bsd/darwin/_os.py
+++ b/dissect/target/plugins/os/unix/bsd/darwin/_os.py
@@ -38,7 +38,7 @@ class DarwinPlugin(BsdPlugin):
     def misc_user_paths(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
         yield from super().misc_user_paths()
 
-        if (user_path := self.target.fs.path("Users")).exists():
+        if (user_path := self.target.fs.path("/Users")).exists():
             yield from ((entry, None) for entry in user_path.iterdir() if entry.is_dir())
 
 

--- a/dissect/target/plugins/os/unix/bsd/darwin/_os.py
+++ b/dissect/target/plugins/os/unix/bsd/darwin/_os.py
@@ -35,8 +35,8 @@ class DarwinPlugin(BsdPlugin):
         return None
 
     @internal
-    def misc_home_dirs(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
-        yield from super().misc_home_dirs()
+    def misc_user_paths(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
+        yield from super().misc_user_paths()
 
         if (user_path := self.target.fs.path("Users")).exists():
             yield from ((entry, None) for entry in user_path.iterdir() if entry.is_dir())

--- a/dissect/target/plugins/os/windows/_os.py
+++ b/dissect/target/plugins/os/windows/_os.py
@@ -315,7 +315,7 @@ class WindowsPlugin(OSPlugin):
                 )
 
     @internal
-    def misc_home_dirs(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
+    def misc_user_paths(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
         yield from (
             (resolved_path, user_criterion)
             for path, user_criterion in [

--- a/dissect/target/plugins/os/windows/_os.py
+++ b/dissect/target/plugins/os/windows/_os.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from dissect.target.exceptions import RegistryError, RegistryValueNotFoundError
 from dissect.target.helpers.record import WindowsUserRecord
-from dissect.target.plugin import OperatingSystem, OSPlugin, export
+from dissect.target.plugin import OperatingSystem, OSPlugin, export, internal
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -314,8 +314,8 @@ class WindowsPlugin(OSPlugin):
                     _target=self.target,
                 )
 
-    @export(property=True)
-    def misc_home_dirs(self) -> Iterator[tuple[tuple[str, tuple[str, str] | None]]]:
+    @internal
+    def misc_home_dirs(self) -> Iterator[tuple[str, tuple[str, str] | None]]:
         yield from (
             (resolved_path, user_criterion)
             for path, user_criterion in [

--- a/dissect/target/plugins/os/windows/_os.py
+++ b/dissect/target/plugins/os/windows/_os.py
@@ -328,8 +328,7 @@ class WindowsPlugin(OSPlugin):
         )
 
         # Homedirs for users when there is no user profile information available.
-        user_dirs = ("sysvol/Users", "sysvol/Documents and Settings")
-        for user_dir in user_dirs:
+        for user_dir in ("sysvol/Users", "sysvol/Documents and Settings"):
             if (resolved := self.target.resolve(user_dir)).exists():
                 yield from ((entry, None) for entry in resolved.iterdir() if entry.is_dir())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -288,6 +288,11 @@ def hive_hklm() -> VirtualHive:
     # set current control set to ControlSet001 and mock it
     change_controlset(hive, 1)
 
+    # set windir
+    current_version_key = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"
+    hive.map_key(current_version_key, VirtualKey(hive, current_version_key))
+    hive.map_value(current_version_key, "SystemRoot", VirtualValue(hive, "SystemRoot", "c:\\Windows"))
+
     return hive
 
 

--- a/tests/plugins/general/test_users.py
+++ b/tests/plugins/general/test_users.py
@@ -44,6 +44,8 @@ def test_misc_users(target_win_users: Target, fs_win: VirtualFilesystem, tmp_pat
     fs_win.map_dir("Windows/SysWOW64/config/systemprofile", tmp_path)
     users_with_home = list(target_win_users.user_details.all_with_home())
     assert len(users_with_home) == 1  # Misc home dir is found
+    assert users_with_home[0].user.sid == "S-1-5-18"
+    assert users_with_home[0].home_path == target_win_users.fs.path("c:/Windows/SysWOW64/config/systemprofile")
 
     home_dirs = list(target_win_users.user_details.all_home_dirs)
     assert len(home_dirs) == 1  # Misc home dir is found

--- a/tests/plugins/general/test_users.py
+++ b/tests/plugins/general/test_users.py
@@ -36,6 +36,12 @@ def test_users_plugin(target_win_users: Target, fs_win: VirtualFilesystem, tmp_p
     assert len(users_with_home) == 1  # only John has a home dir
 
 
+def test_misc_users(target_win_users: Target, fs_win: VirtualFilesystem, tmp_path: Path) -> None:
+    fs_win.map_dir("windows/SysWOW64/config/systemprofile", tmp_path)
+    users_with_home = list(target_win_users.user_details.all_with_home())
+    assert len(users_with_home) == 1  # Misc home dir is found
+
+
 def test_users_plugin_find_no_params(target_unix_users: Target) -> None:
     with pytest.raises(ValueError, match="Either sid or uid or username is expected"):
         target_unix_users.user_details.find()

--- a/tests/plugins/general/test_users.py
+++ b/tests/plugins/general/test_users.py
@@ -35,11 +35,19 @@ def test_users_plugin(target_win_users: Target, fs_win: VirtualFilesystem, tmp_p
     users_with_home = list(target_win_users.user_details.all_with_home())
     assert len(users_with_home) == 1  # only John has a home dir
 
+    home_dirs = list(target_win_users.user_details.all_home_dirs)
+    assert len(home_dirs) == 1
+    assert home_dirs[0] == target_win_users.fs.path("C:/Users/John")
+
 
 def test_misc_users(target_win_users: Target, fs_win: VirtualFilesystem, tmp_path: Path) -> None:
-    fs_win.map_dir("windows/SysWOW64/config/systemprofile", tmp_path)
+    fs_win.map_dir("Windows/SysWOW64/config/systemprofile", tmp_path)
     users_with_home = list(target_win_users.user_details.all_with_home())
     assert len(users_with_home) == 1  # Misc home dir is found
+
+    home_dirs = list(target_win_users.user_details.all_home_dirs)
+    assert len(home_dirs) == 1  # Misc home dir is found
+    assert home_dirs[0] == target_win_users.fs.path("c:/Windows/SysWOW64/config/systemprofile")
 
 
 def test_users_plugin_find_no_params(target_unix_users: Target) -> None:

--- a/tests/plugins/general/test_users.py
+++ b/tests/plugins/general/test_users.py
@@ -35,7 +35,7 @@ def test_users_plugin(target_win_users: Target, fs_win: VirtualFilesystem, tmp_p
     users_with_home = list(target_win_users.user_details.all_with_home())
     assert len(users_with_home) == 1  # only John has a home dir
 
-    home_dirs = list(target_win_users.user_details.all_home_dirs)
+    home_dirs = list(target_win_users.user_details.all_home_paths)
     assert len(home_dirs) == 1
     assert home_dirs[0] == target_win_users.fs.path("C:/Users/John")
 
@@ -47,7 +47,7 @@ def test_misc_users(target_win_users: Target, fs_win: VirtualFilesystem, tmp_pat
     assert users_with_home[0].user.sid == "S-1-5-18"
     assert users_with_home[0].home_path == target_win_users.fs.path("c:/Windows/SysWOW64/config/systemprofile")
 
-    home_dirs = list(target_win_users.user_details.all_home_dirs)
+    home_dirs = list(target_win_users.user_details.all_home_paths)
     assert len(home_dirs) == 1  # Misc home dir is found
     assert home_dirs[0] == target_win_users.fs.path("c:/Windows/SysWOW64/config/systemprofile")
 

--- a/tests/plugins/os/windows/test__os.py
+++ b/tests/plugins/os/windows/test__os.py
@@ -263,7 +263,7 @@ def test_windows_user(target_win_users: Target) -> None:
 
     assert users[0].sid == "S-1-5-18"
     assert users[0].name == "systemprofile"
-    assert users[0].home == windows_path("%systemroot%\\system32\\config\\systemprofile")
+    assert users[0].home == windows_path("c:\\windows\\system32\\config\\systemprofile")
 
     assert users[1].sid == "S-1-5-21-3263113198-3007035898-945866154-1002"
     assert users[1].name == "John"


### PR DESCRIPTION
- Ensure `%windir%/SysWOW64/config/systemprofile` is acquired and discoverable by plugins.
- Move `misc_home_dirs` into target.
- Added a new function `all_home_dirs` to discover user directories without requiring user information 

