### PR TITLE
Fix record cache test

### DIFF
--- a/tests/helpers/test_cache.py
+++ b/tests/helpers/test_cache.py
@@ -20,12 +20,12 @@ def test_cache_namespace(target_bare: Target) -> None:
 
     target_bare._config.CACHE_DIR = "/tmp"
     assert (
-        cache1.cache_path(target_bare, ("a", 1234)).name
-        == "dissect.target.plugins.os.windows.amcache.AmcachePlugin.__call__.KCdhJywgMTIzNCk=.zstd"
+        cache1.cache_path(target_bare, ("a", 1234)).stem
+        == "dissect.target.plugins.os.windows.amcache.AmcachePlugin.__call__.KCdhJywgMTIzNCk="
     )
     assert (
-        cache2.cache_path(target_bare, ("b", 5678)).name
-        == "dissect.target.plugins.os.windows.ual.UalPlugin.__call__.KCdiJywgNTY3OCk=.zstd"
+        cache2.cache_path(target_bare, ("b", 5678)).stem
+        == "dissect.target.plugins.os.windows.ual.UalPlugin.__call__.KCdiJywgNTY3OCk="
     )
 
 
@@ -43,18 +43,16 @@ def test_cache_filename(target_win: Target) -> None:
 
     target_win._config.CACHE_DIR = "/tmp"
     assert (
-        cache1.cache_path(target_win, ()).name
-        == "dissect.target.plugins.os.windows.amcache.AmcachePlugin.applications.KCk=.zstd"
+        cache1.cache_path(target_win, ()).stem
+        == "dissect.target.plugins.os.windows.amcache.AmcachePlugin.applications.KCk="
     )
     assert (
-        cache2.cache_path(target_win, ()).name
-        == "dissect.target.plugins.os.windows.ual.UalPlugin.client_access.KCk=.zstd"
+        cache2.cache_path(target_win, ()).stem == "dissect.target.plugins.os.windows.ual.UalPlugin.client_access.KCk="
     )
     assert (
-        cache3.cache_path(target_win, ()).name
-        == "dissect.target.plugins.os.windows.amcache.AmcachePlugin.applications.KCk=.zstd"
+        cache3.cache_path(target_win, ()).stem
+        == "dissect.target.plugins.os.windows.amcache.AmcachePlugin.applications.KCk="
     )
     assert (
-        cache4.cache_path(target_win, ()).name
-        == "dissect.target.plugins.os.windows.ual.UalPlugin.client_access.KCk=.zstd"
+        cache4.cache_path(target_win, ()).stem == "dissect.target.plugins.os.windows.ual.UalPlugin.client_access.KCk="
     )


### PR DESCRIPTION
The test was unnecessarily restrictive towards zstandard filenames. This is not needed. This now showed up because we merged https://github.com/fox-it/dissect.target/pull/1380, which removes the `zstandard` dependency. And because we pinned to an older version of `flow.record`, it now won't use zstandard files as default.

When we update the `flow.record` dependency to https://github.com/fox-it/flow.record/pull/198, all will be righteous again.