### PR TITLE
Use the target path type inside walkfs.py

### DIFF
--- a/dissect/target/plugins/filesystem/walkfs.py
+++ b/dissect/target/plugins/filesystem/walkfs.py
@@ -145,7 +145,7 @@ def generate_record(
         "ctime": from_unix(entry_stat.st_ctime),
         "btime": from_unix(entry_stat.st_birthtime) if entry_stat.st_birthtime else None,
         "ino": entry_stat.st_ino,
-        "path": target.fs.path(entry.path),
+        "path": entry.path,
         "size": entry_stat.st_size,
         "mode": entry_stat.st_mode,
         "uid": entry_stat.st_uid,

--- a/tests/plugins/filesystem/test_walkfs.py
+++ b/tests/plugins/filesystem/test_walkfs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import itertools
+import platform
 import stat
 from io import BytesIO
 from pathlib import Path
@@ -57,7 +58,8 @@ def test_walkfs_plugin(target_unix: Target, fs_unix: VirtualFilesystem) -> None:
     assert results[2].type == "symlink"
     assert results[3].type == "file"
 
-    assert {str(r.path): r.mimetype for r in results if r.mimetype} == {
+    separator = "\\" if platform.system() == "Windows" else ""
+    assert {fsutil.normalize(str(r.path), alt_separator=separator): r.mimetype for r in results if r.mimetype} == {
         "/.test/.more.test.symlink.txt": "text/plain",  # inferred by txt extension
         "/.test/.more.test.txt": "text/plain",  # inferred by txt extension
         "/.test/test.txt": "text/plain",  # inferred by txt extension


### PR DESCRIPTION
It autmatically detected windows_path on the windows runners
this caused test_walkfs_plugin to fail on windows machines

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
