### PR TITLE
Fix output LNK plugin

### DIFF
--- a/dissect/target/plugins/os/windows/lnk.py
+++ b/dissect/target/plugins/os/windows/lnk.py
@@ -168,7 +168,8 @@ class LnkPlugin(Plugin):
         for entry in self.lnk_entries(path):
             try:
                 lnk_file = Lnk(entry.open())
-                yield parse_lnk_file(self.target, lnk_file, entry)
+                if (lnk_rec := parse_lnk_file(self.target, lnk_file, entry)) is not None:
+                    yield lnk_rec
             except Exception as e:  # noqa: PERF203
                 self.target.log.warning("Failed to parse link file %s", entry)
                 self.target.log.debug("", exc_info=e)


### PR DESCRIPTION
`parse_lnk_file` returns `None` if `parse_lnk_file` is ` False`, but this is not handled by `lnk()`. This resulted in `rdump` errors.