### PR TITLE
#1350 : Make ESXi os plugins compatible with live collection.

### DIFF
--- a/tests/_data/plugins/os/unix/esxi/_os/etc/vmware/esx.conf
+++ b/tests/_data/plugins/os/unix/esxi/_os/etc/vmware/esx.conf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1be2bae79ab474135f906f5579b571dd9f275427d05da0a86fd0633889b3c9b5
+size 23234

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -299,6 +299,13 @@ def fs_bsd() -> VirtualFilesystem:
 
 
 @pytest.fixture
+def fs_esxi() -> VirtualFilesystem:
+    fs = VirtualFilesystem()
+    fs.map_file("/etc/vmware/esx.conf", absolute_path("_data/plugins/os/unix/esxi/_os/etc/vmware/esx.conf"))
+    return fs
+
+
+@pytest.fixture
 def fs_android() -> VirtualFilesystem:
     fs = VirtualFilesystem()
     fs.makedirs("/data")

--- a/tests/plugins/os/unix/esxi/test__os.py
+++ b/tests/plugins/os/unix/esxi/test__os.py
@@ -1,7 +1,9 @@
 from unittest.mock import patch
 
 from dissect.target.filesystem import VirtualFilesystem
+from dissect.target.plugin import OperatingSystem
 from dissect.target.plugins.os.unix.esxi._os import (
+    ESXiPlugin,
     _create_local_fs,
     _decrypt_crypto_util,
     esxi_hash,
@@ -78,3 +80,15 @@ def test_hash_full() -> None:
 def test_hash_empty_key() -> None:
     h = esxi_hash(b"", 666)
     assert h == 8664614747486377173
+
+
+def test_esxi_os_detection(target_bare: Target, fs_esxi: VirtualFilesystem) -> None:
+    target_bare.filesystems.add(fs_esxi)
+    target_bare.apply()
+
+    assert ESXiPlugin.detect(target_bare)
+    assert isinstance(target_bare._os, ESXiPlugin)
+    assert target_bare.os == OperatingSystem.ESXI
+    assert target_bare.hostname == "localhost"
+    assert target_bare.version == "6.7.0"
+    assert target_bare.ips == ["192.168.56.101"]


### PR DESCRIPTION
* It there is only one filesystem where `/etc/vmware/esx.conf` exists, do not look for bootbank.
* Add associated test.
* If version can't be found in the boot.cfg files, default to the value (without build number) available in esx.conf