### PR TITLE
[POC]: loader args decoupled

### DIFF
--- a/dissect/target/loader.py
+++ b/dissect/target/loader.py
@@ -68,8 +68,7 @@ class Loader:
     """
 
     def __init__(
-        self, path: Path, *, parsed_path: urllib.parse.ParseResult | None = None, resolve: bool = True,
-        **kwargs
+        self, path: Path, *, parsed_path: urllib.parse.ParseResult | None = None, resolve: bool = True, **kwargs
     ):
         self.path = path
         self.absolute_path = None
@@ -150,7 +149,7 @@ class Loader:
         # Pass the parsed options directly to the implementation map function
         return self._map(target, **vars(loader_options))
 
-    def _map(self) -> None:
+    def _map(self, **kwargs) -> None:
         """Maps the loaded path into a ``Target``.
 
         Args:

--- a/dissect/target/loader.py
+++ b/dissect/target/loader.py
@@ -94,6 +94,7 @@ class Loader:
     @staticmethod
     def _create_parser(cls: type[Loader]) -> argparse.ArgumentParser:
         """Creates the argument parser for this loader."""
+        # Do like generate_argparse_for_method in cli.py
         parser = argparse.ArgumentParser(
             prog=f"loader:{cls.__name__.lower()}",
             description=f"Options for the '{cls.__name__}' loader.",

--- a/dissect/target/loader.py
+++ b/dissect/target/loader.py
@@ -149,7 +149,7 @@ class Loader:
         # Pass the parsed options directly to the implementation map function
         return self._map(target, **vars(loader_options))
 
-    def _map(self, **kwargs) -> None:
+    def _map(self, target: Target, **kwargs) -> None:
         """Maps the loaded path into a ``Target``.
 
         Args:

--- a/dissect/target/loader.py
+++ b/dissect/target/loader.py
@@ -69,7 +69,7 @@ class Loader:
 
     def __init__(
         self, path: Path, *, parsed_path: urllib.parse.ParseResult | None = None, resolve: bool = True,
-        loader_args: list[str] | None = None, **kwargs
+        **kwargs
     ):
         self.path = path
         self.absolute_path = None
@@ -84,19 +84,25 @@ class Loader:
         self.parsed_query = (
             dict(urllib.parse.parse_qsl(parsed_path.query, keep_blank_values=True)) if parsed_path else {}
         )
-        self.loader_args = loader_args or []
 
-        self._parser = argparse.ArgumentParser(
-            prog=f"loader:{self.__class__.__name__.lower()}",
-            description=f"Options for the '{self.__class__.__name__}' loader.",
+        self._parser = self._create_parser(self.__class__)
+
+    @classmethod
+    def print_help(cls) -> None:
+        """Prints the help message for this loader's specific arguments."""
+        cls._create_parser(cls).print_help()
+
+    @staticmethod
+    def _create_parser(cls: type[Loader]) -> argparse.ArgumentParser:
+        """Creates the argument parser for this loader."""
+        parser = argparse.ArgumentParser(
+            prog=f"loader:{cls.__name__.lower()}",
+            description=f"Options for the '{cls.__name__}' loader.",
             add_help=False,
         )
-        for args, kwargs in  getattr(self, "__args__", []):
-            self._parser.add_argument(*args, **kwargs)
-
-    def print_help(self) -> None:
-        """Prints the help message for this loader's specific arguments."""
-        self._parser.print_help()
+        for args, kwargs in getattr(cls, "__args__", []):
+            parser.add_argument(*args, **kwargs)
+        return parser
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({str(self.path)!r})"
@@ -132,8 +138,8 @@ class Loader:
 
     def map(self, target: Target) -> None:
         """Wrapper around the _map function that handles argument passing."""
-        # The loader now parses its own arguments
-        loader_options = self._parser.parse_args(self.loader_args)
+        # The loader parses its own arguments from argv
+        loader_options, _ = self._parser.parse_known_args()
 
         # The query string can act as a default for any arguments not provided on the command line
         for key, value in self.parsed_query.items():

--- a/dissect/target/loader.py
+++ b/dissect/target/loader.py
@@ -68,13 +68,7 @@ class Loader:
     """
 
     def __init__(
-        self,
-        path: Path,
-        *,
-        parsed_path: urllib.parse.ParseResult | None = None,
-        resolve: bool = True,
-        loader_kwargs: dict | None = None,
-        **kwargs,
+        self, path: Path, *, parsed_path: urllib.parse.ParseResult | None = None, resolve: bool = True, **kwargs
     ):
         self.path = path
         self.absolute_path = None
@@ -89,7 +83,6 @@ class Loader:
         self.parsed_query = (
             dict(urllib.parse.parse_qsl(parsed_path.query, keep_blank_values=True)) if parsed_path else {}
         )
-        self._loader_kwargs = loader_kwargs or {}
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({str(self.path)!r})"
@@ -125,19 +118,6 @@ class Loader:
 
     def map(self, target: Target) -> None:
         """Maps the loaded path into a ``Target``.
-
-        Delegates to :meth:`_map` with any loader-specific keyword arguments set at instantiation time.
-
-        Args:
-            target: The target that we're mapping into.
-        """
-        return self._map(target, **self._loader_kwargs)
-
-    def _map(self, target: Target, **kwargs) -> None:
-        """Implementation hook for :meth:`map`.
-
-        Subclasses that accept loader-specific arguments (declared via ``@arg`` decorators)
-        should override this method instead of :meth:`map`.
 
         Args:
             target: The target that we're mapping into.

--- a/dissect/target/loader.py
+++ b/dissect/target/loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import os
 import urllib.parse
 from pathlib import Path
@@ -67,7 +68,8 @@ class Loader:
     """
 
     def __init__(
-        self, path: Path, *, parsed_path: urllib.parse.ParseResult | None = None, resolve: bool = True, **kwargs
+        self, path: Path, *, parsed_path: urllib.parse.ParseResult | None = None, resolve: bool = True,
+        loader_args: list[str] | None = None, **kwargs
     ):
         self.path = path
         self.absolute_path = None
@@ -82,6 +84,19 @@ class Loader:
         self.parsed_query = (
             dict(urllib.parse.parse_qsl(parsed_path.query, keep_blank_values=True)) if parsed_path else {}
         )
+        self.loader_args = loader_args or []
+
+        self._parser = argparse.ArgumentParser(
+            prog=f"loader:{self.__class__.__name__.lower()}",
+            description=f"Options for the '{self.__class__.__name__}' loader.",
+            add_help=False,
+        )
+        for args, kwargs in  getattr(self, "__args__", []):
+            self._parser.add_argument(*args, **kwargs)
+
+    def print_help(self) -> None:
+        """Prints the help message for this loader's specific arguments."""
+        self._parser.print_help()
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({str(self.path)!r})"
@@ -116,6 +131,20 @@ class Loader:
         yield path
 
     def map(self, target: Target) -> None:
+        """Wrapper around the _map function that handles argument passing."""
+        # The loader now parses its own arguments
+        loader_options = self._parser.parse_args(self.loader_args)
+
+        # The query string can act as a default for any arguments not provided on the command line
+        for key, value in self.parsed_query.items():
+            # argparse sets missing optional arguments to None. We only want to override if it's None.
+            if getattr(loader_options, key, None) is None:
+                setattr(loader_options, key, value)
+
+        # Pass the parsed options directly to the implementation map function
+        return self._map(target, **vars(loader_options))
+
+    def _map(self) -> None:
         """Maps the loaded path into a ``Target``.
 
         Args:

--- a/dissect/target/loader.py
+++ b/dissect/target/loader.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import argparse
 import os
 import urllib.parse
 from pathlib import Path
@@ -19,6 +18,7 @@ if TYPE_CHECKING:
 __all__ = [
     "Loader",
     "RawLoader",
+    "infer_loader",
     "open",
     "register",
 ]
@@ -68,7 +68,13 @@ class Loader:
     """
 
     def __init__(
-        self, path: Path, *, parsed_path: urllib.parse.ParseResult | None = None, resolve: bool = True, **kwargs
+        self,
+        path: Path,
+        *,
+        parsed_path: urllib.parse.ParseResult | None = None,
+        resolve: bool = True,
+        loader_kwargs: dict | None = None,
+        **kwargs,
     ):
         self.path = path
         self.absolute_path = None
@@ -83,26 +89,7 @@ class Loader:
         self.parsed_query = (
             dict(urllib.parse.parse_qsl(parsed_path.query, keep_blank_values=True)) if parsed_path else {}
         )
-
-        self._parser = self._create_parser(self.__class__)
-
-    @classmethod
-    def print_help(cls) -> None:
-        """Prints the help message for this loader's specific arguments."""
-        cls._create_parser(cls).print_help()
-
-    @staticmethod
-    def _create_parser(cls: type[Loader]) -> argparse.ArgumentParser:
-        """Creates the argument parser for this loader."""
-        # Do like generate_argparse_for_method in cli.py
-        parser = argparse.ArgumentParser(
-            prog=f"loader:{cls.__name__.lower()}",
-            description=f"Options for the '{cls.__name__}' loader.",
-            add_help=False,
-        )
-        for args, kwargs in getattr(cls, "__args__", []):
-            parser.add_argument(*args, **kwargs)
-        return parser
+        self._loader_kwargs = loader_kwargs or {}
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({str(self.path)!r})"
@@ -137,21 +124,20 @@ class Loader:
         yield path
 
     def map(self, target: Target) -> None:
-        """Wrapper around the _map function that handles argument passing."""
-        # The loader parses its own arguments from argv
-        loader_options, _ = self._parser.parse_known_args()
+        """Maps the loaded path into a ``Target``.
 
-        # The query string can act as a default for any arguments not provided on the command line
-        for key, value in self.parsed_query.items():
-            # argparse sets missing optional arguments to None. We only want to override if it's None.
-            if getattr(loader_options, key, None) is None:
-                setattr(loader_options, key, value)
+        Delegates to :meth:`_map` with any loader-specific keyword arguments set at instantiation time.
 
-        # Pass the parsed options directly to the implementation map function
-        return self._map(target, **vars(loader_options))
+        Args:
+            target: The target that we're mapping into.
+        """
+        return self._map(target, **self._loader_kwargs)
 
     def _map(self, target: Target, **kwargs) -> None:
-        """Maps the loaded path into a ``Target``.
+        """Implementation hook for :meth:`map`.
+
+        Subclasses that accept loader-specific arguments (declared via ``@arg`` decorators)
+        should override this method instead of :meth:`map`.
 
         Args:
             target: The target that we're mapping into.
@@ -186,6 +172,32 @@ class SubLoader(Loader, Generic[T]):
 
     def map(self, target: Target) -> None:
         raise NotImplementedError
+
+
+def infer_loader(
+    spec: str | Path,
+) -> tuple[type[Loader], Path, urllib.parse.ParseResult | None] | None:
+    """Infer the loader class for a given target specification.
+
+    Uses the same logic as :meth:`Target.open_all <dissect.target.target.Target.open_all>` to determine
+    which :class:`Loader` class would be used for the given ``spec``.
+
+    Args:
+        spec: A target path or URI to infer the loader for.
+
+    Returns:
+        A tuple of ``(loader_cls, path, parsed_path)`` if a suitable loader was found, or ``None`` otherwise.
+    """
+    adjusted_path, parsed_path = parse_path_uri(spec)
+    path = Path(spec) if not isinstance(spec, os.PathLike) else spec
+
+    if parsed_path is not None and (loader_cls := find_loader_by_scheme(parsed_path.scheme)):
+        return loader_cls, adjusted_path, parsed_path
+
+    if loader_cls := find_loader(path, fallbacks=[DirLoader, RawLoader]):
+        return loader_cls, path, None
+
+    return None
 
 
 def register(module_name: str, class_name: str, internal: bool = True) -> None:

--- a/dissect/target/loaders/local.py
+++ b/dissect/target/loaders/local.py
@@ -63,6 +63,10 @@ class LocalLoader(Loader):
         target.path_query = self.parsed_query
         target.path = Path("local")
 
+        # Also honour flags passed via URI query string (e.g. "local?force-directory-fs=1")
+        force_directory_fs = force_directory_fs or "force-directory-fs" in self.parsed_query
+        fallback_to_directory_fs = fallback_to_directory_fs or "fallback-to-directory-fs" in self.parsed_query
+
         os_name = _get_os_name()
 
         if os_name == "windows":

--- a/dissect/target/loaders/local.py
+++ b/dissect/target/loaders/local.py
@@ -15,6 +15,7 @@ from dissect.target.containers.raw import RawContainer
 from dissect.target.exceptions import LoaderError
 from dissect.target.filesystems.dir import DirectoryFilesystem
 from dissect.target.loader import Loader
+from dissect.target.plugin import arg
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -39,6 +40,12 @@ WINDOWS_ERROR_INSUFFICIENT_BUFFER = 0x7A
 WINDOWS_DRIVE_FIXED = 3
 
 
+@arg("--force-directory-fs", action="store_true", help="Force the use of DirectoryFilesystem on all drives.")
+@arg(
+    "--fallback-to-directory-fs",
+    action="store_true",
+    help="Fallback to DirectoryFilesystem if a filesystem cannot be opened.",
+)
 class LocalLoader(Loader):
     """Load local filesystem."""
 
@@ -50,7 +57,7 @@ class LocalLoader(Loader):
     def detect(path: Path) -> bool:
         return urllib.parse.urlparse(str(path)).path == "local"
 
-    def map(self, target: Target) -> None:
+    def _map(self, target: Target, force_directory_fs: bool = False, fallback_to_directory_fs: bool = False) -> None:
         # For the local loader we abuse the path/URI parsing a bit, so fix it up here
         target.parsed_path = urllib.parse.urlparse(str(target.path))
         target.path_query = self.parsed_query
@@ -58,13 +65,10 @@ class LocalLoader(Loader):
 
         os_name = _get_os_name()
 
-        force_dirfs = "force-directory-fs" in self.parsed_query
-        fallback_to_dirfs = "fallback-to-directory-fs" in self.parsed_query
-
         if os_name == "windows":
-            map_windows_mounted_drives(target, force_dirfs=force_dirfs, fallback_to_dirfs=fallback_to_dirfs)
+            map_windows_mounted_drives(target, force_dirfs=force_directory_fs, fallback_to_dirfs=fallback_to_directory_fs)
         else:
-            if fallback_to_dirfs or force_dirfs:
+            if fallback_to_directory_fs or force_directory_fs:
                 # Where Windows does some sophisticated fallback, for other
                 # operating systems we don't know anything yet about the
                 # relation between disks and mount points.

--- a/dissect/target/loaders/local.py
+++ b/dissect/target/loaders/local.py
@@ -50,29 +50,29 @@ class LocalLoader(Loader):
     """Load local filesystem."""
 
     def __init__(self, path: Path, **kwargs):
-        kwargs["parsed_path"] = urllib.parse.urlparse(str(path))
+        if not kwargs.get("parsed_path"):
+            kwargs["parsed_path"] = urllib.parse.urlparse(str(path))
         super().__init__(path, **kwargs, resolve=False)
 
     @staticmethod
     def detect(path: Path) -> bool:
         return urllib.parse.urlparse(str(path)).path == "local"
 
-    def _map(self, target: Target, force_directory_fs: bool = False, fallback_to_directory_fs: bool = False) -> None:
+    def map(self, target: Target) -> None:
         # For the local loader we abuse the path/URI parsing a bit, so fix it up here
         target.parsed_path = urllib.parse.urlparse(str(target.path))
         target.path_query = self.parsed_query
         target.path = Path("local")
 
-        # Also honour flags passed via URI query string (e.g. "local?force-directory-fs=1")
-        force_directory_fs = force_directory_fs or "force-directory-fs" in self.parsed_query
-        fallback_to_directory_fs = fallback_to_directory_fs or "fallback-to-directory-fs" in self.parsed_query
-
         os_name = _get_os_name()
 
+        force_dirfs = "force-directory-fs" in self.parsed_query
+        fallback_to_dirfs = "fallback-to-directory-fs" in self.parsed_query
+
         if os_name == "windows":
-            map_windows_mounted_drives(target, force_dirfs=force_directory_fs, fallback_to_dirfs=fallback_to_directory_fs)
+            map_windows_mounted_drives(target, force_dirfs=force_dirfs, fallback_to_dirfs=fallback_to_dirfs)
         else:
-            if fallback_to_directory_fs or force_directory_fs:
+            if fallback_to_dirfs or force_dirfs:
                 # Where Windows does some sophisticated fallback, for other
                 # operating systems we don't know anything yet about the
                 # relation between disks and mount points.

--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -276,6 +276,7 @@ class Target:
                   If the path is a ``os.PathLike`` object, it will be used as-is.
                   If the path is a string and looks like a URI, it will be parsed as such.
                   If the path is a string and does not like like a URI, it will be treated as a local path.
+            loader_args: Additional arguments for the loader.
 
         Returns:
             A Target with a linked :class:`~dissect.target.loader.Loader` object.

--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -461,6 +461,86 @@ class Target:
         """
         return cls._load("direct", DirectLoader(paths, case_sensitive))
 
+    @classmethod
+    def with_loader(
+        cls,
+        paths: str | Path | list[str | Path],
+        loader_instance: loader.Loader,
+        include_children: bool = False,
+        *,
+        apply: bool = True,
+    ) -> Iterator[Self]:
+        """Yield all targets from one or more paths using an already-instantiated loader.
+
+        This is the same as :meth:`open_all`, but the loader is provided directly instead of being inferred
+        from the target paths.  The caller is responsible for instantiating the loader with the appropriate
+        arguments (including any loader-specific keyword arguments).
+
+        Args:
+            paths: A list of paths to load ``Targets`` from.
+            loader_instance: An already-instantiated :class:`~dissect.target.loader.Loader` to use.
+            include_children: Whether to recursively open child targets.
+            apply: Whether to apply the target after loading.
+
+        Raises:
+            TargetError: Raised when not a single ``Target`` can be loaded.
+        """
+        if isinstance(paths, (str, Path)):
+            paths = [paths]
+
+        loader_cls = type(loader_instance)
+        at_least_one_loaded = False
+
+        for spec in paths:
+            adjusted_path, parsed_path = parse_path_uri(spec)
+            path = Path(spec) if not isinstance(spec, os.PathLike) else spec
+
+            # Use the parsed_path from the spec if available, otherwise use the path as-is
+            found_path = adjusted_path if parsed_path is not None else path
+            load_parsed_path = parsed_path
+
+            get_target_logger(spec).debug("Using provided loader: %s", loader_cls)
+
+            for sub_path in loader_cls.find_all(found_path, parsed_path=load_parsed_path):
+                if sub_path is found_path:
+                    load_spec = spec
+                    load_path = found_path
+                    ldr = loader_instance
+                else:
+                    load_spec = sub_path
+                    if isinstance(sub_path, str):
+                        load_path, load_parsed_path = parse_path_uri(sub_path)
+                    else:
+                        load_path = sub_path
+
+                    # For sub-paths, create a new loader instance of the same type
+                    try:
+                        ldr = loader_cls(load_path, parsed_path=load_parsed_path, loader_kwargs=loader_instance._loader_kwargs)
+                    except Exception as e:
+                        message = "%s" if isinstance(e, TargetPathNotFoundError) else "Failed to initiate loader: %s"
+                        get_target_logger(load_spec).error(message, e)
+                        get_target_logger(load_spec).debug("", exc_info=e)
+                        continue
+
+                try:
+                    target = cls._load(load_spec, ldr, apply=include_children or apply)
+                except Exception as e:
+                    get_target_logger(load_spec).error("Failed to load target with loader %s", ldr)
+                    get_target_logger(load_spec).debug("", exc_info=e)
+                    continue
+                else:
+                    at_least_one_loaded = True
+                    yield target
+
+                if include_children:
+                    try:
+                        yield from target.open_children(apply=apply)
+                    except Exception as e:
+                        get_target_logger(load_spec).error("Failed to load child target from %s", target, exc_info=e)
+
+        if not at_least_one_loaded:
+            raise TargetError(f"Failed to load any target with loader {loader_cls.__name__} for: {paths}")
+
     @property
     def is_direct(self) -> bool:
         """Check if the target is a direct target."""

--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -268,7 +268,7 @@ class Target:
         return target_name
 
     @classmethod
-    def open(cls, path: str | Path) -> Self:
+    def open(cls, path: str | Path, *, apply: bool = True) -> Self:
         """Try to find a suitable loader for the given path and load a ``Target`` from it.
 
         Args:
@@ -305,7 +305,7 @@ class Target:
         except Exception as e:
             raise TargetError(f"Failed to initiate {loader_cls.__name__} for target {spec}: {e}") from e
 
-        return cls._load(spec, loader_instance)
+        return cls._load(spec, loader_instance, apply=apply)
 
     @classmethod
     def open_raw(cls, path: str | Path, *, apply: bool = True) -> Self:

--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -332,7 +332,9 @@ class Target:
             TargetError: Raised when not a single ``Target`` can be loaded.
         """
 
-        def _open_all(spec: str | Path, include_children: bool = False, recursive: bool = False, *, apply: bool = True) -> Iterator[Target]:
+        def _open_all(
+            spec: str | Path, include_children: bool = False, recursive: bool = False, *, apply: bool = True
+        ) -> Iterator[Target]:
             result = loader.infer_loader(spec)
             if result is None:
                 # Couldn't find a loader
@@ -441,88 +443,6 @@ class Target:
         This is useful when running plugins on individual files.
         """
         return cls._load("direct", DirectLoader(paths, case_sensitive))
-
-    @classmethod
-    def with_loader(
-        cls,
-        paths: str | Path | list[str | Path],
-        loader_instance: loader.Loader,
-        include_children: bool = False,
-        recursive: bool = False,
-        *,
-        apply: bool = True,
-    ) -> Iterator[Self]:
-        """Yield all targets from one or more paths using an already-instantiated loader.
-
-        This is the same as :meth:`open_all`, but the loader is provided directly instead of being inferred
-        from the target paths.  The caller is responsible for instantiating the loader with the appropriate
-        arguments (including any loader-specific keyword arguments).
-
-        Args:
-            paths: A list of paths to load ``Targets`` from.
-            loader_instance: An already-instantiated :class:`~dissect.target.loader.Loader` to use.
-            include_children: Whether to open child targets.
-            recursive: Whether to open child targets recursively.
-            apply: Whether to apply the target after loading.
-
-        Raises:
-            TargetError: Raised when not a single ``Target`` can be loaded.
-        """
-        if isinstance(paths, (str, Path)):
-            paths = [paths]
-
-        loader_cls = type(loader_instance)
-        at_least_one_loaded = False
-
-        for spec in paths:
-            adjusted_path, parsed_path = parse_path_uri(spec)
-            path = Path(spec) if not isinstance(spec, os.PathLike) else spec
-
-            # Use the parsed_path from the spec if available, otherwise use the path as-is
-            found_path = adjusted_path if parsed_path is not None else path
-            load_parsed_path = parsed_path
-
-            get_target_logger(spec).debug("Using provided loader: %s", loader_cls)
-
-            for sub_path in loader_cls.find_all(found_path, parsed_path=load_parsed_path):
-                if sub_path is found_path:
-                    load_spec = spec
-                    load_path = found_path
-                    ldr = loader_instance
-                else:
-                    load_spec = sub_path
-                    if isinstance(sub_path, str):
-                        load_path, load_parsed_path = parse_path_uri(sub_path)
-                    else:
-                        load_path = sub_path
-
-                    # For sub-paths, create a new loader instance of the same type
-                    try:
-                        ldr = loader_cls(load_path, parsed_path=load_parsed_path, loader_kwargs=loader_instance._loader_kwargs)
-                    except Exception as e:
-                        message = "%s" if isinstance(e, TargetPathNotFoundError) else "Failed to initiate loader: %s"
-                        get_target_logger(load_spec).error(message, e)
-                        get_target_logger(load_spec).debug("", exc_info=e)
-                        continue
-
-                try:
-                    target = cls._load(load_spec, ldr, apply=include_children or apply)
-                except Exception as e:
-                    get_target_logger(load_spec).error("Failed to load target with loader %s", ldr)
-                    get_target_logger(load_spec).debug("", exc_info=e)
-                    continue
-                else:
-                    at_least_one_loaded = True
-                    yield target
-
-                if include_children:
-                    try:
-                        yield from target.open_children(recursive=recursive, apply=apply)
-                    except Exception as e:
-                        get_target_logger(load_spec).error("Failed to load child target from %s", target, exc_info=e)
-
-        if not at_least_one_loaded:
-            raise TargetError(f"Failed to load any target with loader {loader_cls.__name__} for: {paths}")
 
     @property
     def is_direct(self) -> bool:

--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -268,7 +268,7 @@ class Target:
         return target_name
 
     @classmethod
-    def open(cls, path: str | Path, *, apply: bool = True) -> Self:
+    def open(cls, path: str | Path) -> Self:
         """Try to find a suitable loader for the given path and load a ``Target`` from it.
 
         Args:
@@ -276,7 +276,6 @@ class Target:
                   If the path is a ``os.PathLike`` object, it will be used as-is.
                   If the path is a string and looks like a URI, it will be parsed as such.
                   If the path is a string and does not like like a URI, it will be treated as a local path.
-            loader_args: Additional arguments for the loader.
 
         Returns:
             A Target with a linked :class:`~dissect.target.loader.Loader` object.
@@ -306,7 +305,7 @@ class Target:
         except Exception as e:
             raise TargetError(f"Failed to initiate {loader_cls.__name__} for target {spec}: {e}") from e
 
-        return cls._load(spec, loader_instance, apply=apply)
+        return cls._load(spec, loader_instance)
 
     @classmethod
     def open_raw(cls, path: str | Path, *, apply: bool = True) -> Self:

--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -282,23 +282,13 @@ class Target:
         """
         spec = path
 
-        # If the path is a URI-like string, separate the path component
-        adjusted_path, parsed_path = parse_path_uri(spec)
-        # We always need a path to work with, so convert the spec into one if it's not one already
-        path = Path(spec) if not isinstance(spec, os.PathLike) else spec
-
-        if parsed_path is not None and (loader_cls := loader.find_loader_by_scheme(parsed_path.scheme)):
-            # If we find a loader by URI scheme, use the adjusted path (path component of the URI)
-            found_path = adjusted_path
-        elif loader_cls := loader.find_loader(path, fallbacks=[loader.DirLoader, loader.RawLoader]):
-            # Otherwise try to find a loader for the "raw" path
-            # If we succeed, upgrade the "spec" to the path
-            spec = path
-            found_path = path
-            parsed_path = None
-        else:
-            # No loader found
+        result = loader.infer_loader(spec)
+        if result is None:
             return cls.open_raw(spec)
+
+        loader_cls, found_path, parsed_path = result
+        if parsed_path is None:
+            spec = found_path
 
         try:
             loader_instance = loader_cls(found_path, parsed_path=parsed_path)
@@ -342,26 +332,17 @@ class Target:
             TargetError: Raised when not a single ``Target`` can be loaded.
         """
 
-        def _open_all(
-            spec: str | Path, include_children: bool = False, recursive: bool = False, *, apply: bool = True
-        ) -> Iterator[Target]:
-            # If the path is a URI-like string, separate the path component
-            adjusted_path, parsed_path = parse_path_uri(spec)
-            # We always need a path to work with, so convert the spec into one if it's not one already
-            path = Path(spec) if not isinstance(spec, os.PathLike) else spec
-
-            if parsed_path is not None and (loader_cls := loader.find_loader_by_scheme(parsed_path.scheme)):
-                # If we find a loader by URI scheme, use the adjusted path (path component of the URI)
-                found_path = adjusted_path
-            elif loader_cls := loader.find_loader(path, fallbacks=[loader.DirLoader, loader.RawLoader]):
-                # Otherwise try to find a loader for the "raw" path
-                # If we succeed, upgrade the "spec" to the path
-                spec = path
-                found_path = path
-                parsed_path = None
-            else:
+        def _open_all(spec: str | Path, include_children: bool = False, recursive: bool = False, *, apply: bool = True) -> Iterator[Target]:
+            result = loader.infer_loader(spec)
+            if result is None:
                 # Couldn't find a loader
                 return
+
+            loader_cls, found_path, parsed_path = result
+            # For non-URI specs, infer_loader resolves the spec to a Path; mirror that upgrade here
+            # so that load_spec (used as the target identity) is consistent with what open() would use.
+            if parsed_path is None:
+                spec = found_path
 
             get_target_logger(spec).debug("Attempting to use loader: %s", loader_cls)
             # See if the loader provides any additional paths to load
@@ -467,6 +448,7 @@ class Target:
         paths: str | Path | list[str | Path],
         loader_instance: loader.Loader,
         include_children: bool = False,
+        recursive: bool = False,
         *,
         apply: bool = True,
     ) -> Iterator[Self]:
@@ -479,7 +461,8 @@ class Target:
         Args:
             paths: A list of paths to load ``Targets`` from.
             loader_instance: An already-instantiated :class:`~dissect.target.loader.Loader` to use.
-            include_children: Whether to recursively open child targets.
+            include_children: Whether to open child targets.
+            recursive: Whether to open child targets recursively.
             apply: Whether to apply the target after loading.
 
         Raises:
@@ -534,7 +517,7 @@ class Target:
 
                 if include_children:
                     try:
-                        yield from target.open_children(apply=apply)
+                        yield from target.open_children(recursive=recursive, apply=apply)
                     except Exception as e:
                         get_target_logger(load_spec).error("Failed to load child target from %s", target, exc_info=e)
 

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -18,6 +18,7 @@ from dissect.target.exceptions import (
 )
 from dissect.target.helpers import cache, record_modifier
 from dissect.target.helpers.logging import get_logger
+from dissect.target.loader import LOADERS_BY_SCHEME
 from dissect.target.plugin import (
     PLUGINS,
 )
@@ -114,8 +115,19 @@ def main() -> int:
     args, rest = parser.parse_known_args()
 
     # Show help for target-query
-    if not args.function and ("-h" in rest or "--help" in rest):
-        parser.print_help()
+    if not args.function and ("-h" in rest or "--help" in rest): 
+        if not args.loader:
+            parser.print_help()
+            return 0
+
+        if (loader_cls := LOADERS_BY_SCHEME.get(args.loader, None)) is None:
+            print(f"Error: Loader '{args.loader}' not found.")
+            return 1
+
+        # The loader now knows how to print its own help.
+        # We just need to instantiate it. Note that the path is not important here.
+        loader_instance = loader_cls(pathlib.Path())
+        loader_instance.print_help()
         return 0
 
     process_generic_arguments(parser, args)
@@ -136,6 +148,7 @@ def main() -> int:
             )
 
     # Process plugin arguments after host and child args are checked
+    # This is for plugins, not loaders. We pass `rest` to let it find plugin args.
     different_output_types = process_plugin_arguments(parser, args, rest)
 
     if not args.targets:
@@ -154,7 +167,8 @@ def main() -> int:
     execution_report.set_event_callbacks(Target)
 
     try:
-        for target in open_targets(args):
+        # Pass the loader-specific arguments (`rest`) to open_targets
+        for target in open_targets(args, loader_args=rest):
             record_entries: list[tuple[FunctionDescriptor, Iterator[Record]]] = []
             basic_entries = []
             yield_entries = []

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -17,7 +17,6 @@ from dissect.target.exceptions import (
     UnsupportedPluginError,
 )
 from dissect.target.helpers import cache, record_modifier
-from dissect.target.helpers.loaderutil import parse_path_uri
 from dissect.target.helpers.logging import get_logger
 from dissect.target.loader import LOADERS_BY_SCHEME, infer_loader
 from dissect.target.plugin import (
@@ -116,20 +115,16 @@ def main() -> int:
 
     args, rest = parser.parse_known_args()
 
-    # Determine the loader early so we can build its argument parser and show help for it.
-    # If --loader is specified explicitly, look it up by scheme; otherwise infer from the first target.
-    explicit_loader = bool(args.loader)
-    loader_instance = None
-    loader_cls = None
-    if args.loader:
-        loader_cls = LOADERS_BY_SCHEME.get(args.loader)
-    elif args.targets:
-        result = infer_loader(args.targets[0])
-        if result is not None:
-            loader_cls = result[0]
-
-    # Show help for target-query
+    # Show help for target-query. If a loader can be determined, show loader-specific help.
     if not args.function and ("-h" in rest or "--help" in rest):
+        loader_cls = None
+        if args.loader:
+            loader_cls = LOADERS_BY_SCHEME.get(args.loader)
+        elif args.targets:
+            result = infer_loader(args.targets[0])
+            if result is not None:
+                loader_cls = result[0]
+
         if loader_cls is None:
             parser.print_help()
             return 0
@@ -137,32 +132,6 @@ def main() -> int:
         loader_parser = generate_argparse_for_loader_class(loader_cls)
         loader_parser.print_help()
         return 0
-
-    # Parse loader-specific arguments from the remaining (unknown) arguments.
-    # The parsed values are passed directly to the loader at instantiation time.
-    loader_kwargs: dict = {}
-    if loader_cls is not None and getattr(loader_cls, "__args__", []):
-        loader_parser = generate_argparse_for_loader_class(loader_cls)
-        loader_options, rest = loader_parser.parse_known_args(rest)
-        loader_kwargs = vars(loader_options)
-
-    # Instantiate the loader only when -L was explicitly specified.
-    # When the loader is auto-inferred from targets[0], fall through to open_all which
-    # independently detects the correct loader per path — avoiding the mixed-loader
-    # regression where all targets would be locked to the first inferred loader class.
-    if explicit_loader and loader_cls is not None and args.targets:
-        first_spec = args.targets[0]
-        adjusted_path, parsed_path = parse_path_uri(first_spec)
-        load_path = adjusted_path if parsed_path is not None else pathlib.Path(first_spec)
-
-        try:
-            loader_instance = loader_cls(load_path, parsed_path=parsed_path, loader_kwargs=loader_kwargs)
-        except Exception as e:
-            parser.error(f"Failed to instantiate loader '{loader_cls.__name__}': {e}")
-
-    # Clear args.loader so that process_generic_arguments does not call args_to_uri again —
-    # we have already handled it above.
-    args.loader = None
 
     process_generic_arguments(parser, args)
 
@@ -182,7 +151,6 @@ def main() -> int:
             )
 
     # Process plugin arguments after host and child args are checked
-    # This is for plugins, not loaders. We pass `rest` to let it find plugin args.
     different_output_types = process_plugin_arguments(parser, args, rest)
 
     if not args.targets:
@@ -201,7 +169,7 @@ def main() -> int:
     execution_report.set_event_callbacks(Target)
 
     try:
-        for target in open_targets(args, loader_instance=loader_instance):
+        for target in open_targets(args):
             record_entries: list[tuple[FunctionDescriptor, Iterator[Record]]] = []
             basic_entries = []
             yield_entries = []

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -115,7 +115,7 @@ def main() -> int:
     args, rest = parser.parse_known_args()
 
     # Show help for target-query
-    if not args.function and ("-h" in rest or "--help" in rest): 
+    if not args.function and ("-h" in rest or "--help" in rest):
         if not args.loader:
             parser.print_help()
             return 0

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -118,6 +118,7 @@ def main() -> int:
 
     # Determine the loader early so we can build its argument parser and show help for it.
     # If --loader is specified explicitly, look it up by scheme; otherwise infer from the first target.
+    explicit_loader = bool(args.loader)
     loader_instance = None
     loader_cls = None
     if args.loader:
@@ -145,20 +146,14 @@ def main() -> int:
         loader_options, rest = loader_parser.parse_known_args(rest)
         loader_kwargs = vars(loader_options)
 
-    # Instantiate the loader for the first target path (used for all targets in this run).
-    # For URI-based targets the path component and parsed_path are extracted by infer_loader.
-    if loader_cls is not None and args.targets:
-        if args.loader:
-            first_spec = args.targets[0]
-            adjusted_path, parsed_path = parse_path_uri(first_spec)
-            load_path = adjusted_path if parsed_path is not None else pathlib.Path(first_spec)
-        else:
-            result = infer_loader(args.targets[0])
-            if result is not None:
-                _, load_path, parsed_path = result
-            else:
-                load_path = args.targets[0]
-                parsed_path = None
+    # Instantiate the loader only when -L was explicitly specified.
+    # When the loader is auto-inferred from targets[0], fall through to open_all which
+    # independently detects the correct loader per path — avoiding the mixed-loader
+    # regression where all targets would be locked to the first inferred loader class.
+    if explicit_loader and loader_cls is not None and args.targets:
+        first_spec = args.targets[0]
+        adjusted_path, parsed_path = parse_path_uri(first_spec)
+        load_path = adjusted_path if parsed_path is not None else pathlib.Path(first_spec)
 
         try:
             loader_instance = loader_cls(load_path, parsed_path=parsed_path, loader_kwargs=loader_kwargs)
@@ -166,7 +161,7 @@ def main() -> int:
             parser.error(f"Failed to instantiate loader '{loader_cls.__name__}': {e}")
 
     # Clear args.loader so that process_generic_arguments does not call args_to_uri again —
-    # we have already instantiated the loader with the correct arguments above.
+    # we have already handled it above.
     args.loader = None
 
     process_generic_arguments(parser, args)

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -125,9 +125,7 @@ def main() -> int:
             return 1
 
         # The loader now knows how to print its own help.
-        # We just need to instantiate it. Note that the path is not important here.
-        loader_instance = loader_cls(pathlib.Path())
-        loader_instance.print_help()
+        loader_cls.print_help()
         return 0
 
     process_generic_arguments(parser, args)
@@ -167,8 +165,7 @@ def main() -> int:
     execution_report.set_event_callbacks(Target)
 
     try:
-        # Pass the loader-specific arguments (`rest`) to open_targets
-        for target in open_targets(args, loader_args=rest):
+        for target in open_targets(args):
             record_entries: list[tuple[FunctionDescriptor, Iterator[Record]]] = []
             basic_entries = []
             yield_entries = []

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -17,8 +17,9 @@ from dissect.target.exceptions import (
     UnsupportedPluginError,
 )
 from dissect.target.helpers import cache, record_modifier
+from dissect.target.helpers.loaderutil import parse_path_uri
 from dissect.target.helpers.logging import get_logger
-from dissect.target.loader import LOADERS_BY_SCHEME
+from dissect.target.loader import LOADERS_BY_SCHEME, infer_loader
 from dissect.target.plugin import (
     PLUGINS,
 )
@@ -29,6 +30,7 @@ from dissect.target.tools.utils.cli import (
     configure_plugin_arguments,
     execute_function_on_target,
     find_and_filter_plugins,
+    generate_argparse_for_loader_class,
     open_targets,
     persist_execution_report,
     process_generic_arguments,
@@ -114,19 +116,58 @@ def main() -> int:
 
     args, rest = parser.parse_known_args()
 
+    # Determine the loader early so we can build its argument parser and show help for it.
+    # If --loader is specified explicitly, look it up by scheme; otherwise infer from the first target.
+    loader_instance = None
+    loader_cls = None
+    if args.loader:
+        loader_cls = LOADERS_BY_SCHEME.get(args.loader)
+    elif args.targets:
+        result = infer_loader(args.targets[0])
+        if result is not None:
+            loader_cls = result[0]
+
     # Show help for target-query
     if not args.function and ("-h" in rest or "--help" in rest):
-        if not args.loader:
+        if loader_cls is None:
             parser.print_help()
             return 0
 
-        if (loader_cls := LOADERS_BY_SCHEME.get(args.loader, None)) is None:
-            print(f"Error: Loader '{args.loader}' not found.")
-            return 1
-
-        # The loader now knows how to print its own help.
-        loader_cls.print_help()
+        loader_parser = generate_argparse_for_loader_class(loader_cls)
+        loader_parser.print_help()
         return 0
+
+    # Parse loader-specific arguments from the remaining (unknown) arguments.
+    # The parsed values are passed directly to the loader at instantiation time.
+    loader_kwargs: dict = {}
+    if loader_cls is not None and getattr(loader_cls, "__args__", []):
+        loader_parser = generate_argparse_for_loader_class(loader_cls)
+        loader_options, rest = loader_parser.parse_known_args(rest)
+        loader_kwargs = vars(loader_options)
+
+    # Instantiate the loader for the first target path (used for all targets in this run).
+    # For URI-based targets the path component and parsed_path are extracted by infer_loader.
+    if loader_cls is not None and args.targets:
+        if args.loader:
+            first_spec = args.targets[0]
+            adjusted_path, parsed_path = parse_path_uri(first_spec)
+            load_path = adjusted_path if parsed_path is not None else pathlib.Path(first_spec)
+        else:
+            result = infer_loader(args.targets[0])
+            if result is not None:
+                _, load_path, parsed_path = result
+            else:
+                load_path = args.targets[0]
+                parsed_path = None
+
+        try:
+            loader_instance = loader_cls(load_path, parsed_path=parsed_path, loader_kwargs=loader_kwargs)
+        except Exception as e:
+            parser.error(f"Failed to instantiate loader '{loader_cls.__name__}': {e}")
+
+    # Clear args.loader so that process_generic_arguments does not call args_to_uri again —
+    # we have already instantiated the loader with the correct arguments above.
+    args.loader = None
 
     process_generic_arguments(parser, args)
 
@@ -165,7 +206,7 @@ def main() -> int:
     execution_report.set_event_callbacks(Target)
 
     try:
-        for target in open_targets(args):
+        for target in open_targets(args, loader_instance=loader_instance):
             record_entries: list[tuple[FunctionDescriptor, Iterator[Record]]] = []
             basic_entries = []
             yield_entries = []

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -117,6 +117,8 @@ def main() -> int:
 
     # Show help for target-query. If a loader can be determined, show loader-specific help.
     if not args.function and ("-h" in rest or "--help" in rest):
+        parser.print_help()
+
         loader_cls = None
         if args.loader:
             loader_cls = LOADERS_BY_SCHEME.get(args.loader)
@@ -126,10 +128,10 @@ def main() -> int:
                 loader_cls = result[0]
 
         if loader_cls is None:
-            parser.print_help()
             return 0
 
         loader_parser = generate_argparse_for_loader_class(loader_cls)
+        print("\nLoader-specific options:\n")
         loader_parser.print_help()
         return 0
 

--- a/dissect/target/tools/utils/cli.py
+++ b/dissect/target/tools/utils/cli.py
@@ -257,7 +257,7 @@ def open_targets(args: argparse.Namespace, *, apply: bool = True) -> Iterator[Ta
         if child:
             try:
                 target.log.warning("Switching to --child %s", child)
-                target = target.open_child(child, apply=apply)
+                target = target.open_child(child)
             except Exception as e:
                 target.log.exception("Exception while opening child %r: %s", child, e)  # noqa: TRY401
                 target.log.debug("", exc_info=e)

--- a/dissect/target/tools/utils/cli.py
+++ b/dissect/target/tools/utils/cli.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 from dissect.target.helpers import docs, keychain
 from dissect.target.helpers.docs import get_docstring
-from dissect.target.loader import LOADERS_BY_SCHEME
+from dissect.target.loader import LOADERS_BY_SCHEME, Loader
 from dissect.target.plugin import (
     OSPlugin,
     Plugin,
@@ -242,16 +242,22 @@ def open_target(args: argparse.Namespace, *, apply: bool = True) -> Target:
     return target
 
 
-def open_targets(args: argparse.Namespace, *, apply: bool = True) -> Iterator[Target]:
+def open_targets(
+    args: argparse.Namespace,
+    *,
+    apply: bool = True,
+    loader_instance: Loader | None = None,
+) -> Iterator[Target]:
     direct: bool = getattr(args, "direct", False)
     children: bool = getattr(args, "children", False)
     child: str | None = getattr(args, "child", None)
 
-    targets: Iterable[Target] = (
-        [Target.open_direct(args.targets)]
-        if direct
-        else Target.open_all(args.targets, include_children=children, recursive=args.recursive, apply=apply)
-    )
+    if direct:
+        targets: Iterable[Target] = [Target.open_direct(args.targets)]
+    elif loader_instance is not None:
+        targets = Target.with_loader(args.targets, loader_instance, include_children=children, apply=apply)
+    else:
+        targets = Target.open_all(args.targets, include_children=children, recursive=args.recursive, apply=apply)
 
     for target in targets:
         if child:
@@ -351,6 +357,26 @@ def generate_argparse_for_method(
     func_name = method.__name__
     usage_tmpl = usage_tmpl or "{prog} {usage}"
     parser.usage = usage_tmpl.format(prog=parser.prog, name=func_name, usage=usage[offset:])
+
+    return parser
+
+
+def generate_argparse_for_loader_class(
+    loader_cls: type[Loader],
+    usage_tmpl: str | None = None,
+) -> argparse.ArgumentParser:
+    """Generate an ``argparse.ArgumentParser`` for a :class:`~dissect.target.loader.Loader` class."""
+    desc = get_docstring(loader_cls)
+
+    help_formatter = argparse.RawDescriptionHelpFormatter
+    parser = argparse.ArgumentParser(
+        prog=f"target-query -L {loader_cls.__name__.lower().removesuffix('loader')}",
+        description=desc,
+        formatter_class=help_formatter,
+        add_help=False,
+    )
+
+    _add_args_to_parser(parser, getattr(loader_cls, "__args__", []))
 
     return parser
 

--- a/dissect/target/tools/utils/cli.py
+++ b/dissect/target/tools/utils/cli.py
@@ -567,7 +567,7 @@ def args_to_uri(target: str | Path, loader: str | type[Loader], args: list[str] 
     )
     for load_arg in getattr(loader_cls, "__args__", []):
         arg_opts, arg_kwargs = load_arg
-        kw = dict(arg_kwargs)
+        kw = dict(arg_kwargs)  # Defensive copy to avoid mutating the loader class
         # If no explicit dest provided, prefer the long option string as dest
         if "dest" not in kw:
             long_opts = [o for o in arg_opts if o.startswith("--")]

--- a/dissect/target/tools/utils/cli.py
+++ b/dissect/target/tools/utils/cli.py
@@ -255,7 +255,7 @@ def open_targets(
     if direct:
         targets: Iterable[Target] = [Target.open_direct(args.targets)]
     elif loader_instance is not None:
-        targets = Target.with_loader(args.targets, loader_instance, include_children=children, apply=apply)
+        targets = Target.with_loader(args.targets, loader_instance, include_children=children, recursive=args.recursive, apply=apply)
     else:
         targets = Target.open_all(args.targets, include_children=children, recursive=args.recursive, apply=apply)
 

--- a/dissect/target/tools/utils/cli.py
+++ b/dissect/target/tools/utils/cli.py
@@ -243,12 +243,12 @@ def open_target(args: argparse.Namespace, *, apply: bool = True) -> Target:
 
 
 def open_targets(args: argparse.Namespace, *, apply: bool = True) -> Iterator[Target]:
-    direct: bool = getattr(args, "direct", False) or getattr(args, "direct_sensitive", False)
+    direct: bool = getattr(args, "direct", False)
     children: bool = getattr(args, "children", False)
     child: str | None = getattr(args, "child", None)
 
     targets: Iterable[Target] = (
-        [Target.open_direct(args.targets, case_sensitive=getattr(args, "direct_sensitive", False))]
+        [Target.open_direct(args.targets)]
         if direct
         else Target.open_all(args.targets, include_children=children, recursive=args.recursive, apply=apply)
     )
@@ -257,7 +257,7 @@ def open_targets(args: argparse.Namespace, *, apply: bool = True) -> Iterator[Ta
         if child:
             try:
                 target.log.warning("Switching to --child %s", child)
-                target = target.open_child(child)
+                target = target.open_child(child, apply=apply)
             except Exception as e:
                 target.log.exception("Exception while opening child %r: %s", child, e)  # noqa: TRY401
                 target.log.debug("", exc_info=e)

--- a/dissect/target/tools/utils/cli.py
+++ b/dissect/target/tools/utils/cli.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 from dissect.target.helpers import docs, keychain
 from dissect.target.helpers.docs import get_docstring
-from dissect.target.loader import LOADERS_BY_SCHEME
+from dissect.target.loader import LOADERS_BY_SCHEME, infer_loader
 from dissect.target.plugin import (
     OSPlugin,
     Plugin,
@@ -107,7 +107,18 @@ def process_generic_arguments(parser: argparse.ArgumentParser, args: argparse.Na
 
     targets = args.targets if hasattr(args, "targets") else [args.target] if hasattr(args, "target") else []
     if targets and args.loader:
-        targets = args_to_uri(targets, args.loader)
+        targets = [args_to_uri(t, args.loader) for t in targets]
+    elif targets:
+        # No explicit -L: infer the loader per target and encode any declared loader args into the URI
+        converted = []
+        for target in targets:
+            result = infer_loader(target)
+            if result:
+                loader_cls, _, _ = result
+                converted.append(args_to_uri(target, loader_cls))
+                continue
+            converted.append(target)
+        targets = converted
 
     if hasattr(args, "targets"):
         args.targets = targets
@@ -512,8 +523,8 @@ def catch_sigpipe(func: Callable) -> Callable:
     return wrapper
 
 
-def args_to_uri(targets: list[str], loader_name: str, args: list[str] | None = None) -> list[str]:
-    """Converts argument-style ``-L`` to URI-style.
+def args_to_uri(target: str | Path, loader: str | type[Loader], args: list[str] | None = None) -> str:
+    """Converts argument-style ``-L`` to URI-style for a single target.
 
     Turns:
         ``target-query /evtxs/* -L log --log-hint="evtx" -f evtx``
@@ -521,12 +532,40 @@ def args_to_uri(targets: list[str], loader_name: str, args: list[str] | None = N
         ``target-query "log:///evtxs/*?hint=evtx" -f evtx``
 
     For loaders providing ``@arg()`` arguments.
+
+    If ``target`` is already a URI with a scheme it is returned unchanged; any
+    CLI loader args are ignored because the URI is the authoritative
+    specification.  When ``-L`` is specified alongside a URI target, the
+    explicitly requested loader overrides the one encoded in the URI scheme.
+
+    Args:
+        target: A single target path or URI string.
+        loader: Either the scheme name (``str``) as passed via ``-L``, or the
+            :class:`~dissect.target.loader.Loader` class inferred from the
+            target path.
+        args: Optional list of raw CLI tokens to parse; defaults to
+            ``sys.argv``.
     """
-    loader = LOADERS_BY_SCHEME.get(loader_name, None)
+    # If the target is already a full URI (multi-character scheme), leave it
+    # untouched — the URI is the complete specification.
+    target = str(target)
+    parsed_target = urllib.parse.urlparse(target)
+    if parsed_target.scheme and not (len(parsed_target.scheme) == 1 and parsed_target.scheme.isalpha()):
+        return target
+
+    if isinstance(loader, str):
+        scheme = loader
+        loader_cls = LOADERS_BY_SCHEME.get(scheme)
+    else:
+        loader_cls = loader
+        scheme = next((k for k, v in LOADERS_BY_SCHEME.items() if v is loader_cls), None)
+        if not scheme:
+            return target
+
     parser = argparse.ArgumentParser(
-        argument_default=argparse.SUPPRESS, description="\n".join(textwrap.wrap(get_docstring(loader)))
+        argument_default=argparse.SUPPRESS, description="\n".join(textwrap.wrap(get_docstring(loader_cls)))
     )
-    for load_arg in getattr(loader, "__args__", []):
+    for load_arg in getattr(loader_cls, "__args__", []):
         arg_opts, arg_kwargs = load_arg
         kw = dict(arg_kwargs)
         # If no explicit dest provided, prefer the long option string as dest
@@ -538,12 +577,10 @@ def args_to_uri(targets: list[str], loader_name: str, args: list[str] | None = N
         parser.add_argument(*arg_opts, **kw)
 
     ns, _ = parser.parse_known_args(args)
-    parsed = vars(ns)
-
-    params = {k: (1 if v is True else 0 if v is False else v) for k, v in parsed.items()}
+    params = {k: (1 if v is True else 0 if v is False else v) for k, v in vars(ns).items()}
 
     q = ("?" + urllib.parse.urlencode(params, doseq=True)) if params else ""
-    return [f"{loader_name}://{t}{q}" for t in targets]
+    return f"{scheme}://{target}{q}"
 
 
 def find_and_filter_plugins(

--- a/dissect/target/tools/utils/cli.py
+++ b/dissect/target/tools/utils/cli.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 from dissect.target.helpers import docs, keychain
 from dissect.target.helpers.docs import get_docstring
-from dissect.target.loader import LOADERS_BY_SCHEME, Loader
+from dissect.target.loader import LOADERS_BY_SCHEME
 from dissect.target.plugin import (
     OSPlugin,
     Plugin,
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
     from datetime import datetime
 
+    from dissect.target.loader import Loader
     from dissect.target.plugin import FunctionDescriptor
 
 
@@ -242,22 +243,16 @@ def open_target(args: argparse.Namespace, *, apply: bool = True) -> Target:
     return target
 
 
-def open_targets(
-    args: argparse.Namespace,
-    *,
-    apply: bool = True,
-    loader_instance: Loader | None = None,
-) -> Iterator[Target]:
-    direct: bool = getattr(args, "direct", False)
+def open_targets(args: argparse.Namespace, *, apply: bool = True) -> Iterator[Target]:
+    direct: bool = getattr(args, "direct", False) or getattr(args, "direct_sensitive", False)
     children: bool = getattr(args, "children", False)
     child: str | None = getattr(args, "child", None)
 
-    if direct:
-        targets: Iterable[Target] = [Target.open_direct(args.targets)]
-    elif loader_instance is not None:
-        targets = Target.with_loader(args.targets, loader_instance, include_children=children, recursive=args.recursive, apply=apply)
-    else:
-        targets = Target.open_all(args.targets, include_children=children, recursive=args.recursive, apply=apply)
+    targets: Iterable[Target] = (
+        [Target.open_direct(args.targets, case_sensitive=getattr(args, "direct_sensitive", False))]
+        if direct
+        else Target.open_all(args.targets, include_children=children, recursive=args.recursive, apply=apply)
+    )
 
     for target in targets:
         if child:
@@ -528,14 +523,27 @@ def args_to_uri(targets: list[str], loader_name: str, args: list[str] | None = N
     For loaders providing ``@arg()`` arguments.
     """
     loader = LOADERS_BY_SCHEME.get(loader_name, None)
-
     parser = argparse.ArgumentParser(
         argument_default=argparse.SUPPRESS, description="\n".join(textwrap.wrap(get_docstring(loader)))
     )
     for load_arg in getattr(loader, "__args__", []):
-        parser.add_argument(*load_arg[0], **load_arg[1])
-    args = vars(parser.parse_known_args(args)[0])
-    return [f"{loader_name}://{target}" + (("?" + urllib.parse.urlencode(args)) if args else "") for target in targets]
+        arg_opts, arg_kwargs = load_arg
+        kw = dict(arg_kwargs)
+        # If no explicit dest provided, prefer the long option string as dest
+        if "dest" not in kw:
+            long_opts = [o for o in arg_opts if o.startswith("--")]
+            if long_opts:
+                kw["dest"] = long_opts[0].lstrip("-")
+
+        parser.add_argument(*arg_opts, **kw)
+
+    ns, _ = parser.parse_known_args(args)
+    parsed = vars(ns)
+
+    params = {k: (1 if v is True else 0 if v is False else v) for k, v in parsed.items()}
+
+    q = ("?" + urllib.parse.urlencode(params, doseq=True)) if params else ""
+    return [f"{loader_name}://{t}{q}" for t in targets]
 
 
 def find_and_filter_plugins(

--- a/tests/tools/utils/test_cli.py
+++ b/tests/tools/utils/test_cli.py
@@ -51,23 +51,30 @@ def test_persist_execution_report() -> None:
 
 
 @pytest.mark.parametrize(
-    ("targets", "loader_name", "args", "uris"),
+    ("target", "loader_name", "args", "uri"),
     [
-        (["/path/to/somewhere"], "loader", ["--loader-option", "1"], ["loader:///path/to/somewhere?option=1"]),
-        (["/path/to/somewhere"], "loader", ["--loader-option", "2"], ["loader:///path/to/somewhere?option=2"]),
-        (["/path/to/somewhere"], "unknown", ["--unknown-option", "3"], ["unknown:///path/to/somewhere"]),
-        (["/path/to/somewhere"], "loader", ["--ignored-option", "4"], ["loader:///path/to/somewhere"]),
-        (["/path/to/somewhere"], "loader", [], ["loader:///path/to/somewhere"]),
-        (["/path/to/somewhere"], "invalid", [], ["invalid:///path/to/somewhere"]),
+        ("/path/to/somewhere", "loader", ["--loader-option", "1"], "loader:///path/to/somewhere?option=1"),
+        ("/path/to/somewhere", "loader", ["--loader-option", "2"], "loader:///path/to/somewhere?option=2"),
+        ("/path/to/somewhere", "unknown", ["--unknown-option", "3"], "unknown:///path/to/somewhere"),
+        ("/path/to/somewhere", "loader", ["--ignored-option", "4"], "loader:///path/to/somewhere"),
+        ("/path/to/somewhere", "loader", [], "loader:///path/to/somewhere"),
+        ("/path/to/somewhere", "invalid", [], "invalid:///path/to/somewhere"),
+        # Already a URI — must be returned unchanged regardless of loader args
+        (
+            "loader:///path/to/somewhere?option=1",
+            "loader",
+            ["--loader-option", "2"],
+            "loader:///path/to/somewhere?option=1",
+        ),
     ],
 )
-def test_args_to_uri(targets: list[str], loader_name: str, args: list[str], uris: list[str]) -> None:
+def test_args_to_uri(target: str, loader_name: str, args: list[str], uri: str) -> None:
     @arg("--loader-option", dest="option")
     class FakeLoader:
         pass
 
     with patch("dissect.target.tools.utils.cli.LOADERS_BY_SCHEME", {"loader": FakeLoader}):
-        assert args_to_uri(targets, loader_name, args) == uris
+        assert args_to_uri(target, loader_name, args) == uri
 
 
 def test_process_generic_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -102,7 +109,7 @@ def test_process_generic_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
             patch("dissect.target.tools.utils.cli.sys.exit") as mocked_exit,
             patch(
                 "dissect.target.tools.utils.cli.args_to_uri",
-                return_value=["loader_name://target1", "loader_name://target2"],
+                side_effect=lambda t, loader: f"{loader}://{t}",
             ) as mocked_args_to_uri,
             patch("dissect.target.tools.utils.cli.keychain.register_keychain_file") as mocked_register_keychain_file,
             patch("dissect.target.tools.utils.cli.keychain.register_wildcard_value") as mocked_register_wildcard_value,
@@ -116,7 +123,9 @@ def test_process_generic_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
             mocked_configure_logging.assert_called_once_with(0, False, as_plain_text=True)
             mocked_version.assert_called_once_with("dissect.target")
             mocked_exit.assert_called_once_with(0)
-            mocked_args_to_uri.assert_called_once_with(["target1", "target2"], "loader_name")
+            mocked_args_to_uri.assert_any_call("target1", "loader_name")
+            mocked_args_to_uri.assert_any_call("target2", "loader_name")
+            assert mocked_args_to_uri.call_count == 2
             mocked_register_keychain_file.assert_called_once_with(Path("/path/to/keychain.csv"))
             mocked_register_wildcard_value.assert_called_once_with("some_value")
             mocked_get_external_module_paths.assert_called_once_with([Path("/path/to/plugins")])


### PR DESCRIPTION
(The following is written by @twiggler, not @Miauwkeru)

This PR:

- Adds support for displaying help when invoking with `target-query -L local --help`
- Fixes a regression when invoking with `target-query -f hostname -L local --force-directory-fs local` failed to pick up on the `--force-directory-fs`
- refactor loader selection into `infer_loader`

Originally, I had bigger plans, namely to move the argument parsing of plugins to the top-level and constructing the target as `with_loader(..., loader_instance)`.

 I walked this back, because:
1. Loaders are tied to a specific target path, so using a single instance on multiple targets does not work.
1. We dynamically open child targets. I forgot if they if they also need loader arguments, but the bottom line is that it is hard to create loaders with a bound argument map in advance. 

Now this is solvable by using dependency injection in the form of a  `LoaderFactory` and Loader adapters which support  construction from a uri, cli, or programmatically using a loader spec:

```
┌────────────────────────────────────────────────────────┐
│ Layer A — Inputs (adapters)                            │
│   • URI adapter:   "local?force-dirfs=1"  → LoaderSpec │
│   • CLI adapter:   argparse Namespace      → LoaderSpec │
│   • Programmatic:  LoaderSpec(...)         → LoaderSpec │
└──────────────────────────┬─────────────────────────────┘
                           │  LoaderSpec (value object)
                           ▼
┌────────────────────────────────────────────────────────┐
│ Layer B — Loader options                               │
│   • Typed `Options` dataclass per loader               │
│   • No argparse, no URI, no strings                    │
└──────────────────────────┬─────────────────────────────┘
                           │  Options instance
                           ▼
┌────────────────────────────────────────────────────────┐
│ Layer C — Loaders (business logic)                     │
│   • Loader(path, options) → maps target                │
│   • Pure: knows nothing about CLI or URIs              │
└──────────────────────────┬─────────────────────────────┘
                           │  emits child LoaderSpecs
                           ▼
┌────────────────────────────────────────────────────────┐
│ Layer D — LoaderFactory (dependency inversion)         │
│   • Target.open*(factory=...)                          │
│   • Children call factory.open(child_spec)             │
└────────────────────────────────────────────────────────┘
```
This would also remove the necessity of the `args_to_uri` hack which stringifies parsed arguments back to an uri.

However, I guess such as solution wouldn't be  "pythonic" anymore. 