### PR TITLE
Mount WinRE if present on target

### DIFF
--- a/dissect/target/plugins/os/windows/_os.py
+++ b/dissect/target/plugins/os/windows/_os.py
@@ -56,10 +56,17 @@ class WindowsPlugin(OSPlugin):
         target.fs.alt_separator = "\\"
         target.fs.mount("sysvol", sysvol)
 
+        # Mount EFI
         if not sysvol.exists("boot/BCD"):
             for fs in target.filesystems:
                 if fs.exists("boot/BCD") or fs.exists("EFI/Microsoft/Boot/BCD"):
                     target.fs.mount("efi", fs)
+
+        # Mount WinRE
+        if not sysvol.exists("winre/Recovery/WindowsRE"):
+            for fs in target.filesystems:
+                if fs.exists("Recovery/WindowsRE"):
+                    target.fs.mount("winre", fs)
 
         return cls(target)
 


### PR DESCRIPTION
This PR makes sure the Windows Recovery Environment (WinRE) partition is mounted to `/winre` if such a partition is present on the target.