### PR TITLE
Check whether the target_path is a symlink or not

### DIFF
--- a/dissect/target/tools/fsutils.py
+++ b/dissect/target/tools/fsutils.py
@@ -164,7 +164,7 @@ def print_ls(
     if not long_listing:
         for target_path, name in contents:
             print(name, file=stdout)
-            if target_path.is_dir():
+            if not target_path.is_symlink() and target_path.is_dir():
                 subdirs.append(target_path)
     else:
         if len(contents) > 1:


### PR DESCRIPTION
the `follow_symlinks` isn't backported inside TargetPath for python 3.10
to 3.12

closes #1288
