### PR TITLE
Make syslog parsing optional

### DIFF
--- a/dissect/target/plugins/os/default/network.py
+++ b/dissect/target/plugins/os/default/network.py
@@ -32,7 +32,7 @@ class NetworkPlugin(Plugin):
     def check_compatible(self) -> None:
         pass
 
-    def _interfaces(self) -> Iterator[InterfaceRecord]:
+    def _interfaces(self, *args, **kwargs) -> Iterator[InterfaceRecord]:
         yield from ()
 
     def _get_record_type(self, field_name: str, func: Callable[[Any], Any] | None = None) -> Iterator[Any]:
@@ -46,11 +46,11 @@ class NetworkPlugin(Plugin):
             yield from (map(func, output) if func else output)
 
     @export(record=get_args(InterfaceRecord))
-    def interfaces(self) -> Iterator[InterfaceRecord]:
+    def interfaces(self, *args, **kwargs) -> Iterator[InterfaceRecord]:
         """Yield interfaces."""
         # Only search for the interfaces once
         if self._interface_list is None:
-            self._interface_list = list(self._interfaces())
+            self._interface_list = list(self._interfaces(*args, **kwargs))
 
         yield from self._interface_list
 

--- a/dissect/target/plugins/os/unix/linux/network.py
+++ b/dissect/target/plugins/os/unix/linux/network.py
@@ -721,7 +721,7 @@ def parse_network_manager_centos_dhcp_lease(log_record: LogRecord) -> DhcpLease 
 def parse_debian_centos_dhclient_lease(log_record: LogRecord) -> DhcpLease | None:
     """Parse DHCP lease information from dhclient bound log lines."""
 
-    if not (hasattr(log_record, "service") and log_record.service == "dhclient"):
+    if getattr(log_record, "service", None) != "dhclient":
         return None
 
     # Apr  4 13:37:04 localhost dhclient[4]: bound to 10.13.37.4 -- renewal in 1337 seconds.

--- a/dissect/target/plugins/os/unix/linux/network.py
+++ b/dissect/target/plugins/os/unix/linux/network.py
@@ -29,18 +29,29 @@ if TYPE_CHECKING:
 class LinuxNetworkPlugin(NetworkPlugin):
     """Linux network interface plugin."""
 
-    @arg("-s", "--syslog", action="store_true", help="scan syslog for dhcp leases")
+    @arg(
+        "-s",
+        "--syslog",
+        action="store_true",
+        help="scan syslog for dhcp leases; use --maxlines to specify number of lines",
+    )
     @arg(
         "-m",
         "--maxlines",
         action="store",
         type=int,
-        help="maximum number of lines of syslog to scan (0 is all lines)",
-        default=1000,
+        help="maximum number of lines of syslog to scan (implies --syslog); default is 1000 if --syslog is set",
+        default=None,
     )
     @export(record=get_args(InterfaceRecord))
     def interfaces(self, syslog: bool = False, maxlines: int | None = None) -> Iterator[UnixInterfaceRecord]:
         """Yield interfaces."""
+        # If maxlines is specified, syslog is assumed True
+        if maxlines is not None:
+            syslog = True
+        # If syslog is True and maxlines is None, use default 1000
+        if syslog and maxlines is None:
+            maxlines = 1000
         maxlines = None if maxlines == 0 else maxlines
         yield from super().interfaces(scan_syslog=syslog, maxlines=maxlines)
 

--- a/dissect/target/plugins/os/unix/linux/network.py
+++ b/dissect/target/plugins/os/unix/linux/network.py
@@ -5,9 +5,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from ipaddress import IPv4Interface, IPv6Interface, ip_address, ip_interface
 from itertools import chain, islice
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Union
-
-from typing_extensions import get_args
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Union, get_args
 
 from dissect.target.exceptions import PluginError
 from dissect.target.helpers import configutil

--- a/dissect/target/plugins/os/unix/linux/network.py
+++ b/dissect/target/plugins/os/unix/linux/network.py
@@ -29,23 +29,20 @@ if TYPE_CHECKING:
 class LinuxNetworkPlugin(NetworkPlugin):
     """Linux network interface plugin."""
 
-    @arg("-s", "--syslog", action="store_true", help="Scan syslog for dhcp leases")
+    @arg("-s", "--syslog", action="store_true", help="scan syslog for dhcp leases")
     @arg(
         "-m",
         "--maxlines",
         action="store",
         type=int,
-        help="Maximum number of lines of syslog to scan (0 is all lines)",
+        help="maximum number of lines of syslog to scan (0 is all lines)",
         default=1000,
     )
     @export(record=get_args(InterfaceRecord))
     def interfaces(self, syslog: bool = False, maxlines: int | None = None) -> Iterator[UnixInterfaceRecord]:
         """Yield interfaces."""
         maxlines = None if maxlines == 0 else maxlines
-        if self._interface_list is None:
-            self._interface_list = list(self._interfaces(syslog, maxlines))
-
-        yield from self._interface_list
+        yield from super().interfaces(scan_syslog=syslog, maxlines=maxlines)
 
     def _interfaces(self, scan_syslog: bool, maxlines: int | None) -> Iterator[UnixInterfaceRecord]:
         """Try all available network configuration managers and aggregate the results."""
@@ -663,7 +660,6 @@ def be_hex_to_int(be_hex: str) -> int:
     return int.from_bytes(bytes.fromhex(be_hex), "little")
 
 
-@dataclass
 class DhcpLease(NamedTuple):
     interface: str | None
     ip: NetInterface

--- a/dissect/target/plugins/os/unix/linux/network.py
+++ b/dissect/target/plugins/os/unix/linux/network.py
@@ -35,8 +35,8 @@ class LinuxNetworkPlugin(NetworkPlugin):
     @arg(
         "-m",
         "--maxlines",
-        default=None,
-        action="store_true",
+        action="store",
+        type=int,
         help="Maximum number of lines of syslog to scan (0 is unlimited)",
     )
     @export(record=get_args(InterfaceRecord))

--- a/dissect/target/plugins/os/unix/linux/network.py
+++ b/dissect/target/plugins/os/unix/linux/network.py
@@ -35,11 +35,13 @@ class LinuxNetworkPlugin(NetworkPlugin):
         "--maxlines",
         action="store",
         type=int,
-        help="Maximum number of lines of syslog to scan (0 is unlimited)",
+        help="Maximum number of lines of syslog to scan (0 is all lines)",
+        default=1000,
     )
     @export(record=get_args(InterfaceRecord))
     def interfaces(self, syslog: bool = False, maxlines: int | None = None) -> Iterator[UnixInterfaceRecord]:
         """Yield interfaces."""
+        maxlines = None if maxlines == 0 else maxlines
         if self._interface_list is None:
             self._interface_list = list(self._interfaces(syslog, maxlines))
 

--- a/dissect/target/plugins/os/unix/linux/network.py
+++ b/dissect/target/plugins/os/unix/linux/network.py
@@ -714,7 +714,7 @@ def parse_network_manager_dhcp_lease_new(log_record: LogRecord) -> DhcpLease | N
     """Parse DHCP lease information from NetworkManager logs new style."""
 
     # dhcp4 (eth0): state changed new lease, address=10.13.37.1
-    if not (match := re.search(r"dhcp[46] \((\S+)\): state changed new lease, address=(\S+)", log_record.message)):
+    if not (match := re.search(r"dhcp[46] \((\S+)\): state changed new lease, address=([^\s,]+)", log_record.message)):
         return None
     name, interface = match.groups()
 

--- a/dissect/target/plugins/os/unix/linux/network.py
+++ b/dissect/target/plugins/os/unix/linux/network.py
@@ -41,7 +41,6 @@ class LinuxNetworkPlugin(NetworkPlugin):
         action="store",
         type=int,
         help="maximum number of lines of syslog to scan (implies --syslog); default is 1000 if --syslog is set",
-        default=None,
     )
     @export(record=get_args(InterfaceRecord))
     def interfaces(self, syslog: bool = False, maxlines: int | None = None) -> Iterator[UnixInterfaceRecord]:

--- a/tests/plugins/os/unix/linux/test_network.py
+++ b/tests/plugins/os/unix/linux/test_network.py
@@ -354,6 +354,15 @@ def test_proc_config_parser(target_linux: Target, fs_linux: VirtualFilesystem) -
         (
             {
                 "name": "eth0",
+                "cidr": [ip_interface("10.13.37.1/32")],
+                "gateway": [],
+                "source": "syslog",
+            },
+            "Jan  1 13:37:01 hostname NetworkManager[2]: <info>  [1600000000.0000] dhcp4 (eth0): state changed new lease, address=10.13.37.1, acd pending",  # noqa: E501
+        ),
+        (
+            {
+                "name": "eth0",
                 "cidr": [ip_interface("10.13.37.2/24")],
                 "gateway": [ip_address("10.13.37.0")],
                 "source": "syslog",

--- a/tests/plugins/os/unix/linux/test_network.py
+++ b/tests/plugins/os/unix/linux/test_network.py
@@ -345,11 +345,20 @@ def test_proc_config_parser(target_linux: Target, fs_linux: VirtualFilesystem) -
         (
             {
                 "name": "eth0",
+                "cidr": [ip_interface("10.13.37.1/32")],
+                "gateway": [],
+                "source": "syslog",
+            },
+            "Jan  1 13:37:01 hostname NetworkManager[2]: <info>  [1600000000.0000] dhcp4 (eth0): state changed new lease, address=10.13.37.1",  # noqa: E501
+        ),
+        (
+            {
+                "name": "eth0",
                 "cidr": [ip_interface("10.13.37.2/24")],
                 "gateway": [ip_address("10.13.37.0")],
                 "source": "syslog",
             },
-            "Feb  2 13:37:02 test systemd-networkd[2]: eth0: DHCPv4 address 10.13.37.2/24 via 10.13.37.0",
+            "Feb  2 13:37:02 test systemd-networkd[3]: eth0: DHCPv4 address 10.13.37.2/24 via 10.13.37.0",
         ),
         (
             {
@@ -358,7 +367,7 @@ def test_proc_config_parser(target_linux: Target, fs_linux: VirtualFilesystem) -
                 "gateway": [],
                 "source": "syslog",
             },
-            "Mar  3 13:37:03 localhost NetworkManager[3]: <info>  [1600000000.0003] dhcp4 (eth0):   address 10.13.37.3",
+            "Mar  3 13:37:03 localhost NetworkManager[4]: <info>  [1600000000.0003] dhcp4 (eth0):   address 10.13.37.3",
         ),
         (
             {
@@ -367,7 +376,7 @@ def test_proc_config_parser(target_linux: Target, fs_linux: VirtualFilesystem) -
                 "gateway": [],
                 "source": "syslog",
             },
-            "Apr  4 13:37:04 localhost dhclient[4]: bound to 10.13.37.4 -- renewal in 1337 seconds.",
+            "Apr  4 13:37:04 localhost dhclient[5]: bound to 10.13.37.4 -- renewal in 1337 seconds.",
         ),
         (
             {
@@ -377,8 +386,8 @@ def test_proc_config_parser(target_linux: Target, fs_linux: VirtualFilesystem) -
                 "source": "syslog",
             },
             (
-                "Jun  6 13:37:06 test systemd-networkd[5]: eth0: DHCPv6 address 2001:db8::/64 via 2001:db8:ffff:ffff:ffff:ffff:ffff:ffff\n"  # noqa: E501
-                "May  5 13:37:05 test systemd-networkd[5]: eth0: DHCPv6 lease lost\n"
+                "Jun  6 13:37:06 test systemd-networkd[6]: eth0: DHCPv6 address 2001:db8::/64 via 2001:db8:ffff:ffff:ffff:ffff:ffff:ffff\n"  # noqa: E501
+                "May  5 13:37:05 test systemd-networkd[6]: eth0: DHCPv6 lease lost\n"
             ),
         ),
     ],


### PR DESCRIPTION
- Make parsing of syslog optional in network rewrite.
- Limit number of messages parsed.
