### PR TITLE
Add link field to walkfs plugin docstring

### DIFF
--- a/dissect/target/plugins/filesystem/walkfs.py
+++ b/dissect/target/plugins/filesystem/walkfs.py
@@ -81,6 +81,7 @@ class WalkFsPlugin(Plugin):
             btime (datetime): birth timestamp indicates the time when a file was created.
             ino (varint): number of the corresponding underlying filesystem inode.
             path (path): path location of the entry.
+            link (path): if the entry is a symlink, the target of the symlink.
             size (filesize): size of the file in bytes on the filesystem.
             mode (uint32): contains the file type and mode.
             uid (uint32): the user id of the owner of the entry.


### PR DESCRIPTION
I forgot to add the `link` field to the walkfs plugin docstring. #1608 

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
