### PR TITLE
Used volume SERIAL as UUID when it didnt exist

### DIFF
--- a/dissect/target/plugins/filesystem/ntfs/utils.py
+++ b/dissect/target/plugins/filesystem/ntfs/utils.py
@@ -62,7 +62,7 @@ def get_drive_letter(target: Target, filesystem: NtfsFilesystem) -> str:
 def get_volume_identifier(fs: NtfsFilesystem) -> str | None:
     """Return the filesystem GUID if available."""
     try:
-        return f"{UUID(bytes_le=fs.volume.guid)}"
+        return f"{UUID(bytes_le=fs.volume.guid) if fs.volume.guid else UUID(int=fs.ntfs.serial)}"
     except (AttributeError, TypeError, ValueError):
         # AttributeError is raised when volume is None
         # TypeError is raised when guid is None

--- a/dissect/target/plugins/filesystem/ntfs/utils.py
+++ b/dissect/target/plugins/filesystem/ntfs/utils.py
@@ -60,9 +60,13 @@ def get_drive_letter(target: Target, filesystem: NtfsFilesystem) -> str:
 
 
 def get_volume_identifier(fs: NtfsFilesystem) -> str | None:
-    """Return the filesystem GUID if available, otherwise the filesystem serial as a UUID."""
+    """Return the filesystem GUID if available, otherwise the filesystem serial"""
     try:
-        return f"{UUID(bytes_le=fs.volume.guid) if fs.volume.guid else UUID(int=fs.ntfs.serial)}"
+        if fs.volume.guid:
+            return str(UUID(bytes_le=fs.volume.guid))
+        elif fs.ntfs.serial:
+            return str(fs.ntfs.serial)
+        return None
     except (AttributeError, TypeError, ValueError):
         # AttributeError is raised when volume is None
         # TypeError is raised when guid is None

--- a/dissect/target/plugins/filesystem/ntfs/utils.py
+++ b/dissect/target/plugins/filesystem/ntfs/utils.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import logging
 import re
 from enum import Enum, auto
 from typing import TYPE_CHECKING
-from uuid import UUID
 
 from dissect.ntfs.exceptions import FileNotFoundError
 
@@ -13,7 +11,7 @@ if TYPE_CHECKING:
 
     from dissect.target.filesystems.ntfs import NtfsFilesystem
     from dissect.target.target import Target
-log = logging.getLogger(__name__)
+
 DRIVE_LETTER_RE = re.compile(r"[a-zA-Z]:")
 
 
@@ -63,16 +61,13 @@ def get_drive_letter(target: Target, filesystem: NtfsFilesystem) -> str:
 def get_volume_identifier(fs: NtfsFilesystem) -> str | None:
     """Return the filesystem GUID or serial, if available."""
 
-    try:
-        if fs.volume.guid:
-            return str(UUID(bytes_le=fs.volume.guid))
-        if fs.ntfs.serial:
-            return str(fs.ntfs.serial)
-    except (AttributeError, ValueError) as e:
-        # AttributeError is raised when volume is None
-        # ValueError is raised when the guid string is smaller than 16 bytes
-        log.exception("Error parsing Volume UUID")
-        log.debug("", exc_info=e)
+    if fs.volume and (guid := getattr(fs.volume, "guid", None)):
+        return guid
+
+    # Fallback to NTFS serial if volume GUID is not available
+    if fs.ntfs.serial:
+        return str(fs.ntfs.serial)
+
     return None
 
 

--- a/dissect/target/plugins/filesystem/ntfs/utils.py
+++ b/dissect/target/plugins/filesystem/ntfs/utils.py
@@ -64,7 +64,7 @@ def get_volume_identifier(fs: NtfsFilesystem) -> str | None:
     try:
         if fs.volume.guid:
             return str(UUID(bytes_le=fs.volume.guid))
-        elif fs.ntfs.serial:
+        if fs.ntfs.serial:
             return str(fs.ntfs.serial)
         return None
     except (AttributeError, TypeError, ValueError):

--- a/dissect/target/plugins/filesystem/ntfs/utils.py
+++ b/dissect/target/plugins/filesystem/ntfs/utils.py
@@ -60,7 +60,7 @@ def get_drive_letter(target: Target, filesystem: NtfsFilesystem) -> str:
 
 
 def get_volume_identifier(fs: NtfsFilesystem) -> str | None:
-    """Return the filesystem GUID if available, otherwise the filesystem serial"""
+    """Return the filesystem GUID or serial, if available."""
     try:
         if fs.volume.guid:
             return str(UUID(bytes_le=fs.volume.guid))

--- a/dissect/target/plugins/filesystem/ntfs/utils.py
+++ b/dissect/target/plugins/filesystem/ntfs/utils.py
@@ -60,7 +60,7 @@ def get_drive_letter(target: Target, filesystem: NtfsFilesystem) -> str:
 
 
 def get_volume_identifier(fs: NtfsFilesystem) -> str | None:
-    """Return the filesystem GUID if available."""
+    """Return the filesystem GUID if available, otherwise the filesystem serial as a UUID."""
     try:
         return f"{UUID(bytes_le=fs.volume.guid) if fs.volume.guid else UUID(int=fs.ntfs.serial)}"
     except (AttributeError, TypeError, ValueError):

--- a/dissect/target/plugins/os/windows/_os.py
+++ b/dissect/target/plugins/os/windows/_os.py
@@ -4,6 +4,7 @@ import operator
 import struct
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
+from uuid import UUID
 
 from dissect.target.exceptions import RegistryError, RegistryValueNotFoundError
 from dissect.target.helpers.record import WindowsUserRecord
@@ -76,7 +77,7 @@ class WindowsPlugin(OSPlugin):
                         drive = p[1]
 
                         if value.startswith(b"DMIO:ID:"):
-                            guid = value[8:]
+                            guid = str(UUID(bytes_le=value[8:]))
 
                             for volume in self.target.volumes:
                                 if volume.guid == guid and volume.fs:

--- a/dissect/target/volumes/disk.py
+++ b/dissect/target/volumes/disk.py
@@ -36,7 +36,7 @@ class DissectVolumeSystem(VolumeSystem):
                 v.size,
                 v.type,
                 name,
-                guid=v.guid,
+                guid=str(v.guid) if v.guid else None,
                 raw=v,
                 disk=self.disk,
                 vs=self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "dissect.regf>=3.13,<4",
     "dissect.sql>=3.12,<4",
     "dissect.util>=3,<4",
-    "dissect.volume>=2,<4",
+    "dissect.volume>=3.17.dev1,<4",  # TODO: update on release!
     "flow.record~=3.20.0",
     "structlog",
 ]
@@ -99,7 +99,7 @@ dev = [
     "dissect.thumbcache[dev]>=1.0.dev,<2.0.dev",
     "dissect.util>=3.0.dev,<4.0.dev",
     "dissect.vmfs[dev]>=3.12.dev,<4.0.dev",
-    "dissect.volume[dev]>=3.0.dev,<4.0.dev",
+    "dissect.volume[dev]>=3.17.dev,<4.0.dev",  # TODO: update on release!
     "dissect.xfs[dev]>=3.0.dev,<4.0.dev",
 ]
 yara = [

--- a/tests/plugins/filesystem/ntfs/test_mft.py
+++ b/tests/plugins/filesystem/ntfs/test_mft.py
@@ -108,26 +108,29 @@ def test_get_owner_and_group_none_attr() -> None:
 
 
 @pytest.mark.parametrize(
-    ("guid_bytes", "ntfs_serial", "expected_result"),
+    ("guid", "serial", "expected_result"),
     [
-        (b",\xa6\xc1}\x88\xc4\xc5G\x8e\xab\t$\x0f8\x89N", 0x9E0C158A4CE55327, "7dc1a62c-c488-47c5-8eab-09240f38894e"),
+        ("7dc1a62c-c488-47c5-8eab-09240f38894e", 0x9E0C158A4CE55327, "7dc1a62c-c488-47c5-8eab-09240f38894e"),
         (None, 0x2B4A7D188A9163F2, "3119443236264961010"),
-        (b"", None, None),
+        ("", None, None),
         (None, None, None),
     ],
 )
-def test_volume_identifier(guid_bytes: bytes, ntfs_serial: int, expected_result: str | None | int) -> None:
+def test_volume_identifier(guid: str, serial: int, expected_result: str | None | int) -> None:
     filesystem = Mock()
-    filesystem.ntfs.serial = ntfs_serial
-    filesystem.volume.guid = guid_bytes
+    filesystem.ntfs.serial = serial
+    filesystem.volume.guid = guid
     assert get_volume_identifier(filesystem) == expected_result
 
 
 def test_volume_identifier_no_volume() -> None:
     filesystem = Mock()
     filesystem.volume = None
-    filesystem.ntfs = None
+    filesystem.ntfs.serial = None
     assert get_volume_identifier(filesystem) is None
+
+    filesystem.ntfs.serial = 0x2B4A7D188A9163F2
+    assert get_volume_identifier(filesystem) == "3119443236264961010"
 
 
 def test_volume_identifier_none_guid() -> None:

--- a/tests/plugins/filesystem/ntfs/test_mft.py
+++ b/tests/plugins/filesystem/ntfs/test_mft.py
@@ -111,7 +111,7 @@ def test_get_owner_and_group_none_attr() -> None:
     ("guid_bytes","ntfs_serial", "expected_result"),
     [
         (b",\xa6\xc1}\x88\xc4\xc5G\x8e\xab\t$\x0f8\x89N", 0x9e0c158a4ce55327 , "7dc1a62c-c488-47c5-8eab-09240f38894e"),
-        (None, 0x2b4a7d188a9163f2 , "00000000-0000-0000-2b4a-7d188a9163f2"),
+        (None, 0x2b4a7d188a9163f2 , "3119443236264961010"),
         (b"", None , None),
         (None, None, None),
     ],

--- a/tests/plugins/filesystem/ntfs/test_mft.py
+++ b/tests/plugins/filesystem/ntfs/test_mft.py
@@ -108,11 +108,11 @@ def test_get_owner_and_group_none_attr() -> None:
 
 
 @pytest.mark.parametrize(
-    ("guid_bytes","ntfs_serial", "expected_result"),
+    ("guid_bytes", "ntfs_serial", "expected_result"),
     [
-        (b",\xa6\xc1}\x88\xc4\xc5G\x8e\xab\t$\x0f8\x89N", 0x9e0c158a4ce55327 , "7dc1a62c-c488-47c5-8eab-09240f38894e"),
-        (None, 0x2b4a7d188a9163f2 , "3119443236264961010"),
-        (b"", None , None),
+        (b",\xa6\xc1}\x88\xc4\xc5G\x8e\xab\t$\x0f8\x89N", 0x9E0C158A4CE55327, "7dc1a62c-c488-47c5-8eab-09240f38894e"),
+        (None, 0x2B4A7D188A9163F2, "3119443236264961010"),
+        (b"", None, None),
         (None, None, None),
     ],
 )

--- a/tests/plugins/filesystem/ntfs/test_mft.py
+++ b/tests/plugins/filesystem/ntfs/test_mft.py
@@ -108,15 +108,17 @@ def test_get_owner_and_group_none_attr() -> None:
 
 
 @pytest.mark.parametrize(
-    ("guid_bytes", "expected_result"),
+    ("guid_bytes","ntfs_serial", "expected_result"),
     [
-        (b",\xa6\xc1}\x88\xc4\xc5G\x8e\xab\t$\x0f8\x89N", "7dc1a62c-c488-47c5-8eab-09240f38894e"),
-        (b"", None),
-        (None, None),
+        (b",\xa6\xc1}\x88\xc4\xc5G\x8e\xab\t$\x0f8\x89N", 0x9e0c158a4ce55327 , "7dc1a62c-c488-47c5-8eab-09240f38894e"),
+        (None, 0x2b4a7d188a9163f2 , "00000000-0000-0000-2b4a-7d188a9163f2"),
+        (b"", None , None),
+        (None, None, None),
     ],
 )
-def test_volume_identifier(guid_bytes: bytes, expected_result: str | None) -> None:
+def test_volume_identifier(guid_bytes: bytes, ntfs_serial: int, expected_result: str | None | int) -> None:
     filesystem = Mock()
+    filesystem.ntfs.serial = ntfs_serial
     filesystem.volume.guid = guid_bytes
     assert get_volume_identifier(filesystem) == expected_result
 
@@ -124,12 +126,14 @@ def test_volume_identifier(guid_bytes: bytes, expected_result: str | None) -> No
 def test_volume_identifier_no_volume() -> None:
     filesystem = Mock()
     filesystem.volume = None
+    filesystem.ntfs = None
     assert get_volume_identifier(filesystem) is None
 
 
 def test_volume_identifier_none_guid() -> None:
     filesystem = Mock()
     filesystem.volume.guid = None
+    filesystem.ntfs.serial = None
     assert get_volume_identifier(filesystem) is None
 
 


### PR DESCRIPTION
By converting an NTFS volume's serial number (from $boot) to a UUID, you can obtain a UUID even when utilizing the **Master Boot Record (MBR)**. Although the resulting identifier is less unique than a native GUID Partition Table (GPT) UUID, it remains sufficiently unique for the majority of practical applications and use cases.