### PR TITLE
Fix typo in Registry RunKey value for auto-start

### DIFF
--- a/dissect/target/plugins/os/windows/regf/runkeys.py
+++ b/dissect/target/plugins/os/windows/regf/runkeys.py
@@ -32,7 +32,7 @@ class RunKeysPlugin(Plugin):
         "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
         "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\RunOnce",
         "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\RunOnce\\Setup",
-        "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\RunOnceE",
+        "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\RunOnceEx",
         "HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Run",
         "HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\RunOnce",
         "HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\RunOnce\\Setup",


### PR DESCRIPTION
This MR corrects a syntax error in the Windows Registry RunKey path. A missing character in the key string was preventing the application from registering correctly for startup persistence.