### PR TITLE
Add timestamp to yara plugin

### DIFF
--- a/dissect/target/plugins/filesystem/yara.py
+++ b/dissect/target/plugins/filesystem/yara.py
@@ -29,6 +29,7 @@ log = logging.getLogger(__name__)
 YaraMatchRecord = TargetRecordDescriptor(
     "filesystem/yara/match",
     [
+        ("datetime", "ts"),
         ("path", "path"),
         ("string", "rule"),
         ("string[]", "matches"),
@@ -99,6 +100,7 @@ class YaraPlugin(Plugin):
                             string_matches.extend(f"{string}={instance}" for instance in string.instances)
 
                         yield YaraMatchRecord(
+                            ts=file.stat().st_mtime,
                             path=self.target.fs.path(file.path),
                             rule=match.rule,
                             matches=string_matches,

--- a/dissect/target/plugins/filesystem/yara.py
+++ b/dissect/target/plugins/filesystem/yara.py
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 YaraMatchRecord = TargetRecordDescriptor(
     "filesystem/yara/match",
     [
-        ("datetime", "ts"),
+        ("datetime", "ts_mtime"),
         ("path", "path"),
         ("string", "rule"),
         ("string[]", "matches"),
@@ -100,7 +100,7 @@ class YaraPlugin(Plugin):
                             string_matches.extend(f"{string}={instance}" for instance in string.instances)
 
                         yield YaraMatchRecord(
-                            ts=file.stat().st_mtime,
+                            ts_mtime=file.stat().st_mtime,
                             path=self.target.fs.path(file.path),
                             rule=match.rule,
                             matches=string_matches,

--- a/tests/tools/test_yara.py
+++ b/tests/tools/test_yara.py
@@ -41,8 +41,8 @@ def test_yara(target_default: Target, monkeypatch: pytest.MonkeyPatch, capsys: p
 
         out, _ = capsys.readouterr()
 
-        hit1 = "<filesystem/yara/match hostname=None domain=None path='/test_file' rule='test_rule_name' matches=['$=test string'] tags=['tag1', 'tag2', 'tag3'] digest=(md5=d690ba32b59d28614aebefe9b03c74d4, sha1=4b1ced217aabe37138e96fb93bf40026639b9d3b, sha256=7a644118588ff0dcf2fadbe198ae1f1629c29374bac491ba41d5cf957edf0dfc)"  # noqa E501
-        hit2 = "<filesystem/yara/match hostname=None domain=None path='/test/dir/to/test_file' rule='test_rule_name' matches=['$=test string'] tags=['tag1', 'tag2', 'tag3'] digest=(md5=bd7490dd2978ce983e2e1613ac8444c0, sha1=849a062cf09280f5c7dce4c7f87c69a1d9262e08, sha256=9bf7629a67c7ce8019910f1c1251fe44b61b3fff55a59a5e148af3c207dc102f)"  # noqa E501
+        hit1 = "<filesystem/yara/match hostname=None domain=None ts_mtime=1970-01-01 00:00:00+00:00 path='/test_file' rule='test_rule_name' matches=['$=test string'] tags=['tag1', 'tag2', 'tag3'] digest=(md5=d690ba32b59d28614aebefe9b03c74d4, sha1=4b1ced217aabe37138e96fb93bf40026639b9d3b, sha256=7a644118588ff0dcf2fadbe198ae1f1629c29374bac491ba41d5cf957edf0dfc)"  # noqa E501
+        hit2 = "<filesystem/yara/match hostname=None domain=None ts_mtime=1970-01-01 00:00:00+00:00 path='/test/dir/to/test_file' rule='test_rule_name' matches=['$=test string'] tags=['tag1', 'tag2', 'tag3'] digest=(md5=bd7490dd2978ce983e2e1613ac8444c0, sha1=849a062cf09280f5c7dce4c7f87c69a1d9262e08, sha256=9bf7629a67c7ce8019910f1c1251fe44b61b3fff55a59a5e148af3c207dc102f)"  # noqa E501
 
         assert hit1 in out
         assert hit2 in out


### PR DESCRIPTION
This PR adds a timestamp to the Yara plugin, by using the modification timestamp of the file. By adding this we can show yara results in a timeline method, allowing for easier analysis.

If there is any feedback please let me know!