### PR TITLE
Prevent target info crash

### DIFF
--- a/dissect/target/tools/info.py
+++ b/dissect/target/tools/info.py
@@ -132,7 +132,8 @@ def get_property(target: Target, func: str) -> str | None:
         if target.has_function(func):
             return getattr(target, func)
     except Exception as e:
-        log.warning("Error executing %s : %s", str(func), e)
+        log.warning("Error executing %s: %s", func, e)
+        log.debug("", exc_info=e)
     return None
 
 
@@ -169,7 +170,8 @@ def catch_errors(func: Callable[[Target], list[dict]]) -> Callable[[Target], lis
         try:
             return func(*args, **kwargs)
         except Exception as e:
-            log.warning("Error executing %s: %s", str(func), e)
+            log.warning("Error executing %s: %s", func.__name__, e)
+            log.debug("", exc_info=e)
             return [{"error": str(e)}]
 
     return wrapper

--- a/tests/tools/test_info.py
+++ b/tests/tools/test_info.py
@@ -58,6 +58,7 @@ def test_target_info(
 def test_target_info_with_exception(
     capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch, output_type: str, options: list
 ) -> None:
+    """Test target-info on a target that raises exceptions in some properties."""
     with monkeypatch.context() as m:
         m.setattr(
             "sys.argv",


### PR DESCRIPTION
Wrap every function call within target info with a try catch. This allows to ensure that even if one plugin crash for an unknown reason, target info will produces information

On exemple is running `uv run --extra full target-info -r tests/_data/loaders/acquire/test-windows-fs-c-absolute.tar` on the current branch. 
* closes #1463 