### PR TITLE
Fix UnixUserRecord shell field type from string to path. #900

### DIFF
--- a/dissect/target/helpers/record.py
+++ b/dissect/target/helpers/record.py
@@ -137,7 +137,7 @@ COMMON_UNIX_FIELDS = [
     ("varint", "gid"),
     ("string", "gecos"),
     ("path", "home"),
-    ("string", "shell"),
+    ("path", "shell"),
     ("string", "source"),
 ]
 

--- a/tests/helpers/test_record.py
+++ b/tests/helpers/test_record.py
@@ -114,6 +114,10 @@ def test_trd_call_with_default_fields() -> None:
     assert record.domain == "some.domain"
     assert record._source == "/some/path"
 
+def test_trd_unix_shell_type() -> None:
+    shell_fields = [field for field in UnixUserRecord.get_field_tuples() if field[1] == "shell"]
+    assert shell_fields, "UnixUserRecord should have a 'shell' field"
+    assert all(field[0] == "path" for field in shell_fields), "All 'shell' fields in UnixUserRecord should have type 'path'"
 
 def test_trd_call_no_target() -> None:
     record = TestRecord(


### PR DESCRIPTION
Made sure to change the field type of shell in UnixUserRecord from string to path. I also added a unit test, with a sanity check to make sure that the operation goes correctly as stated.

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
