### PR TITLE
Better error handling for invalid paths and broken loaders

### DIFF
--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -433,6 +433,11 @@ class Target:
             if parsed_path is None or isinstance(spec, os.PathLike):
                 path = Path(spec) if not isinstance(spec, os.PathLike) else spec
 
+                if not path.exists():
+                    raise TargetError(f"Failed to find loader for {path}: path does not exist")
+                elif not path.is_dir():
+                    raise TargetError(f"Failed to find loader for {path}: path is not a directory")
+
                 for entry in path.iterdir():
                     for target in _open_all(entry, include_children=include_children):
                         at_least_one_loaded = True

--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -396,7 +396,8 @@ class Target:
                     # For file/dir-like paths it's a Path object
                     target = cls._load(load_spec, ldr)
                 except Exception as e:
-                    getlogger(load_spec).error("Failed to load target with loader %s", ldr, exc_info=e)
+                    getlogger(load_spec).error("Failed to load target with loader %s", ldr)
+                    getlogger(load_spec).debug("", exc_info=e)
                     continue
                 else:
                     yield target

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -266,7 +266,7 @@ def main() -> int:
                 if break_out:
                     break
 
-    except TargetError as e:
+    except (TargetError, FileNotFoundError) as e:
         log.error(e)  # noqa: TRY400
         log.debug("", exc_info=e)
         return 1

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -266,7 +266,7 @@ def main() -> int:
                 if break_out:
                     break
 
-    except (TargetError, FileNotFoundError) as e:
+    except TargetError as e:
         log.error(e)  # noqa: TRY400
         log.debug("", exc_info=e)
         return 1

--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -1603,7 +1603,7 @@ def main() -> int:
 
     try:
         open_shell(args.targets, args.python, args.registry, args.commands)
-    except (TargetError, FileNotFoundError) as e:
+    except TargetError as e:
         log.error("Error opening shell: %s", e)  # noqa: TRY400
         log.debug("", exc_info=e)
 

--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -1603,8 +1603,8 @@ def main() -> int:
 
     try:
         open_shell(args.targets, args.python, args.registry, args.commands)
-    except TargetError as e:
-        log.exception("Error opening shell")
+    except (TargetError, FileNotFoundError) as e:
+        log.error("Error opening shell: %s", e)  # noqa: TRY400
         log.debug("", exc_info=e)
 
     return 0

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -755,18 +755,18 @@ def test_exception_invalid_path() -> None:
 
     with pytest.raises(
         TargetError,
-        match="Failed to initiate RawLoader for target [/\\]path[/\\]to[/\\]invalid\.img: Provided target path does not exist",
+        match=r"Failed to initiate RawLoader for target [/\\]path[/\\]to[/\\]invalid.img: Provided target path does not exist",  # noqa: E501
     ):
-        Target.open(path)
+        Target.open("/path/to/invalid.img")
 
     with pytest.raises(
         TargetError,
-        match="Failed to find loader for [/\\]path[/\\]to[/\\]invalid\.img: path does not exist",
+        match=r"Failed to find loader for [/\\]path[/\\]to[/\\]invalid.img: path does not exist",
     ):
-        next(Target.open_all(path))
+        next(Target.open_all("/path/to/invalid.img"))
 
     with pytest.raises(
         TargetError,
-        match="Failed to find any loader for targets: \['smb://invalid'\]",
+        match=r"Failed to find any loader for targets: \['smb://invalid'\]",
     ):
         next(Target.open_all("smb://invalid"))

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import logging
 import platform
+import sys
 import urllib.parse
 from collections import defaultdict
 from pathlib import Path
@@ -753,17 +754,19 @@ def test_expected_path(path: str | Path, expected: Path) -> None:
 def test_exception_invalid_path() -> None:
     """Test if we throw small and neat error messages and not long stack traces when giving invalid path(s)."""
 
-    with pytest.raises(
-        TargetError,
-        match="Failed to initiate RawLoader for target /path/to/invalid.img: Provided target path does not exist",
-    ):
-        Target.open("/path/to/invalid.img")
+    path = "\\path\\to\\invalid.img" if sys.platform == "windows" else "/path/to/invalid.img"
 
     with pytest.raises(
         TargetError,
-        match="Failed to find loader for /path/to/invalid.img: path does not exist",
+        match=f"Failed to initiate RawLoader for target {path}: Provided target path does not exist",
     ):
-        next(Target.open_all("/path/to/invalid.img"))
+        Target.open(path)
+
+    with pytest.raises(
+        TargetError,
+        match=f"Failed to find loader for {path}: path does not exist",
+    ):
+        next(Target.open_all(path))
 
     with pytest.raises(
         TargetError,

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -13,7 +13,7 @@ import pytest
 
 from dissect.target import loader
 from dissect.target.containers.raw import RawContainer
-from dissect.target.exceptions import FilesystemError
+from dissect.target.exceptions import FilesystemError, TargetError
 from dissect.target.filesystem import VirtualFilesystem
 from dissect.target.filesystems.dir import DirectoryFilesystem
 from dissect.target.helpers.fsutil import TargetPath
@@ -748,3 +748,27 @@ def test_expected_path(path: str | Path, expected: Path) -> None:
     assert target.path == expected
     if isinstance(path, Path):
         assert type(target.path) is type(expected)
+
+
+def test_exception_invalid_path() -> None:
+    """Test if we throw small and neat error messages and not long stack traces when giving invalid path(s)."""
+
+    with pytest.raises(TargetError) as e:
+        Target.open("/path/to/invalid.img")
+
+    assert e.value.args == (
+        "Failed to initiate RawLoader for target /path/to/invalid.img: Provided target path does not exist",
+    )
+    assert len(e.traceback) == 2
+
+    with pytest.raises(TargetError) as e:
+        next(Target.open_all("/path/to/invalid.img"))
+
+    assert e.value.args == ("Failed to find loader for /path/to/invalid.img: path does not exist",)
+    assert len(e.traceback) == 2
+
+    with pytest.raises(TargetError) as e:
+        next(Target.open_all("smb://invalid"))
+
+    assert e.value.args == ("Failed to find any loader for targets: ['smb://invalid']",)
+    assert len(e.traceback) == 2

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -753,22 +753,20 @@ def test_expected_path(path: str | Path, expected: Path) -> None:
 def test_exception_invalid_path() -> None:
     """Test if we throw small and neat error messages and not long stack traces when giving invalid path(s)."""
 
-    with pytest.raises(TargetError) as e:
+    with pytest.raises(
+        TargetError,
+        match="Failed to initiate RawLoader for target /path/to/invalid.img: Provided target path does not exist",
+    ):
         Target.open("/path/to/invalid.img")
 
-    assert e.value.args == (
-        "Failed to initiate RawLoader for target /path/to/invalid.img: Provided target path does not exist",
-    )
-    assert len(e.traceback) == 2
-
-    with pytest.raises(TargetError) as e:
+    with pytest.raises(
+        TargetError,
+        match="Failed to find loader for /path/to/invalid.img: path does not exist",
+    ):
         next(Target.open_all("/path/to/invalid.img"))
 
-    assert e.value.args == ("Failed to find loader for /path/to/invalid.img: path does not exist",)
-    assert len(e.traceback) == 2
-
-    with pytest.raises(TargetError) as e:
+    with pytest.raises(
+        TargetError,
+        match=r"Failed to find any loader for targets: \['smb://invalid'\]",
+    ):
         next(Target.open_all("smb://invalid"))
-
-    assert e.value.args == ("Failed to find any loader for targets: ['smb://invalid']",)
-    assert len(e.traceback) == 2

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -754,22 +754,20 @@ def test_expected_path(path: str | Path, expected: Path) -> None:
 def test_exception_invalid_path() -> None:
     """Test if we throw small and neat error messages and not long stack traces when giving invalid path(s)."""
 
-    path = "\\path\\to\\invalid.img" if sys.platform == "windows" else "/path/to/invalid.img"
-
     with pytest.raises(
         TargetError,
-        match=f"Failed to initiate RawLoader for target {path}: Provided target path does not exist",
+        match="Failed to initiate RawLoader for target [/\\]path[/\\]to[/\\]invalid\.img: Provided target path does not exist",
     ):
         Target.open(path)
 
     with pytest.raises(
         TargetError,
-        match=f"Failed to find loader for {path}: path does not exist",
+        match="Failed to find loader for [/\\]path[/\\]to[/\\]invalid\.img: path does not exist",
     ):
         next(Target.open_all(path))
 
     with pytest.raises(
         TargetError,
-        match=r"Failed to find any loader for targets: \['smb://invalid'\]",
+        match="Failed to find any loader for targets: \['smb://invalid'\]",
     ):
         next(Target.open_all("smb://invalid"))

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import io
 import logging
 import platform
-import sys
 import urllib.parse
 from collections import defaultdict
 from pathlib import Path


### PR DESCRIPTION
This PR attempts to reduce non-informative stacktrace dumping by dissect when encountering invalid paths or broken loaders.

Before:
```
$ target-query -f users invalid.img
2025-09-08T09:25:25.982598Z [error    ] invalid.img: Provided target path does not exist [dissect.target.target]
Traceback (most recent call last):
  File "/tmp/.venv/bin/target-query", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/tmp/dissect/target/tools/utils.py", line 394, in wrapper
    return func(*args, **kwargs)
  File "/tmp/dissect/target/tools/query.py", line 151, in main
    for target in open_targets(args):
                  ~~~~~~~~~~~~^^^^^^
  File "/tmp/dissect/target/tools/utils.py", line 184, in open_targets
    for target in targets:
                  ^^^^^^^
  File "/tmp/dissect/target/target.py", line 435, in open_all
    for entry in path.iterdir():
                 ~~~~~~~~~~~~^^
  File "/tmp/share/uv/python/cpython-3.13.2-linux-x86_64-gnu/lib/python3.13/pathlib/_local.py", line 575, in iterdir
    with os.scandir(root_dir) as scandir_it:
         ~~~~~~~~~~^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'invalid.img'
```

```
$ target-shell smb://invalid.img
2025-09-08T14:57:24.580391Z [error    ] smb://invalid.img: Failed to initiate loader: Required dependency 'impacket' is missing, install with 'pip install dissect.target[smb]' [dissect.target.target]
2025-09-08T14:57:24.580521Z [error    ] Error opening shell [dissect.target.tools.shell]
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /tmp/dissect/target/tools/shell.py:1605 in main         │
│                                                                                                  │
│   1602 │   │   │   )                                                                             │
│   1603 │                                                                                         │
│   1604 │   try:                                                                                  │
│ ❱ 1605 │   │   open_shell(args.targets, args.python, args.registry, args.commands)               │
│   1606 │   except TargetError as e:                                                              │
│   1607 │   │   log.exception("Error opening shell")                                              │
│   1608 │   │   log.debug("", exc_info=e)                                                         │
│                                                                                                  │
│ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
│ │      _ = []                                                                                  │ │
│ │   args = Namespace(targets=['smb://invalid.img'], python=False, registry=False,              │ │
│ │          commands=None, keychain_file=None, keychain_value=None, loader=None, verbose=0,     │ │
│ │          version=False, quiet=False, plugin_path=None)                                       │ │
│ │      e = TargetError("Failed to find any loader for targets: ['smb://invalid.img']")         │ │
│ │ parser = ArgumentParser(prog='target-shell', usage=None, description='dissect.target',       │ │
│ │          formatter_class=<class 'argparse.ArgumentDefaultsHelpFormatter'>,                   │ │
│ │          conflict_handler='error', add_help=True)                                            │ │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
│                                                                                                  │
│ /tmp/dissect/target/tools/shell.py:1482 in open_shell   │
│                                                                                                  │
│   1479                                                                                           │
│   1480 def open_shell(targets: list[str | pathlib.Path], python: bool, registry: bool, commands  │
│   1481 │   """Helper method for starting a regular, Python or registry shell for one or multipl  │
│ ❱ 1482 │   targets = list(Target.open_all(targets))                                              │
│   1483 │                                                                                         │
│   1484 │   if python:                                                                            │
│   1485 │   │   python_shell(targets, commands=commands)                                          │
│                                                                                                  │
│ ╭───────────── locals ─────────────╮                                                             │
│ │ commands = None                  │                                                             │
│ │   python = False                 │                                                             │
│ │ registry = False                 │                                                             │
│ │  targets = ['smb://invalid.img'] │                                                             │
│ ╰──────────────────────────────────╯                                                             │
│                                                                                                  │
│ /tmp/dissect/target/target.py:441 in open_all           │
│                                                                                                  │
│   438 │   │   │   │   │   │   yield target                                                       │
│   439 │   │                                                                                      │
│   440 │   │   if not at_least_one_loaded:                                                        │
│ ❱ 441 │   │   │   raise TargetError(f"Failed to find any loader for targets: {paths}")           │
│   442 │                                                                                          │
│   443 │   @classmethod                                                                           │
│   444 │   def open_direct(cls, paths: list[str | Path]) -> Self:                                 │
│                                                                                                  │
│ ╭──────────────────── locals ─────────────────────╮                                              │
│ │                   _ = PosixPath('invalid.img')  │                                              │
│ │ at_least_one_loaded = False                     │                                              │
│ │    include_children = False                     │                                              │
│ │              loaded = False                     │                                              │
│ │         parsed_path = ParseResult(              │                                              │
│ │                       │   scheme='smb',         │                                              │
│ │                       │   netloc='invalid.img', │                                              │
│ │                       │   path='',              │                                              │
│ │                       │   params='',            │                                              │
│ │                       │   query='',             │                                              │
│ │                       │   fragment=''           │                                              │
│ │                       )                         │                                              │
│ │               paths = ['smb://invalid.img']     │                                              │
│ │                spec = 'smb://invalid.img'       │                                              │
│ ╰─────────────────────────────────────────────────╯                                              │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
TargetError: Failed to find any loader for targets: ['smb://invalid.img']
```

After:

```
$ target-query -f users invalid.img
2025-09-08T09:29:18.578305Z [error    ] invalid.img: Provided target path does not exist [dissect.target.target]
2025-09-08T09:29:18.578506Z [error    ] [Errno 2] No such file or directory: 'invalid.img' [dissect.target.tools.query]
```

```
$ target-shell smb://invalid.img
2025-09-08T14:58:03.846306Z [error    ] smb://invalid.img: Failed to initiate loader: Required dependency 'impacket' is missing, install with 'pip install dissect.target[smb]' [dissect.target.target]
2025-09-08T14:58:03.846445Z [error    ] Error opening shell: Failed to find any loader for targets: ['smb://invalid.img'] [dissect.target.tools.shell]
```