### PR TITLE
Fix for empty RepoTags keyword in manifest.json for containers

### DIFF
--- a/dissect/target/loaders/containerimage.py
+++ b/dissect/target/loaders/containerimage.py
@@ -61,7 +61,7 @@ class ContainerImageTarSubLoader(TarSubLoader):
         if self.tarfs.path("/manifest.json").exists():
             try:
                 self.manifest = json.loads(self.tarfs.path("/manifest.json").read_text())[0]
-                self.name = self.manifest.get("RepoTags", [None])[0]
+                self.name = (self.manifest.get("RepoTags") or [None])[0]
                 self.layers = [self.tarfs.path(p) for p in self.manifest.get("Layers", [])]
             except Exception as e:
                 raise ValueError(f"Unable to read manifest.json inside docker image filesystem: {e}") from e
@@ -70,6 +70,14 @@ class ContainerImageTarSubLoader(TarSubLoader):
                 self.config = json.loads(self.tarfs.path(self.manifest.get("Config")).read_text())
             except Exception as e:
                 raise ValueError(f"Unable to read config inside docker image filesystem: {e}") from e
+
+            # When self.name not set from "RepoTags" in manifest.json, try creating one from the "Config" json.
+            if self.config and not self.name:
+                labels = self.config.get("config", {}).get("Labels", {})
+                title = labels.get("org.opencontainers.image.title")
+                version = labels.get("org.opencontainers.image.version")
+                if title and version:
+                    self.name = f"{title}:{version}"
 
         # OCI spec only has index.json
         elif self.tarfs.path("/index.json").exists():


### PR DESCRIPTION
Aims to close https://github.com/fox-it/dissect.target/issues/1448

Also added some code to try to set self.name based on information from the Config json file using the `org.opencontainers.image.title` and `org.opencontainers.image.version` keywords in the designated Config json. 

But this last part is a bit optional.