### PR TITLE
Improve parsing of plugin arguments in target-query

### DIFF
--- a/dissect/target/plugins/filesystem/ntfs/mft.py
+++ b/dissect/target/plugins/filesystem/ntfs/mft.py
@@ -156,7 +156,6 @@ class MftPlugin(Plugin):
     )
     @arg(
         "--compact",
-        group="fmt",
         action="store_true",
         help="compacts the MFT entry timestamps into a single record",
     )
@@ -165,7 +164,6 @@ class MftPlugin(Plugin):
     @arg("--end", type=int, default=-1, help="the last MFT segment number")
     @arg(
         "--macb",
-        group="fmt",
         action="store_true",
         help="compacts MFT timestamps into MACB bitfield (format: MACB[standard|ads]/MACB[filename])",
     )

--- a/dissect/target/plugins/filesystem/walkfs.py
+++ b/dissect/target/plugins/filesystem/walkfs.py
@@ -50,7 +50,7 @@ class WalkFsPlugin(Plugin):
             raise UnsupportedPluginError("No filesystems to walk")
 
     @export(record=FilesystemRecord)
-    @arg("--walkfs-path", default="/", help="path to recursively walk")
+    @arg("-p", "--walkfs-path", default="/", help="path to recursively walk")
     @arg("--capability", action="store_true", help="output capability records")
     @arg("--mimetype", action="store_true", help="enable mimetype lookup of files")
     def walkfs(

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -71,8 +71,10 @@ def main() -> int:
         fromfile_prefix_chars="@",
         formatter_class=help_formatter,
         add_help=False,
+        conflict_handler="resolve",
     )
     parser.add_argument("targets", metavar="TARGETS", nargs="*", help="Targets to load")
+    parser.add_argument("-h", "--help", action="store_true", help="show this help message and exit")
     parser.add_argument("--direct", action="store_true", help="treat TARGETS as paths to pass to plugins directly")
 
     configure_plugin_arguments(parser)
@@ -113,10 +115,31 @@ def main() -> int:
 
     args, rest = parser.parse_known_args()
 
-    # Show help for target-query
-    if not args.function and ("-h" in rest or "--help" in rest):
+    # Show help for target-query (when --help is specified without a function)
+    if not args.function and args.help:
         parser.print_help()
         return 0
+
+    # Dynamically add plugin arguments for the specified function(s)
+    for func_desc in find_and_filter_plugins(
+        functions=args.function or "",
+        target=None,
+        excluded_func_paths=args.excluded_functions,
+    ):
+        plugin_args = func_desc.args
+        for arg in plugin_args:
+            opts, kwargs = arg
+            kwargs.pop("group", None)  # Remove 'group' if it exists, as this is a special argument used in dissect.
+            parser.add_argument(*opts, **kwargs)
+
+    # Re-parse arguments now that requested plugin arguments have been added.
+    # Unknown args will automatically be shown to the user here to catch any misspelled or invalid arguments early on.
+    args = parser.parse_args()
+
+    # Propagate --help argument to plugin to show the help message of the plugin.
+    rest = []
+    if args.help:
+        rest.append("--help")
 
     process_generic_arguments(parser, args)
 

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -127,9 +127,9 @@ def main() -> int:
         excluded_func_paths=args.excluded_functions,
     ):
         plugin_args = func_desc.args
-        for arg in plugin_args:
-            opts, kwargs = arg
-            kwargs.pop("group", None)  # Remove 'group' if it exists, as this is a special argument used in dissect.
+        for opts, kwargs in plugin_args:
+            # Skip 'group' if it exists, as this is a special argument used in dissect.
+            kwargs = {k: v for k, v in kwargs.items() if k != "group"}
             parser.add_argument(*opts, **kwargs)
 
     # Re-parse arguments now that requested plugin arguments have been added.

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -125,6 +125,7 @@ def main() -> int:
         functions=args.function or "",
         target=None,
         excluded_func_paths=args.excluded_functions,
+        plugin_paths=args.plugin_path or [],
     ):
         plugin_args = func_desc.args
         for opts, kwargs in plugin_args:

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -128,8 +128,6 @@ def main() -> int:
     ):
         plugin_args = func_desc.args
         for opts, kwargs in plugin_args:
-            # Skip 'group' if it exists, as this is a special argument used in dissect.
-            kwargs = {k: v for k, v in kwargs.items() if k != "group"}
             parser.add_argument(*opts, **kwargs)
 
     # Re-parse arguments now that requested plugin arguments have been added.

--- a/dissect/target/tools/utils/cli.py
+++ b/dissect/target/tools/utils/cli.py
@@ -494,8 +494,20 @@ def args_to_uri(targets: list[str], loader_name: str, args: list[str] | None = N
 
 
 def find_and_filter_plugins(
-    functions: str, target: Target, excluded_func_paths: set[str] | None = None
+    functions: str,
+    target: Target,
+    excluded_func_paths: set[str] | None = None,
+    plugin_paths: list[Path] | None = None,
 ) -> Iterator[FunctionDescriptor]:
+    """Find and filter plugins for the given functions and target.
+
+    If ``plugin_paths`` are provided, they are loaded before plugin discovery
+    to ensure external plugins are included in the results.
+    """
+    if plugin_paths:
+        paths = get_external_module_paths(plugin_paths)
+        load_modules_from_paths(paths)
+
     # Keep a set of plugins that were already executed on the target.
     executed_plugins = set()
     excluded_func_paths = excluded_func_paths or set()

--- a/dissect/target/tools/utils/cli.py
+++ b/dissect/target/tools/utils/cli.py
@@ -344,7 +344,8 @@ def generate_argparse_for_method(
     help_formatter = argparse.RawDescriptionHelpFormatter
     parser = argparse.ArgumentParser(description=desc, formatter_class=help_formatter, conflict_handler="resolve")
 
-    _add_args_to_parser(parser, getattr(method, "__args__", []))
+    for args, kwargs in getattr(method, "__args__", []):
+        parser.add_argument(*args, **kwargs)
 
     usage = parser.format_usage()
     offset = usage.find(parser.prog) + len(parser.prog)
@@ -369,7 +370,8 @@ def generate_argparse_for_plugin_class(
     help_formatter = argparse.RawDescriptionHelpFormatter
     parser = argparse.ArgumentParser(description=desc, formatter_class=help_formatter, conflict_handler="resolve")
 
-    _add_args_to_parser(parser, getattr(plugin_cls.__call__, "__args__", []))
+    for args, kwargs in getattr(plugin_cls.__call__, "__args__", []):
+        parser.add_argument(*args, **kwargs)
 
     usage = parser.format_usage()
     offset = usage.find(parser.prog) + len(parser.prog)
@@ -392,27 +394,6 @@ def generate_argparse_for_plugin(
         raise ValueError(f"Plugin `{plugin_instance}` is not a namespace plugin and is not callable")
 
     return generate_argparse_for_plugin_class(plugin_instance.__class__, usage_tmpl=usage_tmpl)
-
-
-def _add_args_to_parser(
-    parser: argparse.ArgumentParser,
-    fargs: list[tuple[list[str], dict[str, Any]]],
-) -> None:
-    groups = {}
-    default_group_options = {"required": False}
-    for args, kwargs in fargs:
-        if "group" in kwargs:
-            group_name = kwargs.pop("group")
-            options = kwargs.pop("group_options") if "group_options" in kwargs else default_group_options
-            if group_name not in groups:
-                group = parser.add_mutually_exclusive_group(**options)
-                groups[group_name] = group
-            else:
-                group = groups[group_name]
-
-            group.add_argument(*args, **kwargs)
-        else:
-            parser.add_argument(*args, **kwargs)
 
 
 def execute_function_on_target(

--- a/tests/tools/test_query.py
+++ b/tests/tools/test_query.py
@@ -562,8 +562,8 @@ def test_plugin_argument_handling(capsys: pytest.CaptureFixture, monkeypatch: py
         target_query()
 
     out, _ = capsys.readouterr()
-    assert "path='/path/to/symlink/target'" in out
-    assert "path='/path/to/symlink'" in out
+    assert "ino=14" in out
+    assert "ino=15" in out
     assert len(out.splitlines()) == 2
 
 

--- a/tests/tools/test_query.py
+++ b/tests/tools/test_query.py
@@ -4,7 +4,7 @@ import contextlib
 import json
 import re
 from typing import TYPE_CHECKING, Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -220,7 +220,21 @@ def mock_execute_function(
     return (func.output, func.name)
 
 
-def test_filtered_functions(monkeypatch: pytest.MonkeyPatch) -> None:
+@patch("dissect.target.plugin.PLUGINS", new_callable=PluginRegistry)
+def test_filtered_functions(mock_plugins: PluginRegistry, monkeypatch: pytest.MonkeyPatch) -> None:
+    class MockQueryArgsPlugin(Plugin):
+        def check_compatible(self) -> None:
+            pass
+
+        @export(output="none")
+        @arg("-j", "--json", action="store_true")
+        @arg("--compact", action="store_true")
+        def mock_function(self, json: bool, compact: bool) -> None:
+            pass
+
+    def mock_query_plugin_args() -> list[tuple[list[str], dict[str, Any]]]:
+        return getattr(MockQueryArgsPlugin(MagicMock()).mock_function, "__args__", [])
+
     with monkeypatch.context() as m:
         m.setattr(
             "sys.argv",
@@ -235,6 +249,12 @@ def test_filtered_functions(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
         with (
+            patch.object(
+                FunctionDescriptor,
+                "args",
+                new_callable=PropertyMock,
+                side_effect=mock_query_plugin_args,
+            ),
             patch(
                 "dissect.target.tools.utils.cli.find_functions",
                 autospec=True,
@@ -441,6 +461,9 @@ def test_arguments_passed_correctly(
             assert json is True
             assert compact is True
 
+    def mock_query_plugin_args() -> list[tuple[list[str], dict[str, Any]]]:
+        return getattr(MockPlugin(MagicMock()).mock_function, "__args__", [])
+
     with monkeypatch.context() as m:
         m.setattr(
             "sys.argv",
@@ -454,6 +477,12 @@ def test_arguments_passed_correctly(
         )
 
         with (
+            patch.object(
+                FunctionDescriptor,
+                "args",
+                new_callable=PropertyMock,
+                side_effect=mock_query_plugin_args,
+            ),
             patch(
                 "dissect.target.tools.utils.cli.find_functions",
                 autospec=True,
@@ -511,3 +540,53 @@ def test_direct_mode(capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPa
         target_query()
         out, _ = capsys.readouterr()
     assert len(out.splitlines()) == 3
+
+
+def test_plugin_argument_handling(capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test argument handling of target-query for a plugin with arguments."""
+    with monkeypatch.context() as m:
+        m.setattr(
+            "sys.argv",
+            [
+                "target-query",
+                "-q",
+                "-s",  # output as text records
+                "-f",
+                "walkfs",
+                "--walkfs-path",
+                "/path/to/symlink",
+                str(absolute_path("_data/filesystems/symlink_disk.ext4")),
+            ],
+        )
+
+        target_query()
+
+    out, _ = capsys.readouterr()
+    assert "path='/path/to/symlink/target'" in out
+    assert "path='/path/to/symlink'" in out
+    assert len(out.splitlines()) == 2
+
+
+def test_plugin_argument_unknown(capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that unknown plugin arguments are caught and logged."""
+    with monkeypatch.context() as m:
+        m.setattr(
+            "sys.argv",
+            [
+                "target-query",
+                "-q",
+                "-s",  # output as text records
+                "-f",
+                "walkfs,yara",
+                "--some-unknown-arg=/usr/local/bin",
+                "--rules",
+                str(absolute_path("tests/_data/plugins/filesystem/yara/rule-dir/rule.yar")),
+                str(absolute_path("_data/filesystems/symlink_disk.ext4")),
+            ],
+        )
+
+        with pytest.raises(SystemExit):
+            target_query()
+
+    _, err = capsys.readouterr()
+    assert "error: unrecognized arguments: --some-unknown-arg" in err

--- a/tests/tools/test_query.py
+++ b/tests/tools/test_query.py
@@ -555,15 +555,17 @@ def test_plugin_argument_handling(capsys: pytest.CaptureFixture, monkeypatch: py
                 "walkfs",
                 "--walkfs-path",
                 "/path/to/symlink",
-                str(absolute_path("_data/filesystems/symlink_disk.ext4")),
+                str(absolute_path("_data/filesystems/filesystem.ext4")),
             ],
         )
 
         target_query()
 
-    out, _ = capsys.readouterr()
+    out, _err = capsys.readouterr()
+
+    # We expect these two inodes in /path/to/symlink
     assert "ino=14" in out
-    assert "ino=15" in out
+    assert "ino=16" in out
     assert len(out.splitlines()) == 2
 
 
@@ -581,7 +583,7 @@ def test_plugin_argument_unknown(capsys: pytest.CaptureFixture, monkeypatch: pyt
                 "--some-unknown-arg=/usr/local/bin",
                 "--rules",
                 str(absolute_path("tests/_data/plugins/filesystem/yara/rule-dir/rule.yar")),
-                str(absolute_path("_data/filesystems/symlink_disk.ext4")),
+                str(absolute_path("_data/filesystems/filesystem.ext4")),
             ],
         )
 

--- a/tests/tools/utils/test_cli.py
+++ b/tests/tools/utils/test_cli.py
@@ -14,7 +14,6 @@ from dissect.target.tools.utils.cli import (
     args_to_uri,
     configure_generic_arguments,
     execute_function_on_target,
-    generate_argparse_for_method,
     persist_execution_report,
     process_generic_arguments,
 )

--- a/tests/tools/utils/test_cli.py
+++ b/tests/tools/utils/test_cli.py
@@ -152,20 +152,6 @@ def test_plugin_name_confusion_regression(target_unix_users: Target, pattern: st
     assert expected_function in str(exc_info.value)
 
 
-def test_plugin_mutual_exclusive_arguments() -> None:
-    fargs = [
-        (("--aa",), {"group": "aa"}),
-        (("--bb",), {"group": "aa"}),
-        (("--cc",), {"group": "bb"}),
-        (("--dd",), {"group": "bb"}),
-    ]
-    method = test_plugin_mutual_exclusive_arguments
-    method.__args__ = fargs
-    with patch("inspect.isfunction", return_value=True):
-        parser = generate_argparse_for_method(method)
-    assert len(parser._mutually_exclusive_groups) == 2
-
-
 def test_namespace_plugin_args() -> None:
     class Fake(Plugin):
         __namespace__ = "fake"


### PR DESCRIPTION
This PR implements the suggested solution described in #1508, the described edgecase is left open.

It mainly gets the supported argparse arguments from the requested plugins to `target-query`, and then reparses the arguments again so it properly parses known plugin flags. This essentially fixes the problem described in the issue.

Unknown arguments/flags now also throw an error, which before would go unnoticed.

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
resolves #1508, #1362