### PR TITLE
Add benchmark test for acquire tar

### DIFF
--- a/tests/loaders/test_acquire.py
+++ b/tests/loaders/test_acquire.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from dissect.target import Target
 from dissect.target.loaders.tar import TarLoader
+from dissect.target.target import Target
 from tests._utils import absolute_path
 
 if TYPE_CHECKING:

--- a/tests/loaders/test_acquire.py
+++ b/tests/loaders/test_acquire.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from dissect.target import Target
 from dissect.target.loaders.tar import TarLoader
 from tests._utils import absolute_path
 

--- a/tests/loaders/test_acquire.py
+++ b/tests/loaders/test_acquire.py
@@ -10,7 +10,7 @@ from tests._utils import absolute_path
 
 
 @pytest.mark.parametrize(
-    "archive,loader",
+    ("archive", "loader"),
     [
         ("_data/loaders/tar/test-windows-fs-c-relative.tar", TarLoader),
     ],

--- a/tests/loaders/test_acquire.py
+++ b/tests/loaders/test_acquire.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import pytest
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from dissect.target import Target
+from dissect.target.loader import Loader
+from dissect.target.loaders.tar import TarLoader
+from tests._utils import absolute_path
+
+
+@pytest.mark.parametrize(
+    "archive,loader",
+    [
+        ("_data/loaders/tar/test-windows-fs-c-relative.tar", TarLoader),
+    ],
+)
+@pytest.mark.benchmark
+def test_benchmark(benchmark: BenchmarkFixture, target_default: Target, archive: str, loader: Loader) -> None:
+    file = Path(absolute_path(archive))
+
+    benchmark(lambda: loader(file).map(target_default))

--- a/tests/loaders/test_acquire.py
+++ b/tests/loaders/test_acquire.py
@@ -10,7 +10,6 @@ from tests._utils import absolute_path
 if TYPE_CHECKING:
     from pytest_benchmark.fixture import BenchmarkFixture
 
-    from dissect.target import Target
     from dissect.target.loader import Loader
 
 
@@ -21,7 +20,7 @@ if TYPE_CHECKING:
     ],
 )
 @pytest.mark.benchmark
-def test_benchmark(benchmark: BenchmarkFixture, target_default: Target, archive: str, loader: type[Loader]) -> None:
+def test_benchmark(benchmark: BenchmarkFixture, archive: str, loader: type[Loader]) -> None:
     file = absolute_path(archive)
 
-    benchmark(lambda: loader(file).map(target_default))
+    benchmark(lambda: loader(file).map(Target()))

--- a/tests/loaders/test_acquire.py
+++ b/tests/loaders/test_acquire.py
@@ -1,12 +1,17 @@
-from pathlib import Path
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest_benchmark.fixture import BenchmarkFixture
 
-from dissect.target import Target
-from dissect.target.loader import Loader
 from dissect.target.loaders.tar import TarLoader
 from tests._utils import absolute_path
+
+if TYPE_CHECKING:
+    from pytest_benchmark.fixture import BenchmarkFixture
+
+    from dissect.target import Target
+    from dissect.target.loader import Loader
 
 
 @pytest.mark.parametrize(
@@ -16,7 +21,7 @@ from tests._utils import absolute_path
     ],
 )
 @pytest.mark.benchmark
-def test_benchmark(benchmark: BenchmarkFixture, target_default: Target, archive: str, loader: Loader) -> None:
-    file = Path(absolute_path(archive))
+def test_benchmark(benchmark: BenchmarkFixture, target_default: Target, archive: str, loader: type[Loader]) -> None:
+    file = absolute_path(archive)
 
     benchmark(lambda: loader(file).map(target_default))


### PR DESCRIPTION
This PR adds the benchmark test for Acquire tar files, as included in #935. This allows us to compare the performance of #935 by first merging this PR.  