### PR TITLE
Fix TypeError when extracting KB from title

### DIFF
--- a/dissect/target/plugins/os/windows/wua_history.py
+++ b/dissect/target/plugins/os/windows/wua_history.py
@@ -1064,7 +1064,7 @@ class WuaHistoryPlugin(Plugin):
             format_data["classification_mapped"] = CLASSIFICATION_MAP.get(value, "Unknown")
         elif mapped_column_name == "title":
             if isinstance(value,(bytes, bytearray)):
-                value = value.decode(errors="ignore")
+                value = bytes(value).decode(errors="ignore")
             format_data[mapped_column_name] = value
             if kb := re.search(r"(KB.[0-9]*)", value):
                 format_data["kb"] = kb.group(1)        


### PR DESCRIPTION
In some cases the title value in wua_history can be returned as
bytes instead of str. This causes re.search to raise a
TypeError when attempting to extract KB identifiers.

This change ensures the value is decoded to str before applying the
regex, preventing the crash. Fixes #1414. 

Additionally, the KB regex was tightened to match valid KB identifiers
(KB\d+) instead of allowing arbitrary characters.

Proposed Changes
	•	Decode value to str when it is bytes in the title field
	•	Update regex from (KB.[0-9]*) to (KB\d+)
	•	Use group(1) to extract the KB identifier

How to test
	•	Run: dissect.target <image> -p windows.wua_history
	•	Ensure no TypeError is raised when processing records
	•	Verify KB identifiers are still correctly extracted from titles


