### PR TITLE
Fix namespace execution in target-query

### DIFF
--- a/dissect/target/plugins/general/example.py
+++ b/dissect/target/plugins/general/example.py
@@ -157,3 +157,21 @@ class ExamplePlugin(Plugin):
         Use the ``@internal`` plugin to mark your plugin as internal and hide it from the plugin overview.
         """
         return "Example internal plugin."
+
+
+class ExampleNamespacePlugin(Plugin):
+    """Example namespace plugin."""
+
+    __namespace__ = "example_namespace"
+    __findable__ = False
+
+    def check_compatible(self) -> None:
+        pass
+
+    @export(record=ExampleRecordRecord)
+    def example_record(self) -> Iterator[ExampleRecordRecord]:
+        yield ExampleRecordRecord(
+            field_a="namespace_example",
+            field_b="record",
+            _target=self.target,
+        )

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -135,7 +135,9 @@ def main() -> int:
 
     default_output_type = None
     if len(different_output_types) > 1:
-        log.warning("Mixed output types detected: %s, only outputting records", ",".join(different_output_types))
+        log.warning(
+            "Mixed output types detected: %s, only outputting records", ", ".join(map(str, different_output_types))
+        )
         default_output_type = "record"
 
     execution_report = ExecutionReport()
@@ -156,7 +158,7 @@ def main() -> int:
                 # We perform this check here because plugins that require output files/dirs
                 # will exit if we attempt to exec them without (because they are implied by the wildcard).
                 # Also this saves cycles of course.
-                if default_output_type == "record" and func_def.output != "record":
+                if default_output_type == "record" and func_def.output != "record" and not func_def.namespace:
                     continue
 
                 if args.dry_run:

--- a/tests/tools/test_query.py
+++ b/tests/tools/test_query.py
@@ -472,3 +472,29 @@ def test_arguments_passed_correctly(
             target_query()
 
         assert "Exception while executing function mock" not in caplog.text
+
+
+def test_mixed_output_types_regression(
+    capsys: pytest.CaptureFixture, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test if the mixed output warning message can handle NoneType."""
+    with monkeypatch.context() as m:
+        m.setattr(
+            "sys.argv",
+            [
+                "target-query",
+                "-f",
+                "example_record,example_namespace",
+                str(absolute_path("_data/loaders/tar/test-archive.tar.gz")),
+                "-s",
+            ],
+        )
+
+        target_query()
+        out, _ = capsys.readouterr()
+
+    assert "Mixed output types detected: None, record, only outputting records" in caplog.text
+    assert (
+        "<example/descriptor hostname=None domain=None field_a='example' field_b='record'>\n"
+        "<example/descriptor hostname=None domain=None field_a='namespace_example' field_b='record'>\n"
+    ) in out


### PR DESCRIPTION
This PR is a workaround for issue #1317. It is our opinion that the final accepted fix for this issue should result in a patch release of dissect (e.g. `3.20.1`).