### PR TITLE
Fix deprecation warning for structlog

### DIFF
--- a/dissect/target/tools/utils/logging.py
+++ b/dissect/target/tools/utils/logging.py
@@ -46,7 +46,7 @@ def configure_logging(verbose_value: int, be_quiet: bool, as_plain_text: bool = 
     """
     styles = structlog.dev.ConsoleRenderer.get_default_level_styles()
     renderer = (
-        structlog.dev.ConsoleRenderer(colors=True, pad_event=10, level_styles=styles)
+        structlog.dev.ConsoleRenderer(colors=True, pad_event_to=10, level_styles=styles)
         if as_plain_text
         else structlog.processors.JSONRenderer(sort_keys=True)
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "dissect.util>=3,<4",
     "dissect.volume>=3.17,<4",
     "flow.record~=3.21.0",
-    "structlog",
+    "structlog>=25.5.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request. Please:

* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Associate the PR with an issue. If it doesn't exist, create it. Use 
  closing keywords in the body during creation, e.g.:
    * close(|s|d) #<nr>
    * fix(|es|ed) #<nr>
    * resolve(|s|d) #<nr>
-->


# Fix deprecation warning structlog

Structlog deprecated pad_event, where the new one is pad_event_to

## Proposed Changes

Pin structlog to use the newer version where `pad_event_to` is added
Replace `pad_event` with `pad_event_to`.

