### PR TITLE
fix: str_to_isoformat for unformatted datetime

### DIFF
--- a/dissect/target/plugins/os/windows/tasks/xml.py
+++ b/dissect/target/plugins/os/windows/tasks/xml.py
@@ -97,6 +97,34 @@ def str_to_bool(string_to_convert: str) -> bool | None:
     raise ValueError(f"Invalid boolean string: '{string_to_convert}' (expected 'true' or 'false')")
 
 
+def str_to_isoformat(string_to_convert: str) -> str | None:
+    """Convert a datetime string to ISO 8601 format.
+
+    Accepts strings in the form YYYY-MM-DDThh:mm:ss
+    and returns a zero-padded ISO format string.
+
+    Args:
+        string_to_convert: The input datetime string.
+
+    Returns:
+        None for an empty string, otherwise a ISO 8601 formatted string.
+    """
+    if not string_to_convert:
+        return None
+    if "T" in string_to_convert:
+        date_part, time_part = string_to_convert.split("T")
+    elif " " in string_to_convert:
+        date_part, time_part = string_to_convert.split(" ")
+    else:
+        raise ValueError(f"Invalid datetime string: '{string_to_convert}' (expected 'YYYY-MM-DDThh:mm:ss')")
+
+    try:
+        year, month, day = date_part.split("-")
+        return f"{year}-{int(month):02d}-{int(day):02d}T{time_part}"
+    except Exception:
+        raise ValueError(f"Invalid datetime string: '{string_to_convert}' (expected 'YYYY-MM-DDThh:mm:ss')")
+
+
 class XmlTask:
     """Parses and extracts information from an XML-based Task Scheduler file.
 
@@ -245,8 +273,8 @@ class XmlTask:
         for trigger in self.task_element.findall("Triggers/*"):
             trigger_type = trigger.tag
             trigger_enabled = str_to_bool(self.get_element("Enabled", trigger))
-            start_boundary = self.get_element("StartBoundary", trigger)
-            end_boundary = self.get_element("EndBoundary", trigger)
+            start_boundary = str_to_isoformat(self.get_element("StartBoundary", trigger))
+            end_boundary = str_to_isoformat(self.get_element("EndBoundary", trigger))
             repetition_interval = self.get_element("Repetition/Interval", trigger)
             repetition_duration = self.get_element("Repetition/Duration", trigger)
             repetition_stop_duration_end = str_to_bool(self.get_element("Repetition/StopAtDurationEnd", trigger))


### PR DESCRIPTION
### Summary
Introduce `str_to_isoformat` to format datetime strings
encountered in Windows Task Scheduler XML. This ensures
non-padded months/days and space-separated datetimes are
converted into strict ISO 8601 strings.

### Motivation
Parsing a velo package could result in the following error:
```
  File "/usr/lib/pypy/lib/pypy3.11/datetime.py", line 1852, in fromisoformat
    raise ValueError(
ValueError: Invalid isoformat string: '2025-7-29T16:34:00'
```
This PR solves that issue.