### PR TITLE
Fix VirtualFilesystem directory member overwrites

### DIFF
--- a/dissect/target/filesystem.py
+++ b/dissect/target/filesystem.py
@@ -1018,7 +1018,7 @@ class VirtualDirectory(FilesystemEntry):
         raise TypeError(f"lattr is not allowed on VirtualDirectory: {self.path}")
 
     def add(self, name: str, entry: FilesystemEntry) -> None:
-        """Add an entry to this :class:`VirtualDirectory`."""
+        """Add an entry to this :class:`VirtualDirectory`. Overrides already existing entries with ``name``."""
         if not self.fs.case_sensitive:
             name = name.lower()
 

--- a/dissect/target/filesystem.py
+++ b/dissect/target/filesystem.py
@@ -1017,10 +1017,24 @@ class VirtualDirectory(FilesystemEntry):
     def lattr(self) -> Any:
         raise TypeError(f"lattr is not allowed on VirtualDirectory: {self.path}")
 
-    def add(self, name: str, entry: FilesystemEntry) -> None:
-        """Add an entry to this :class:`VirtualDirectory`. Overrides already existing entries with ``name``."""
+    def add(self, name: str, entry: FilesystemEntry, clobber: bool = False) -> None:
+        """Add an entry to this :class:`VirtualDirectory`.
+
+        Only overrides already existing entries with ``name`` if argument ``clobber`` is set to ``True``.
+
+        Args:
+            name: Name of the entry in this directory
+            entry: FilesystemEntry to add to this directory
+            clobber: Allow overwrites (default: False)
+
+        Raises:
+            KeyError if ``name`` already exists in this directory and ``clobber`` is ``False``
+        """
         if not self.fs.case_sensitive:
             name = name.lower()
+
+        if not clobber and name in self.entries:
+            raise KeyError(f"Entry {name!r} already exists in {self!r}")
 
         self.entries[name] = entry
 
@@ -1307,7 +1321,7 @@ class VirtualFilesystem(Filesystem):
 
     mount = map_fs
 
-    def map_dir(self, vfspath: str, realpath: pathlib.Path | str) -> None:
+    def map_dir(self, vfspath: str, realpath: pathlib.Path | str, *, clobber: bool = False) -> None:
         """Recursively map a directory from the host machine into the VFS."""
         if not isinstance(realpath, pathlib.Path):
             realpath = pathlib.Path(realpath)
@@ -1337,9 +1351,11 @@ class VirtualFilesystem(Filesystem):
             for file_ in files:
                 vfs_file_path = fsutil.join(vfsroot, file_, sep=self.sep)
                 real_file_path = root.joinpath(file_)
-                directory.add(file_, MappedFile(self, vfs_file_path, str(real_file_path)))
+                directory.add(file_, MappedFile(self, vfs_file_path, str(real_file_path)), clobber=clobber)
 
-    def map_file(self, vfspath: str, realpath: str | pathlib.Path, compression: str | None = None) -> None:
+    def map_file(
+        self, vfspath: str, realpath: str | pathlib.Path, *, compression: str | None = None, clobber: bool = False
+    ) -> None:
         """Map a file from the host machine into the VFS."""
         realpath = str(realpath)
         vfspath = fsutil.normalize(vfspath, sep=self.sep)
@@ -1347,14 +1363,14 @@ class VirtualFilesystem(Filesystem):
             mapped_file = MappedCompressedFile(self, vfspath.lstrip("/"), realpath, algo=compression)
         else:
             mapped_file = MappedFile(self, vfspath.lstrip("/"), realpath)
-        self.map_file_entry(vfspath, mapped_file)
+        self.map_file_entry(vfspath, mapped_file, clobber=clobber)
 
-    def map_file_fh(self, vfspath: str, fh: BinaryIO) -> None:
+    def map_file_fh(self, vfspath: str, fh: BinaryIO, *, clobber: bool = False) -> None:
         """Map a file handle into the VFS."""
         vfspath = fsutil.normalize(vfspath, sep=self.sep)
-        self.map_file_entry(vfspath, VirtualFile(self, vfspath.lstrip("/"), fh))
+        self.map_file_entry(vfspath, VirtualFile(self, vfspath.lstrip("/"), fh), clobber=clobber)
 
-    def map_file_entry(self, vfspath: str, entry: FilesystemEntry) -> None:
+    def map_file_entry(self, vfspath: str, entry: FilesystemEntry, *, clobber: bool = False) -> None:
         """Map a :class:`FilesystemEntry` into the VFS.
 
         Any missing subdirectories up to, but not including, the last part of
@@ -1371,9 +1387,11 @@ class VirtualFilesystem(Filesystem):
                 directory = self.root
 
             entry_name = fsutil.basename(vfspath, sep=self.sep)
-            directory.add(entry_name, entry)
+            directory.add(entry_name, entry, clobber=clobber)
 
-    def map_dir_from_tar(self, vfspath: str, tar_file: str | pathlib.Path, map_single_file: bool = False) -> None:
+    def map_dir_from_tar(
+        self, vfspath: str, tar_file: str | pathlib.Path, *, map_single_file: bool = False, clobber: bool = False
+    ) -> None:
         """Map files in a tar onto the VFS.
 
         Args:
@@ -1394,12 +1412,12 @@ class VirtualFilesystem(Filesystem):
             # We map the first file we find in the tar to the provided vfspath.
             for file in [f[0] for _, _, f in tfs.walk_ext("/") if f]:
                 file.name = fsutil.basename(vfspath)
-                self.map_file_entry(vfspath, file)
+                self.map_file_entry(vfspath, file, clobber=clobber)
                 return
         else:
             self.mount(vfspath, tfs)
 
-    def map_file_from_tar(self, vfspath: str, tar_file: str | pathlib.Path) -> None:
+    def map_file_from_tar(self, vfspath: str, tar_file: str | pathlib.Path, *, clobber: bool = False) -> None:
         """Map a single file in a tar archive to the given path in the VFS.
 
         The provided tar archive should contain *one* file.
@@ -1408,7 +1426,7 @@ class VirtualFilesystem(Filesystem):
             vfspath: Destination path in the virtual filesystem.
             tar_file: Source path of the tar file to map.
         """
-        return self.map_dir_from_tar(vfspath.lstrip("/"), tar_file, map_single_file=True)
+        return self.map_dir_from_tar(vfspath.lstrip("/"), tar_file, map_single_file=True, clobber=clobber)
 
     def link(self, src: str, dst: str) -> None:
         """Hard link a :class:`FilesystemEntry` to another location.

--- a/dissect/target/filesystems/tar.py
+++ b/dissect/target/filesystems/tar.py
@@ -68,6 +68,15 @@ class TarFilesystem(Filesystem):
 
             entry_cls = TarFilesystemDirectoryEntry if member.isdir() else TarFilesystemEntry
             file_entry = entry_cls(self, rel_name, member)
+
+            # Prevent overriding an already created folder with an empty member dir entry.
+            try:
+                if member.isdir() and self._fs.get(file_entry.path).is_dir():
+                    log.debug("Skipping directory member %r in tar as %r is already mapped", member, file_entry.path)
+                    continue
+            except (FileNotFoundError, NotADirectoryError):
+                pass
+
             self._fs.map_file_entry(rel_name, file_entry)
 
     @staticmethod

--- a/dissect/target/filesystems/tar.py
+++ b/dissect/target/filesystems/tar.py
@@ -69,15 +69,10 @@ class TarFilesystem(Filesystem):
             entry_cls = TarFilesystemDirectoryEntry if member.isdir() else TarFilesystemEntry
             file_entry = entry_cls(self, rel_name, member)
 
-            # Prevent overriding an already created folder with an empty member dir entry.
             try:
-                if member.isdir() and self._fs.get(file_entry.path).is_dir():
-                    log.debug("Skipping directory member %r in tar as %r is already mapped", member, file_entry.path)
-                    continue
-            except (FileNotFoundError, NotADirectoryError):
-                pass
-
-            self._fs.map_file_entry(rel_name, file_entry)
+                self._fs.map_file_entry(rel_name, file_entry)
+            except KeyError as e:
+                log.debug("Skipping directory member %r in tar as %r is already mapped: %s", member, file_entry.path, e)
 
     @staticmethod
     def _detect(fh: BinaryIO) -> bool:

--- a/dissect/target/filesystems/zip.py
+++ b/dissect/target/filesystems/zip.py
@@ -64,7 +64,10 @@ class ZipFilesystem(Filesystem):
                 continue
 
             rel_name = self._resolve_path(member.filename).strip("/")
-            self._fs.map_file_entry(rel_name, ZipFilesystemEntry(self, rel_name, member))
+            try:
+                self._fs.map_file_entry(rel_name, ZipFilesystemEntry(self, rel_name, member))
+            except KeyError as e:
+                log.debug("Skipping directory member %r in zip as %r is already mapped: %s", member, rel_name, e)
 
     @staticmethod
     def _detect(fh: BinaryIO) -> bool:

--- a/dissect/target/loaders/direct.py
+++ b/dissect/target/loaders/direct.py
@@ -41,9 +41,9 @@ class DirectLoader(Loader):
         vfs = VirtualFilesystem(case_sensitive=self.case_sensitive)
         for path in self.paths:
             if path.is_file():
-                vfs.map_file(str(path), path)
+                vfs.map_file(str(path), path, clobber=True)
             elif path.is_dir():
-                vfs.map_dir(str(path), path)
+                vfs.map_dir(str(path), path, clobber=True)
 
         target.filesystems.add(vfs)
         target._os_plugin = DefaultOSPlugin

--- a/dissect/target/loaders/tar.py
+++ b/dissect/target/loaders/tar.py
@@ -117,15 +117,10 @@ class GenericTarSubLoader(TarSubLoader):
             entry_cls = TarFilesystemDirectoryEntry if member.isdir() else TarFilesystemEntry
             entry = entry_cls(volume, fsutil.normpath(mname), member)
 
-            # Prevent overriding an already created folder with an empty member dir entry.
             try:
-                if member.isdir() and volume.get(entry.path).is_dir():
-                    log.debug("Skipping directory member %r in tar as %r is already mapped", member, entry.path)
-                    continue
-            except (FileNotFoundError, NotADirectoryError):
-                pass
-
-            volume.map_file_entry(entry.path, entry)
+                volume.map_file_entry(entry.path, entry)
+            except KeyError as e:
+                log.debug("Skipping directory member %r in tar as %r is already mapped: %s", member, entry.path, e)
 
         for vol_name, vol in volumes.items():
             loaderutil.add_virtual_ntfs_filesystem(

--- a/dissect/target/loaders/tar.py
+++ b/dissect/target/loaders/tar.py
@@ -116,6 +116,15 @@ class GenericTarSubLoader(TarSubLoader):
 
             entry_cls = TarFilesystemDirectoryEntry if member.isdir() else TarFilesystemEntry
             entry = entry_cls(volume, fsutil.normpath(mname), member)
+
+            # Prevent overriding an already created folder with an empty member dir entry.
+            try:
+                if member.isdir() and volume.get(entry.path).is_dir():
+                    log.debug("Skipping directory member %r in tar as %r is already mapped", member, entry.path)
+                    continue
+            except (FileNotFoundError, NotADirectoryError):
+                pass
+
             volume.map_file_entry(entry.path, entry)
 
         for vol_name, vol in volumes.items():

--- a/tests/_data/loaders/tar/test-dir.tar
+++ b/tests/_data/loaders/tar/test-dir.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7afd27f5300feb91359526bace8b8e49fc7331fcf16419779e59f2fec26a23ba
+size 10240

--- a/tests/filesystems/test_tar.py
+++ b/tests/filesystems/test_tar.py
@@ -265,3 +265,21 @@ def test_benchmark_tar_filesystem(
         list(fs.get("LARGE").scandir())
 
     benchmark(benchy)
+
+
+def test_skip_folder_member_if_previously_mapped() -> None:
+    """Test if we skip a directory tar member if the path of said directory is already mapped."""
+    buf = io.BytesIO()
+    tf = tarfile.TarFile(fileobj=buf, mode="w")
+    _mkfile(tf, "folder/file", b"file contents")  # Write the file member first
+    _mkdir(tf, "folder")  # Then write the 'empty' directory member
+    tf.close()
+    buf.seek(0)
+
+    fs = TarFilesystem(buf)
+
+    # Sanity check
+    assert list(fs.get("/").iterdir()) == ["folder"]
+
+    # Make sure the /folder/file entry is mapped.
+    assert list(fs.get("/folder").iterdir()) == ["file"]

--- a/tests/filesystems/test_tar.py
+++ b/tests/filesystems/test_tar.py
@@ -275,7 +275,22 @@ def test_skip_folder_member_if_previously_mapped() -> None:
     _mkdir(tf, "folder")  # Then write the 'empty' directory member
     tf.close()
     buf.seek(0)
+    fs = TarFilesystem(buf)
 
+    # Sanity check
+    assert list(fs.get("/").iterdir()) == ["folder"]
+
+    # Make sure the /folder/file entry is mapped.
+    assert list(fs.get("/folder").iterdir()) == ["file"]
+
+    # Now the other way around, folder is created first and then folder/file
+
+    buf = io.BytesIO()
+    tf = tarfile.TarFile(fileobj=buf, mode="w")
+    _mkdir(tf, "folder")  # Write the empty folder first
+    _mkfile(tf, "folder/file", b"file contents")  # Then write the file member
+    tf.close()
+    buf.seek(0)
     fs = TarFilesystem(buf)
 
     # Sanity check

--- a/tests/filesystems/test_zip.py
+++ b/tests/filesystems/test_zip.py
@@ -250,3 +250,21 @@ def test_benchmark_zip_filesystem(
         list(fs.get("LARGE").scandir())
 
     benchmark(benchy)
+
+
+def test_skip_folder_member_if_previously_mapped() -> None:
+    """Test if we skip a directory zip member if the path of said directory is already mapped."""
+    buf = io.BytesIO()
+    zf = zipfile.ZipFile(file=buf, mode="w")
+    zf.writestr("folder/file", b"file contents")  # write the file member first
+    _mkdir(zf, "folder")  # then write the 'empty' dir member
+    zf.close()
+    buf.seek(0)
+    fs = ZipFilesystem(buf)
+
+    # Sanity check
+    assert list(fs.get("/").iterdir()) == ["folder"]
+
+    # Make sure the /folder/file entry is mapped.
+    assert list(fs.get("/folder").iterdir()) == ["file"]
+    assert fs.get("/folder/file").open().read() == b"file contents"

--- a/tests/loaders/test_tar.py
+++ b/tests/loaders/test_tar.py
@@ -168,3 +168,15 @@ def test_detect_buffer(file: str, tmp_path: Path) -> None:
     tmp_tar.write_bytes(small_file.read_bytes())
 
     assert TarLoader.detect(tmp_tar)
+
+
+def test_skip_folder_member_if_previously_mapped() -> None:
+    """Test if we skip a directory tar member if the path of said directory is already mapped."""
+
+    path = absolute_path("_data/loaders/tar/test-dir.tar")
+    loader = loader_open(path)
+    target = Target()
+    loader.map(target)
+
+    assert list(target.fs.get("/").iterdir()) == ["folder"]
+    assert list(target.fs.get("/folder").iterdir()) == ["file"]

--- a/tests/loaders/test_tar.py
+++ b/tests/loaders/test_tar.py
@@ -172,7 +172,6 @@ def test_detect_buffer(file: str, tmp_path: Path) -> None:
 
 def test_skip_folder_member_if_previously_mapped() -> None:
     """Test if we skip a directory tar member if the path of said directory is already mapped."""
-
     path = absolute_path("_data/loaders/tar/test-dir.tar")
     loader = loader_open(path)
     target = Target()

--- a/tests/plugins/apps/browser/test_edge.py
+++ b/tests/plugins/apps/browser/test_edge.py
@@ -127,10 +127,12 @@ def test_unix_edge_passwords_basic_plugin(target_edge_unix: Target, fs_unix: Vir
     fs_unix.map_file(
         "/root/.config/microsoft-edge/Default/Login Data",
         absolute_path("_data/plugins/apps/browser/chromium/unix/basic/Login Data"),
+        clobber=True,
     )
     fs_unix.map_file(
         "/root/.config/microsoft-edge/Profile 1/Login Data",
         absolute_path("_data/plugins/apps/browser/chromium/unix/basic/Login Data"),
+        clobber=True,
     )
 
     records = list(target_edge_unix.edge.passwords())
@@ -150,10 +152,12 @@ def test_unix_edge_passwords_gnome_plugin(target_edge_unix: Target, fs_unix: Vir
     fs_unix.map_file(
         "/root/.config/microsoft-edge/Default/Login Data",
         absolute_path("_data/plugins/apps/browser/chromium/unix/gnome/Login Data"),
+        clobber=True,
     )
     fs_unix.map_file(
         "/root/.config/microsoft-edge/Profile 1/Login Data",
         absolute_path("_data/plugins/apps/browser/chromium/unix/gnome/Login Data"),
+        clobber=True,
     )
 
     records = list(target_edge_unix.edge.passwords())

--- a/tests/plugins/apps/webserver/test_caddy.py
+++ b/tests/plugins/apps/webserver/test_caddy.py
@@ -62,7 +62,6 @@ def test_caddy_config(target_unix: Target, fs_unix: VirtualFilesystem) -> None:
     config_file = absolute_path("_data/plugins/apps/webserver/caddy/Caddyfile")
     fs_unix.map_file("etc/caddy/Caddyfile", config_file)
 
-    fs_unix.map_file("etc/caddy/Caddyfile", config_file)
     fs_unix.map_file_fh("var/www/log/access.log", BytesIO(b"Foo"))
     fs_unix.map_file_fh("var/log/caddy/access.log", BytesIO(b"Foo"))
 

--- a/tests/plugins/os/unix/test_users.py
+++ b/tests/plugins/os/unix/test_users.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 def test_unix_passwd_file(target_unix_users: Target, fs_unix: VirtualFilesystem) -> None:
     passwd_file = absolute_path("_data/plugins/os/unix/_os/passwd")
-    fs_unix.map_file("/etc/passwd", passwd_file)
+    fs_unix.map_file("/etc/passwd", passwd_file, clobber=True)
     target_unix_users.add_plugin(UnixPlugin)
 
     results = list(target_unix_users.users())
@@ -30,7 +30,7 @@ def test_unix_passwd_file(target_unix_users: Target, fs_unix: VirtualFilesystem)
 def test_unix_passwd_syslog(target_unix_users: Target, fs_unix: VirtualFilesystem) -> None:
     syslog_file = absolute_path("_data/plugins/os/unix/_os/passwd-syslog")
     fs_unix.map_file("/var/log/syslog", syslog_file)
-    fs_unix.map_file_fh("/etc/passwd", BytesIO())
+    fs_unix.map_file_fh("/etc/passwd", BytesIO(), clobber=True)
     target_unix_users.add_plugin(UnixPlugin)
 
     results = list(target_unix_users.users(sessions=True))

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1335,3 +1335,24 @@ def test_filesystem_identifier_string_when_no_guid_or_name() -> None:
     fs.volume.name = None
 
     assert fs.identifier == repr(fs)
+
+
+def test_filesystem_clobber_behavior(tmp_path: Path) -> None:
+    """Test if we skip a direntry if the path of said direntry is already mapped."""
+    fs = VirtualFilesystem()
+    fs.map_file_fh("folder/file", BytesIO(b"file contents"))
+
+    fs.makedirs("folder")
+    assert fs.exists("folder/file")
+
+    tmp_path.joinpath("file").write_bytes(b"tmp duplicate")
+    with pytest.raises(KeyError, match="Entry 'file' already exists in <VirtualDirectory 'folder'>"):
+        fs.map_dir("folder", tmp_path)
+
+    with pytest.raises(KeyError, match="Entry 'file' already exists in <VirtualDirectory 'folder'>"):
+        fs.map_file_fh("folder/file", BytesIO(b"duplicate file"))
+
+    assert fs.path("folder/file").read_text() == "file contents"
+
+    fs.map_file_fh("folder/file", BytesIO(b"duplicate file"), clobber=True)
+    assert fs.path("folder/file").read_text() == "duplicate file"

--- a/tests/tools/test_reg.py
+++ b/tests/tools/test_reg.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 def target_win_reg(target_win: Target, fs_win: VirtualFilesystem) -> Target:
-    fs_win.map_file("Windows/System32/config/SYSTEM", absolute_path("_data/tools/reg/SYSTEM.gz"), "gzip")
+    fs_win.map_file("Windows/System32/config/SYSTEM", absolute_path("_data/tools/reg/SYSTEM.gz"), compression="gzip")
     target_win.apply()
     target_win.add_plugin(RegistryPlugin)
     return target_win


### PR DESCRIPTION
This PR fixes an issue in VirtualFilesystem and consequently in the tar and zip implementations (`GenericTarSubLoader`, `TarFilesystem`, `ZipFilesystem`) of dissect. When an archive file has an out-of-order member definition of a directory, the previous path is erroneously overwritten, discarding any children of that member in the process.

Steps to reproduce:
```
$ tar -tf tests/_data/loaders/tar/test-dir.tar 
folder/file
folder/

$ target-shell tests/_data/loaders/tar/test-dir.tar
test-dir.tar:/$ stat folder/file
/folder/file: No such file or directory
```

The core issue lies in the `VirtualDirectory.add()` method.