### PR TITLE
POC: Implement artifact spec

### DIFF
--- a/dissect/target/artifact_spec.py
+++ b/dissect/target/artifact_spec.py
@@ -1,4 +1,8 @@
 from collections.abc import Iterator
+from pathlib import Path
+
+from dissect.target import Target
+from dissect.target.plugins.general.users import UserRecord
 
 
 class Artifact:
@@ -6,7 +10,7 @@ class Artifact:
     An artifact is a specific location of a forensic artifact, including related metadata
     """
 
-    def __init__(self, path, user=None):
+    def __init__(self, path: Path, user: UserRecord = None):
         self.path = path
         self.user = user
 
@@ -16,17 +20,17 @@ class Spec:
     A spec is a definition of artifact locations
     """
 
-    def __init__(self, glob_list, from_user_home=False):
+    def __init__(self, glob_list: tuple, from_user_home: bool = False):
         self.glob_list = glob_list
         self._from_user_home = from_user_home
 
-    def get_artifacts(self, target) -> Iterator[Artifact]:
+    def get_artifacts(self, target: Target) -> Iterator[Artifact]:
         for glob in self.glob_list:
             if self._from_user_home:
                 for user_details in target.user_details.all_with_home():
                     user_glob = user_details.home_path.joinpath(glob).as_posix()
                     for path in target.fs.path().glob(user_glob):
-                        yield Artifact(path,user=user_details.user)
+                        yield Artifact(path, user=user_details.user)
             else:
                 for path in target.fs.path().glob(glob):
                     yield Artifact(path)

--- a/dissect/target/plugins/apps/remoteaccess/anydesk.py
+++ b/dissect/target/plugins/apps/remoteaccess/anydesk.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from dissect.target.artifact_spec import Spec
 from dissect.target.exceptions import UnsupportedPluginError
@@ -25,47 +25,57 @@ class AnydeskPlugin(RemoteAccessPlugin):
     __namespace__ = "anydesk"
 
     # Anydesk logs when installed as a service
-    SERVICE_GLOBS = Spec((
-        # Standard client >= Windows 7
-        "sysvol/ProgramData/AnyDesk/*.trace",
-        # Custom client >= Windows 7
-        "sysvol/ProgramData/AnyDesk/ad_*/*.trace",
-        # Windows XP / 2003
-        "sysvol/Documents and Settings/Public/AnyDesk/*.trace",
-        "sysvol/Documents and Settings/Public/AnyDesk/ad_*/*.trace",
-        # Standard/Custom client Linux/MacOS
-        "var/log/anydesk*/*.trace",
-    ))
+    SERVICE_GLOBS = Spec(
+        (
+            # Standard client >= Windows 7
+            "sysvol/ProgramData/AnyDesk/*.trace",
+            # Custom client >= Windows 7
+            "sysvol/ProgramData/AnyDesk/ad_*/*.trace",
+            # Windows XP / 2003
+            "sysvol/Documents and Settings/Public/AnyDesk/*.trace",
+            "sysvol/Documents and Settings/Public/AnyDesk/ad_*/*.trace",
+            # Standard/Custom client Linux/MacOS
+            "var/log/anydesk*/*.trace",
+        )
+    )
 
     # Anydesk Filetransfer logs when installed as a service
-    FILETRANSFER_SERVICE_LOGS = Spec((
-        # File transfer service log
-        "sysvol/ProgramData/AnyDesk/file_transfer_trace.txt",
-    ))
+    FILETRANSFER_SERVICE_LOGS = Spec(
+        (
+            # File transfer service log
+            "sysvol/ProgramData/AnyDesk/file_transfer_trace.txt",
+        )
+    )
 
     # User specific Anydesk filetransfer log
-    FILETRANSFER_USER_LOGS = Spec((
-        # File transfer log
-        "AppData/Roaming/AnyDesk/file_transfer_trace.txt",
-    ), from_user_home=True)
+    FILETRANSFER_USER_LOGS = Spec(
+        (
+            # File transfer log
+            "AppData/Roaming/AnyDesk/file_transfer_trace.txt",
+        ),
+        from_user_home=True,
+    )
 
     # User specific Anydesk logs
-    USER_GLOBS = Spec((
-        # Standard client Windows
-        "AppData/Roaming/AnyDesk/*.trace",
-        # Custom client Windows
-        "AppData/Roaming/AnyDesk/ad_*/*.trace",
-        # Windows XP / 2003
-        "AppData/AnyDesk/*.trace",
-        # Standard client Linux/MacOS
-        ".anydesk/*.trace",
-        # Custom client Linux/MacOS
-        ".anydesk_ad_*/*.trace",
-    ), from_user_home=True)
+    USER_GLOBS = Spec(
+        (
+            # Standard client Windows
+            "AppData/Roaming/AnyDesk/*.trace",
+            # Custom client Windows
+            "AppData/Roaming/AnyDesk/ad_*/*.trace",
+            # Windows XP / 2003
+            "AppData/AnyDesk/*.trace",
+            # Standard client Linux/MacOS
+            ".anydesk/*.trace",
+            # Custom client Linux/MacOS
+            ".anydesk_ad_*/*.trace",
+        ),
+        from_user_home=True,
+    )
 
-    __spec__ = {
-        'trace_files': [SERVICE_GLOBS, USER_GLOBS],
-        'filetransfer_files': [FILETRANSFER_SERVICE_LOGS, FILETRANSFER_USER_LOGS]
+    __spec__: ClassVar[dict[str, list[Spec]]] = {
+        "trace_files": [SERVICE_GLOBS, USER_GLOBS],
+        "filetransfer_files": [FILETRANSFER_SERVICE_LOGS, FILETRANSFER_USER_LOGS],
     }
 
     RemoteAccessLogRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
@@ -77,7 +87,7 @@ class AnydeskPlugin(RemoteAccessPlugin):
     )
 
     def check_compatible(self) -> None:
-        if not self.artifacts.get('trace_files') and not self.artifacts.get('filetransfer_files'):
+        if not self.artifacts.get("trace_files") and not self.artifacts.get("filetransfer_files"):
             raise UnsupportedPluginError("No Anydesk files found on target")
 
     @export(record=RemoteAccessLogRecord)


### PR DESCRIPTION
This PR adds a POC for defining needed artifacts as artifact spec (with a bit of inspiration from acquire). Currently multiple plugins have a repetative pattern of loading related artifacts which can be handled by `Plugin` after this PR. Furtheremore this makes it possible to have acquire collect everything that is parsed by target, without the need to specify the spec on both sides. 

This PR adds a `__spec__` attribute to each plugin. This property is then used to collect all the needed artifacts from the target, and can be obtained by the plugins by using the new `artifacts` property. This way it is no longer needed to obtain the relevant files within the `__init__`.  

Currently there is already `Plugin.get_paths()` which is aimed to return all the relevant paths for a certain plugin. However, if we would use this in acquire we loose the option to log that we aimed to collect a certain file but it's not present. Acquire simply does not have the information about which paths are checked. After this PR we can use `__spec__` as spec definition within Acquire.

For now I only implemented it for the Anydesk plugin, mainly since I wanted to know if this is a way in which we want to move forward. Tests, and further implementation can follow but since this touches the base of Plugin it might be good to have some discussion first. 

Relates to #1082 and #1487
