### PR TITLE
Fix incorrect timestamps of ZipInfo objects

### DIFF
--- a/dissect/target/filesystems/zip.py
+++ b/dissect/target/filesystems/zip.py
@@ -161,11 +161,10 @@ class ZipFilesystemEntry(VirtualDirectory):
         elif not self.entry.is_dir() and not stat.S_ISREG(mode):
             mode = stat.S_IFREG | mode
 
-        date_time = self.entry.date_time
-        if date_time[0] < 1980 or date_time[:2] == (1980, 0) or date_time[:3] == (1980, 1, 0):
-            date_time = (1980, 1, 1, 0, 0, 0)
-        elif date_time[0] > 2107:
-            date_time = (2107, 12, 31, 23, 59, 59)
+        try:
+            timestamp = datetime(*self.entry.date_time, tzinfo=timezone.utc).timestamp()
+        except ValueError:
+            timestamp = 315532800  # datetime(*(1980, 1, 1, 0, 0, 0), tzinfo=timezone.utc).timestamp()
 
         return fsutil.stat_result(
             [
@@ -177,7 +176,7 @@ class ZipFilesystemEntry(VirtualDirectory):
                 0,
                 self.entry.file_size,
                 0,
-                datetime(*date_time, tzinfo=timezone.utc).timestamp(),
+                timestamp,
                 0,
             ]
         )

--- a/dissect/target/filesystems/zip.py
+++ b/dissect/target/filesystems/zip.py
@@ -162,11 +162,9 @@ class ZipFilesystemEntry(VirtualDirectory):
             mode = stat.S_IFREG | mode
 
         try:
-            timestamp = datetime(*self.entry.date_time, tzinfo=timezone.utc).timestamp()
+            mtime = datetime(*self.entry.date_time, tzinfo=timezone.utc)
         except ValueError:
-            # 4354819199 ==  datetime(*(2107, 12, 31, 23, 59, 59), tzinfo=timezone.utc).timestamp()
-            # 315532800 ==  datetime(*(1980, 1, 1, 0, 0, 0), tzinfo=timezone.utc).timestamp()
-            timestamp = 4354819199 if self.entry.date_time[0] >= 2107 else 315532800
+            mtime = datetime(*(2107, 12, 31, 23, 59, 59) if self.entry.date_time[0] >= 2107 else *(1980, 1, 1, 0, 0, 0), tzinfo=timezone.utc)
 
         return fsutil.stat_result(
             [
@@ -178,7 +176,7 @@ class ZipFilesystemEntry(VirtualDirectory):
                 0,
                 self.entry.file_size,
                 0,
-                timestamp,
+                mtime.timestamp(),
                 0,
             ]
         )

--- a/dissect/target/filesystems/zip.py
+++ b/dissect/target/filesystems/zip.py
@@ -162,7 +162,7 @@ class ZipFilesystemEntry(VirtualDirectory):
             mode = stat.S_IFREG | mode
 
         date_time = self.entry.date_time
-        if date_time[0] < 1980 or date_time[:3] == (1980, 0, 0):
+        if date_time[0] < 1980 or date_time[:2] == (1980, 0) or date_time[:3] == (1980, 1, 0):
             date_time = (1980, 1, 1, 0, 0, 0)
         elif date_time[0] > 2107:
             date_time = (2107, 12, 31, 23, 59, 59)

--- a/dissect/target/filesystems/zip.py
+++ b/dissect/target/filesystems/zip.py
@@ -164,7 +164,8 @@ class ZipFilesystemEntry(VirtualDirectory):
         try:
             mtime = datetime(*self.entry.date_time, tzinfo=timezone.utc)
         except ValueError:
-            mtime = datetime(*(2107, 12, 31, 23, 59, 59) if self.entry.date_time[0] >= 2107 else *(1980, 1, 1, 0, 0, 0), tzinfo=timezone.utc)
+            mtime_tuple = (2107, 12, 31, 23, 59, 59) if self.entry.date_time[0] >= 2107 else (1980, 1, 1, 0, 0, 0)
+            mtime = datetime(*mtime_tuple, tzinfo=timezone.utc)
 
         return fsutil.stat_result(
             [

--- a/dissect/target/filesystems/zip.py
+++ b/dissect/target/filesystems/zip.py
@@ -164,7 +164,9 @@ class ZipFilesystemEntry(VirtualDirectory):
         try:
             timestamp = datetime(*self.entry.date_time, tzinfo=timezone.utc).timestamp()
         except ValueError:
-            timestamp = 315532800  # datetime(*(1980, 1, 1, 0, 0, 0), tzinfo=timezone.utc).timestamp()
+            # 4354819199 ==  datetime(*(2107, 12, 31, 23, 59, 59), tzinfo=timezone.utc).timestamp()
+            # 315532800 ==  datetime(*(1980, 1, 1, 0, 0, 0), tzinfo=timezone.utc).timestamp()
+            timestamp = 4354819199 if self.entry.date_time[0] >= 2107 else 315532800
 
         return fsutil.stat_result(
             [

--- a/tests/filesystems/test_zip.py
+++ b/tests/filesystems/test_zip.py
@@ -51,6 +51,9 @@ def _create_zip(prefix: str = "", zip_dir: bool = True) -> io.BytesIO:
 
     zf.writestr(zipfile.ZipInfo(f"{prefix}file_1", (1980, 0, 0, 0, 0, 0)), "file 1 contents")
     zf.writestr(zipfile.ZipInfo(f"{prefix}file_2", (2107, 1, 1, 0, 0, 0)), "file 2 contents")
+    zf.writestr(zipfile.ZipInfo(f"{prefix}file_3", (1980, 1, 0, 0, 0, 0)), "file 3 contents")
+    zf.writestr(zipfile.ZipInfo(f"{prefix}file_4", (2107, 13, 1, 0, 0, 0)), "file 4 contents")
+    zf.writestr(zipfile.ZipInfo(f"{prefix}file_5", (2025, 9, 8, 10, 39, 40)), "file 5 contents")
 
     if zip_dir:
         _mkdir(zf, f"{prefix}dir/")
@@ -113,12 +116,16 @@ def test_filesystems_zip(obj: str, base: str, request: pytest.FixtureRequest) ->
 
     fs = ZipFilesystem(fh, base)
     assert isinstance(fs, ZipFilesystem)
-    assert len(fs.listdir("/")) == 5
+    assert len(fs.listdir("/")) == 8
 
     assert fs.get("./file_1").open().read() == b"file 1 contents"
     assert fs.get("./file_2").open().read() == b"file 2 contents"
+    assert fs.get("./file_3").open().read() == b"file 3 contents"
     assert fs.get("./file_1").lstat().st_mtime_ns == 315532800000000000
     assert fs.get("./file_2").lstat().st_mtime_ns == 4323283200000000000
+    assert fs.get("./file_3").lstat().st_mtime_ns == 315532800000000000
+    assert fs.get("./file_4").lstat().st_mtime_ns == 315532800000000000
+    assert fs.get("./file_5").lstat().st_mtime_ns == 1757327980000000000
     assert fs.get("./symlink_file").open().read() == b"file 1 contents"
     assert len(list(fs.glob("./dir/*"))) == 100
     assert len(list(fs.glob("./symlink_dir/*"))) == 100

--- a/tests/filesystems/test_zip.py
+++ b/tests/filesystems/test_zip.py
@@ -124,7 +124,7 @@ def test_filesystems_zip(obj: str, base: str, request: pytest.FixtureRequest) ->
     assert fs.get("./file_1").lstat().st_mtime_ns == 315532800000000000
     assert fs.get("./file_2").lstat().st_mtime_ns == 4323283200000000000
     assert fs.get("./file_3").lstat().st_mtime_ns == 315532800000000000
-    assert fs.get("./file_4").lstat().st_mtime_ns == 315532800000000000
+    assert fs.get("./file_4").lstat().st_mtime_ns == 4354819199000000000
     assert fs.get("./file_5").lstat().st_mtime_ns == 1757327980000000000
     assert fs.get("./symlink_file").open().read() == b"file 1 contents"
     assert len(list(fs.glob("./dir/*"))) == 100


### PR DESCRIPTION
Some issues are still present after #1270. This PR complete to make ZipLoader more robust

Example 1
```
datetime(1980,0,1,0,0,0)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-6-533ec990f051> in <module>
----> 1 datetime(1980,0,1,0,0,0)

ValueError: month must be in 1..12
```
Example 2
```
datetime(1980,1,0,0,0,0)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-dd5756bd5dae> in <module>
----> 1 datetime(1980,1,0,0,0,0)

ValueError: day is out of range for month
```  

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
