### PR TITLE
Rename CLI Plugins to make the names more inline with the whole project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,20 +152,20 @@ dev = [
 ]
 
 [project.scripts]
-target-build-magic = "dissect.target.tools.build_magic:main"
-target-build-pluginlist = "dissect.target.tools.build_pluginlist:main"
-target-dd = "dissect.target.tools.dd:main"
-target-inspect = "dissect.target.tools.inspect:main"
-target-diff = "dissect.target.tools.diff:main"
-target-dump = "dissect.target.tools.dump:main"
-target-fs = "dissect.target.tools.fs:main"
-target-info = "dissect.target.tools.info:main"
-target-mount = "dissect.target.tools.mount:main"
-target-qfind = "dissect.target.tools.qfind:main"
-target-query = "dissect.target.tools.query:main"
-target-reg = "dissect.target.tools.reg:main"
-target-shell = "dissect.target.tools.shell:main"
-target-yara = "dissect.target.tools.yara:main"
+dissect-target-build-magic = "dissect.target.tools.build_magic:main"
+dissect-target-build-pluginlist = "dissect.target.tools.build_pluginlist:main"
+dissect-target-dd = "dissect.target.tools.dd:main"
+dissect-target-inspect = "dissect.target.tools.inspect:main"
+dissect-target-diff = "dissect.target.tools.diff:main"
+dissect-target-dump = "dissect.target.tools.dump:main"
+dissect-target-fs = "dissect.target.tools.fs:main"
+dissect-target-info = "dissect.target.tools.info:main"
+dissect-target-mount = "dissect.target.tools.mount:main"
+dissect-target-qfind = "dissect.target.tools.qfind:main"
+dissect-target-query = "dissect.target.tools.query:main"
+dissect-target-reg = "dissect.target.tools.reg:main"
+dissect-target-shell = "dissect.target.tools.shell:main"
+dissect-target-yara = "dissect.target.tools.yara:main"
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,19 +153,33 @@ dev = [
 
 [project.scripts]
 dissect-target-build-magic = "dissect.target.tools.build_magic:main"
+target-build-magic = "dissect.target.tools.build_magic:main"
 dissect-target-build-pluginlist = "dissect.target.tools.build_pluginlist:main"
+target-build-pluginlist = "dissect.target.tools.build_pluginlist:main"
 dissect-target-dd = "dissect.target.tools.dd:main"
+target-dd = "dissect.target.tools.dd:main"
 dissect-target-inspect = "dissect.target.tools.inspect:main"
+target-inspect = "dissect.target.tools.inspect:main"
 dissect-target-diff = "dissect.target.tools.diff:main"
+target-diff = "dissect.target.tools.diff:main"
 dissect-target-dump = "dissect.target.tools.dump:main"
+target-dump = "dissect.target.tools.dump:main"
 dissect-target-fs = "dissect.target.tools.fs:main"
+target-fs = "dissect.target.tools.fs:main"
 dissect-target-info = "dissect.target.tools.info:main"
+target-info = "dissect.target.tools.info:main"
 dissect-target-mount = "dissect.target.tools.mount:main"
+target-mount = "dissect.target.tools.mount:main"
 dissect-target-qfind = "dissect.target.tools.qfind:main"
+target-qfind = "dissect.target.tools.qfind:main"
 dissect-target-query = "dissect.target.tools.query:main"
+target-query = "dissect.target.tools.query:main"
 dissect-target-reg = "dissect.target.tools.reg:main"
+target-reg = "dissect.target.tools.reg:main"
 dissect-target-shell = "dissect.target.tools.shell:main"
+target-shell = "dissect.target.tools.shell:main"
 dissect-target-yara = "dissect.target.tools.yara:main"
+target-yara = "dissect.target.tools.yara:main"
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request. Please:

* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Associate the PR with an issue. If it doesn't exist, create it. Use 
  closing keywords in the body during creation, e.g.:
    * close(|s|d) #<nr>
    * fix(|es|ed) #<nr>
    * resolve(|s|d) #<nr>
-->

# Rename CLI Plugins to make the names more inline with the whole project

When installing the dissect package the cli used is mostly `target-query` which can be a bit confusing

## Proposed Changes

Prepend `dissect-` to all the cli entries. Resolves #1627.



