### PR TITLE
Fix DirLoader

### DIFF
--- a/dissect/target/loaders/dir.py
+++ b/dissect/target/loaders/dir.py
@@ -27,7 +27,10 @@ class DirLoader(Loader):
         return find_entry_path(path) is not None
 
     def map(self, target: Target) -> None:
-        path = self.absolute_path.joinpath(find_entry_path(self.absolute_path))
+        if (entry_path := find_entry_path(self.absolute_path)):
+            path = self.absolute_path.joinpath(entry_path)
+        else:
+            path = self.absolute_path
         find_and_map_dirs(target, path)
 
 


### PR DESCRIPTION
https://github.com/fox-it/dissect.target/pull/1106 seems to have broken default DirLoader behavior. This PR attempts to fix that.

```
$ tree foo
foo
└── test dir
    ├── another test dir
    └── file.txt
```

```
# before
$ target-shell dir://foo
2026-01-08T14:46:56.840760Z [error    ] dir://foo: Failed to load target with loader DirLoader('foo') [dissect.target.target]
2026-01-08T14:46:56.840922Z [error    ] Error opening shell: Failed to find any loader for targets: ['dir://foo'] [dissect.target.tools.shell]
$ 

# after
$ target-shell dir://foo
2026-01-08T14:46:11.536849Z [warning  ] <Target foo>: Failed to find OS plugin, falling back to default [dissect.target.target]
foo:/$ 
```

Also `DirLoader` detection seems broken (`target-shell foo` does not work), but that might be intentional?