### PR TITLE
Prevent OS modules of being hidden during docs-build

### DIFF
--- a/tests/_docs/conf.py
+++ b/tests/_docs/conf.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from sphinx.application import Sphinx
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
 
 project = "dissect.target"
 


### PR DESCRIPTION
- **Stop skipping OS modules during docs-build**
- **Add docstring to `ConfigNode` and `FortiOSConfig`**

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
