### PR TITLE
Fix target-shell info cmd and add testcase

### DIFF
--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -42,7 +42,7 @@ from dissect.target.tools.fsutils import (
     print_stat,
     print_xattr,
 )
-from dissect.target.tools.info import print_target_info
+from dissect.target.tools.info import get_target_info, print_target_info
 from dissect.target.tools.utils import (
     catch_sigpipe,
     configure_generic_arguments,
@@ -727,7 +727,8 @@ class TargetCli(TargetCmd):
 
     def do_info(self, line: str) -> bool:
         """print target information"""
-        print_target_info(self.target)
+        target_info = get_target_info(self.target)
+        print_target_info(self.target, target_info)
         return False
 
     def do_reload(self, line: str) -> bool:

--- a/tests/tools/test_shell.py
+++ b/tests/tools/test_shell.py
@@ -232,6 +232,18 @@ def test_target_cli_ls(target_win: Target, capsys: pytest.CaptureFixture, monkey
     assert captured.out == "c:\nsysvol" + "\n"
 
 
+def test_target_cli_info(target_win: Target, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    # disable colorful output in `target-shell`
+    monkeypatch.setattr(fsutils, "LS_COLORS", {})
+
+    cli = TargetCli(target_win)
+    cli.onecmd("info")
+
+    captured = capsys.readouterr()
+    # Check if common keywords are present in output
+    assert all(key in captured.out for key in ["Hostname", "path", "Os"])
+
+
 @pytest.mark.parametrize(
     ("folders", "files", "save", "expected"),
     [


### PR DESCRIPTION
Fix for https://github.com/fox-it/dissect.target/issues/1355 and added a test case for the info command of target-shell.