### PR TITLE
Expose Target arguments to Plugin instances

### DIFF
--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -24,11 +24,16 @@ import dissect.target.plugins.os.default as default
 from dissect.target.exceptions import PluginError, PluginNotFoundError, UnsupportedPluginError
 from dissect.target.helpers import cache
 from dissect.target.helpers.fsutil import has_glob_magic
+from dissect.target.helpers.lazy import import_lazy
 from dissect.target.helpers.logging import get_logger
 from dissect.target.helpers.record import EmptyRecord
 from dissect.target.helpers.utils import StrEnum
 
+generate_argparse_for_plugin_class = import_lazy("dissect.target.tools.utils.cli").generate_argparse_for_plugin_class
+LenientNamespace = import_lazy("dissect.target.tools.utils.cli").LenientNamespace
+
 if TYPE_CHECKING:
+    import argparse
     from collections.abc import Iterator
 
     from flow.record import Record
@@ -456,6 +461,15 @@ class Plugin:
             except Exception as e:
                 self.target.log.error("Error while executing `%s.%s`: %s", self.__namespace__, method_name, e)  # noqa: TRY400
                 self.target.log.debug("", exc_info=e)
+
+    def get_args(self) -> argparse.Namespace:
+        """Return argparse arguments for this :class:`Plugin`."""
+        args = None
+        if self.target.rest_args:
+            parser = generate_argparse_for_plugin_class(self.__class__)
+            args, _rest = parser.parse_known_args(self.target.rest_args)
+
+        return LenientNamespace(**dict(args._get_kwargs()) if args else {})
 
     def get_paths(self) -> Iterator[Path]:
         """Return all artifact paths."""

--- a/dissect/target/plugin.py
+++ b/dissect/target/plugin.py
@@ -118,7 +118,7 @@ class FunctionDescriptor:
 
     @property
     def args(self) -> list[tuple[list[str], dict[str, Any]]]:
-        return getattr(self.func, "__args__", [])
+        return getattr(self.cls, "__args__", []) + getattr(self.func, "__args__", [])
 
 
 @dataclass(frozen=True, eq=True, slots=True)
@@ -465,9 +465,9 @@ class Plugin:
     def get_args(self) -> argparse.Namespace:
         """Return argparse arguments for this :class:`Plugin`."""
         args = None
-        if self.target.rest_args:
+        if self.target.unknown_args:
             parser = generate_argparse_for_plugin_class(self.__class__)
-            args, _rest = parser.parse_known_args(self.target.rest_args)
+            args, _rest = parser.parse_known_args(self.target.unknown_args)
 
         return LenientNamespace(**dict(args._get_kwargs()) if args else {})
 

--- a/dissect/target/plugins/apps/other/env.py
+++ b/dissect/target/plugins/apps/other/env.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+from dissect.target.exceptions import UnsupportedPluginError
 from dissect.target.helpers.configutil import Env
 from dissect.target.helpers.record import TargetRecordDescriptor
 from dissect.target.plugin import Plugin, arg, export
+from dissect.target.target import Target
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -21,33 +24,36 @@ EnvironmentFileRecord = TargetRecordDescriptor(
 )
 
 
+@arg("--path", required=True, help="path to scan environment files in")
+@arg("--extension", default="env", help="extension of files to scan")
 class EnvironmentFilePlugin(Plugin):
     """Environment file plugin."""
 
+    def __init__(self, target: Target):
+        super().__init__(target)
+
+        args = self.get_args()
+        self.path = args.path
+        self.extension = args.extension
+        self.files: list[Path] = []
+
+        if args.path and (dir := self.target.fs.path(args.path)).is_dir():
+            self.files.extend(path for path in dir.glob(f"**/*.{args.extension}"))
+
     def check_compatible(self) -> None:
-        # `--env-path` is required at runtime
-        pass
+        if not self.files:
+            raise UnsupportedPluginError(f"No environment variable files found in {self.path}/**/*.{self.extension}")
 
     @export(record=EnvironmentFileRecord)
-    @arg("--env-path", required=True, help="path to scan environment files in")
-    @arg("--extension", default="env", help="extension of files to scan")
-    def envfile(self, env_path: str, extension: str = "env") -> Iterator[EnvironmentFileRecord]:
+    def envfile(self) -> Iterator[EnvironmentFileRecord]:
         """Yield environment variables found in ``.env`` files at the provided path."""
-        if not env_path:
-            self.target.log.error("No ``--path`` provided!")
-            return
-
-        if not (path := self.target.fs.path(env_path)).exists():
-            self.target.log.error("Provided path %s does not exist!", path)
-            return
-
-        for file in path.glob("**/*." + extension):
+        for file in self.files:
             if not file.is_file():
                 continue
 
             mtime = file.lstat().st_mtime
 
-            with file.open("r") as fh:
+            with file.open("rt") as fh:
                 parser = Env(comments=True)
                 parser.read_file(fh)
 

--- a/dissect/target/plugins/apps/other/env.py
+++ b/dissect/target/plugins/apps/other/env.py
@@ -7,10 +7,11 @@ from dissect.target.exceptions import UnsupportedPluginError
 from dissect.target.helpers.configutil import Env
 from dissect.target.helpers.record import TargetRecordDescriptor
 from dissect.target.plugin import Plugin, arg, export
-from dissect.target.target import Target
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from dissect.target.target import Target
 
 EnvironmentFileRecord = TargetRecordDescriptor(
     "application/other/file/environment",
@@ -24,7 +25,7 @@ EnvironmentFileRecord = TargetRecordDescriptor(
 )
 
 
-@arg("--path", required=True, help="path to scan environment files in")
+@arg("--path", required=True, type=Path, help="path to scan environment files in")
 @arg("--extension", default="env", help="extension of files to scan")
 class EnvironmentFilePlugin(Plugin):
     """Environment file plugin."""

--- a/dissect/target/plugins/general/example.py
+++ b/dissect/target/plugins/general/example.py
@@ -33,6 +33,7 @@ ExampleUserRegistryRecord = create_extended_descriptor(
 )
 
 
+@arg("--plugin-flag", action="store_true", help="Flag available to all plugin functions.")
 class ExamplePlugin(Plugin):
     """Example plugin.
 

--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -69,11 +69,13 @@ class Target:
 
     Args:
         path: The path of a target.
+        rest: Optional list of argument strings not consumed by the tool calling :class:`Target`.
     """
 
-    def __init__(self, path: str | Path | None = None):
+    def __init__(self, path: str | Path | None = None, rest: list[str] | None = None):
         self.path_scheme = None
         self.path_query = {}
+        self.rest_args = rest
 
         self.path, self.parsed_path = parse_path_uri(path)
         if self.parsed_path:
@@ -325,6 +327,7 @@ class Target:
         include_children: bool = False,
         recursive: bool = False,
         apply: bool = True,
+        rest: list[str] | None = None,
     ) -> Iterator[Self]:
         """Yield all targets from one or more paths or directories.
 
@@ -343,7 +346,7 @@ class Target:
         """
 
         def _open_all(
-            spec: str | Path, include_children: bool = False, recursive: bool = False, *, apply: bool = True
+            spec: str | Path, include_children: bool = False, recursive: bool = False, *, apply: bool = True, rest: list[str] | None = None
         ) -> Iterator[Target]:
             # If the path is a URI-like string, separate the path component
             adjusted_path, parsed_path = parse_path_uri(spec)
@@ -400,7 +403,7 @@ class Target:
                     # For file/dir-like paths it's a Path object
                     # If include_children is True, we override the apply parameter so we can find child targets
                     # The apply parameter will then be used on the children
-                    target = cls._load(load_spec, ldr, apply=include_children or apply)
+                    target = cls._load(load_spec, ldr, apply=include_children or apply, rest=rest)
                 except Exception as e:
                     get_target_logger(load_spec).error("Failed to load target with loader %s", ldr)
                     get_target_logger(load_spec).debug("", exc_info=e)
@@ -423,7 +426,7 @@ class Target:
         for spec in paths:
             loaded = False
 
-            for target in _open_all(spec, include_children=include_children, recursive=recursive, apply=apply):
+            for target in _open_all(spec, include_children=include_children, recursive=recursive, apply=apply, rest=rest):
                 loaded = True
                 at_least_one_loaded = True
                 yield target
@@ -600,7 +603,9 @@ class Target:
         raise TargetError("Target has no path and/or loader")
 
     @classmethod
-    def _load(cls, path: str | Path | None, ldr: loader.Loader, *, apply: bool = True) -> Self:
+    def _load(
+        cls, path: str | Path | None, ldr: loader.Loader, *, apply: bool = True, rest: list[str] | None = None
+    ) -> Self:
         """Internal function that attemps to load a path using a given loader.
 
         Args:
@@ -613,7 +618,7 @@ class Target:
         Returns:
             A ``Target`` object with disks, volumes and/or filesystems mapped by the ``ldr`` from the given ``path``.
         """
-        target = cls(path)
+        target = cls(path, rest)
 
         try:
             ldr.map(target)

--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -69,13 +69,13 @@ class Target:
 
     Args:
         path: The path of a target.
-        rest: Optional list of argument strings not consumed by the tool calling :class:`Target`.
+        unknown_args: Optional list of argument strings not consumed by the tool calling :class:`Target`.
     """
 
-    def __init__(self, path: str | Path | None = None, rest: list[str] | None = None):
+    def __init__(self, path: str | Path | None = None, unknown_args: list[str] | None = None):
         self.path_scheme = None
         self.path_query = {}
-        self.rest_args = rest
+        self.unknown_args = unknown_args
 
         self.path, self.parsed_path = parse_path_uri(path)
         if self.parsed_path:
@@ -278,6 +278,7 @@ class Target:
                   If the path is a ``os.PathLike`` object, it will be used as-is.
                   If the path is a string and looks like a URI, it will be parsed as such.
                   If the path is a string and does not like like a URI, it will be treated as a local path.
+            apply: Resolve all disks, volumes and filesystems and load an operating system on the :class:`Target`.
 
         Returns:
             A Target with a linked :class:`~dissect.target.loader.Loader` object.
@@ -327,7 +328,7 @@ class Target:
         include_children: bool = False,
         recursive: bool = False,
         apply: bool = True,
-        rest: list[str] | None = None,
+        unknown_args: list[str] | None = None,
     ) -> Iterator[Self]:
         """Yield all targets from one or more paths or directories.
 
@@ -340,13 +341,20 @@ class Target:
                    If the path is a string and does not look like a URI, it will be treated as a local path.
             include_children: Whether to open child targets.
             recursive: Whether to open child targets recursively.
+            apply: Resolve all disks, volumes and filesystems and load an operating system on the :class:`Target`.
+            unknown_args: List of unknown arguments possibly beloning to plugins.
 
         Raises:
             TargetError: Raised when not a single ``Target`` can be loaded.
         """
 
         def _open_all(
-            spec: str | Path, include_children: bool = False, recursive: bool = False, *, apply: bool = True, rest: list[str] | None = None
+            spec: str | Path,
+            include_children: bool = False,
+            recursive: bool = False,
+            *,
+            apply: bool = True,
+            unknown_args: list[str] | None = None,
         ) -> Iterator[Target]:
             # If the path is a URI-like string, separate the path component
             adjusted_path, parsed_path = parse_path_uri(spec)
@@ -403,7 +411,7 @@ class Target:
                     # For file/dir-like paths it's a Path object
                     # If include_children is True, we override the apply parameter so we can find child targets
                     # The apply parameter will then be used on the children
-                    target = cls._load(load_spec, ldr, apply=include_children or apply, rest=rest)
+                    target = cls._load(load_spec, ldr, apply=include_children or apply, unknown_args=unknown_args)
                 except Exception as e:
                     get_target_logger(load_spec).error("Failed to load target with loader %s", ldr)
                     get_target_logger(load_spec).debug("", exc_info=e)
@@ -426,7 +434,9 @@ class Target:
         for spec in paths:
             loaded = False
 
-            for target in _open_all(spec, include_children=include_children, recursive=recursive, apply=apply, rest=rest):
+            for target in _open_all(
+                spec, include_children=include_children, recursive=recursive, apply=apply, unknown_args=unknown_args
+            ):
                 loaded = True
                 at_least_one_loaded = True
                 yield target
@@ -448,7 +458,11 @@ class Target:
                 if path.is_dir():
                     for entry in path.iterdir():
                         for target in _open_all(
-                            entry, include_children=include_children, recursive=recursive, apply=apply
+                            entry,
+                            include_children=include_children,
+                            recursive=recursive,
+                            apply=apply,
+                            unknown_args=unknown_args,
                         ):
                             at_least_one_loaded = True
                             yield target
@@ -604,13 +618,15 @@ class Target:
 
     @classmethod
     def _load(
-        cls, path: str | Path | None, ldr: loader.Loader, *, apply: bool = True, rest: list[str] | None = None
+        cls, path: str | Path | None, ldr: loader.Loader, *, apply: bool = True, unknown_args: list[str] | None = None
     ) -> Self:
         """Internal function that attemps to load a path using a given loader.
 
         Args:
             path: The path to the target.
             ldr: The loader to use for loading this target.
+            apply: Resolve all disks, volumes and filesystems and load an operating system on the :class:`Target`.
+            unknown_args: List of unknown arguments possibly beloning to plugins.
 
         Raises:
             TargetError: If it failed to load a target.
@@ -618,7 +634,7 @@ class Target:
         Returns:
             A ``Target`` object with disks, volumes and/or filesystems mapped by the ``ldr`` from the given ``path``.
         """
-        target = cls(path, rest)
+        target = cls(path, unknown_args)
 
         try:
             ldr.map(target)

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -176,7 +176,7 @@ def main() -> int:
     execution_report.set_event_callbacks(Target)
 
     try:
-        for target in open_targets(args):
+        for target in open_targets(args, rest=rest):
             record_entries: list[tuple[FunctionDescriptor, Iterator[Record]]] = []
             basic_entries = []
             yield_entries = []

--- a/dissect/target/tools/query.py
+++ b/dissect/target/tools/query.py
@@ -121,13 +121,15 @@ def main() -> int:
         return 0
 
     # Dynamically add plugin arguments for the specified function(s)
+    all_plugin_args = []
     for func_desc in find_and_filter_plugins(
         functions=args.function or "",
         target=None,
         excluded_func_paths=args.excluded_functions,
         plugin_paths=args.plugin_path or [],
     ):
-        plugin_args = func_desc.args
+        plugin_args = func_desc.args + getattr(func_desc.cls, "__args__", [])
+        all_plugin_args += plugin_args
         for opts, kwargs in plugin_args:
             parser.add_argument(*opts, **kwargs)
 
@@ -175,8 +177,15 @@ def main() -> int:
     execution_report.set_cli_args(args)
     execution_report.set_event_callbacks(Target)
 
+    # Extract unknown arguments for passing on to Plugin argument parsing
+    arg_names = [name.strip("-") for names, _ in all_plugin_args for name in names]
+    unknown_args = []
+    for k, v in args.__dict__.items():
+        if k in arg_names:
+            unknown_args.extend([f"--{k}", v])
+
     try:
-        for target in open_targets(args, rest=rest):
+        for target in open_targets(args, unknown_args=unknown_args):
             record_entries: list[tuple[FunctionDescriptor, Iterator[Record]]] = []
             basic_entries = []
             yield_entries = []

--- a/dissect/target/tools/utils/cli.py
+++ b/dissect/target/tools/utils/cli.py
@@ -242,7 +242,7 @@ def open_target(args: argparse.Namespace, *, apply: bool = True) -> Target:
     return target
 
 
-def open_targets(args: argparse.Namespace, *, apply: bool = True) -> Iterator[Target]:
+def open_targets(args: argparse.Namespace, *, apply: bool = True, rest: list[str] | None = None) -> Iterator[Target]:
     direct: bool = getattr(args, "direct", False) or getattr(args, "direct_sensitive", False)
     children: bool = getattr(args, "children", False)
     child: str | None = getattr(args, "child", None)
@@ -250,7 +250,7 @@ def open_targets(args: argparse.Namespace, *, apply: bool = True) -> Iterator[Ta
     targets: Iterable[Target] = (
         [Target.open_direct(args.targets, case_sensitive=getattr(args, "direct_sensitive", False))]
         if direct
-        else Target.open_all(args.targets, include_children=children, recursive=args.recursive, apply=apply)
+        else Target.open_all(args.targets, include_children=children, recursive=args.recursive, apply=apply, rest=rest)
     )
 
     for target in targets:
@@ -530,3 +530,13 @@ def find_and_filter_plugins(
 def escape_str(value: str) -> str:
     """Escape non-ASCII, unicode characters and bytes to a printable form."""
     return repr(value)[1:-1]
+
+
+class LenientNamespace(argparse.Namespace):
+    """:class:`argparse.Namespace` implementation with lienient attribute access."""
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return object.__getattribute__(self, name)
+        except AttributeError:
+            return None

--- a/dissect/target/tools/utils/cli.py
+++ b/dissect/target/tools/utils/cli.py
@@ -242,7 +242,9 @@ def open_target(args: argparse.Namespace, *, apply: bool = True) -> Target:
     return target
 
 
-def open_targets(args: argparse.Namespace, *, apply: bool = True, rest: list[str] | None = None) -> Iterator[Target]:
+def open_targets(
+    args: argparse.Namespace, *, apply: bool = True, unknown_args: list[str] | None = None
+) -> Iterator[Target]:
     direct: bool = getattr(args, "direct", False) or getattr(args, "direct_sensitive", False)
     children: bool = getattr(args, "children", False)
     child: str | None = getattr(args, "child", None)
@@ -250,7 +252,9 @@ def open_targets(args: argparse.Namespace, *, apply: bool = True, rest: list[str
     targets: Iterable[Target] = (
         [Target.open_direct(args.targets, case_sensitive=getattr(args, "direct_sensitive", False))]
         if direct
-        else Target.open_all(args.targets, include_children=children, recursive=args.recursive, apply=apply, rest=rest)
+        else Target.open_all(
+            args.targets, include_children=children, recursive=args.recursive, apply=apply, unknown_args=unknown_args
+        )
     )
 
     for target in targets:

--- a/dissect/target/tools/utils/cli.py
+++ b/dissect/target/tools/utils/cli.py
@@ -158,7 +158,7 @@ def process_plugin_arguments(parser: argparse.ArgumentParser, args: argparse.Nam
     It puts the excluded function paths inside ``args.excluded_functions`` as a side effect.
 
     Returns:
-        ``True`` if there are multiple output types detected, false otherwise.
+        Set of plugin output types for all matching functions.
     """
     # Show help for a function or in general
     if "-h" in rest or "--help" in rest:
@@ -170,13 +170,17 @@ def process_plugin_arguments(parser: argparse.ArgumentParser, args: argparse.Nam
         plugin_class = load(func)
         if issubclass(plugin_class, OSPlugin):
             obj = getattr(OSPlugin, func.method_name)
+        elif func.method_name == "__call__":
+            obj = plugin_class
         else:
             obj = getattr(plugin_class, func.method_name)
 
         if isinstance(obj, type) and issubclass(obj, Plugin):
             parser = generate_argparse_for_plugin_class(obj, usage_tmpl=USAGE_FORMAT_TMPL)
         elif isinstance(obj, (Callable, property)):
-            parser = generate_argparse_for_method(getattr(obj, "fget", obj), usage_tmpl=USAGE_FORMAT_TMPL)
+            parser = generate_argparse_for_method(
+                getattr(obj, "fget", obj), usage_tmpl=USAGE_FORMAT_TMPL, plugin=getattr(func, "cls", None)
+            )
         else:
             parser.error(f"can't find plugin with function `{func.method_name}`")
         parser.print_help()
@@ -331,6 +335,7 @@ def list_children(args: argparse.Namespace) -> None:
 def generate_argparse_for_method(
     method: Callable,
     usage_tmpl: str | None = None,
+    plugin: Plugin | None = None,
 ) -> argparse.ArgumentParser:
     """Generate an ``argparse.ArgumentParser`` for a bound or unbound ``Plugin`` class method."""
     # allow functools.partial wrapped method
@@ -350,6 +355,10 @@ def generate_argparse_for_method(
 
     for args, kwargs in getattr(method, "__args__", []):
         parser.add_argument(*args, **kwargs)
+
+    if plugin:
+        for args, kwargs in getattr(plugin, "__args__", []):
+            parser.add_argument(*args, **kwargs)
 
     usage = parser.format_usage()
     offset = usage.find(parser.prog) + len(parser.prog)
@@ -375,6 +384,9 @@ def generate_argparse_for_plugin_class(
     parser = argparse.ArgumentParser(description=desc, formatter_class=help_formatter, conflict_handler="resolve")
 
     for args, kwargs in getattr(plugin_cls.__call__, "__args__", []):
+        parser.add_argument(*args, **kwargs)
+
+    for args, kwargs in getattr(plugin_cls, "__args__", []):
         parser.add_argument(*args, **kwargs)
 
     usage = parser.format_usage()

--- a/tests/plugins/apps/other/test_envfile.py
+++ b/tests/plugins/apps/other/test_envfile.py
@@ -12,11 +12,14 @@ if TYPE_CHECKING:
 
 
 def test_envfile(target_unix: Target, fs_unix: VirtualFilesystem) -> None:
-    target_unix.add_plugin(EnvironmentFilePlugin)
+    """Test if we find and parse ``.env`` files correctly."""
     fs_unix.map_file("/root/foo.env", absolute_path("_data/plugins/apps/other/env/test.env"))
     fs_unix.map_file("/root/foo/bar/test.env", absolute_path("_data/plugins/apps/other/env/test.env"))
 
-    records = list(target_unix.envfile(env_path="/root"))
+    target_unix.rest_args = ["--path=/root"]
+    target_unix.add_plugin(EnvironmentFilePlugin)
+
+    records = list(target_unix.envfile())
 
     assert len(records) == 4 * 2
 

--- a/tests/plugins/apps/other/test_envfile.py
+++ b/tests/plugins/apps/other/test_envfile.py
@@ -16,7 +16,7 @@ def test_envfile(target_unix: Target, fs_unix: VirtualFilesystem) -> None:
     fs_unix.map_file("/root/foo.env", absolute_path("_data/plugins/apps/other/env/test.env"))
     fs_unix.map_file("/root/foo/bar/test.env", absolute_path("_data/plugins/apps/other/env/test.env"))
 
-    target_unix.rest_args = ["--path=/root"]
+    target_unix.unknown_args = ["--path=/root"]
     target_unix.add_plugin(EnvironmentFilePlugin)
 
     records = list(target_unix.envfile())

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -30,6 +30,7 @@ from dissect.target.plugin import (
     _find_py_files,
     _save_plugin_import_failure,
     alias,
+    arg,
     environment_variable_paths,
     export,
     find_functions,
@@ -1691,8 +1692,7 @@ def test_exported_plugin_format(descriptor: FunctionDescriptor) -> None:
     assert_compliant_rst(class_doc_str)
 
     # Arguments of the plugin should define their type and if they are required (explicitly or implicitly).
-    for arg in descriptor.args:
-        names, settings = arg
+    for names, settings in descriptor.args:
         is_bool_action = settings.get("action", "") in (
             "store_true",
             "store_false",
@@ -1948,3 +1948,39 @@ def test_namespace_class_usage(descriptor: PluginDescriptor) -> None:
     assert descriptor.cls.__subclasses__(), (
         f"NamespacePlugin {descriptor.module}.{descriptor.qualname} has no subclasses, are you sure you're using NamespacePlugin correctly?"  # noqa: E501
     )
+
+
+@arg("--my-arg", help="Example plugin argument")
+class ExampleArgumentPlugin(Plugin):
+    """Example plugin with argument."""
+
+    __register__ = False
+
+    def check_compatible(self) -> None:
+        if self.get_args().my_arg != "example-plugin-value":
+            raise UnsupportedPluginError
+
+    @export(output="yield")
+    @arg("--my-func-arg", help="Example function argument")
+    def example_func(self, my_func_arg: str) -> Iterator[str]:
+        """Example function."""
+        yield my_func_arg
+
+
+def test_plugin_arguments(target_bare: Target) -> None:
+    """Test if we handle :class:`Plugin` arguments correctly."""
+    # Simulate arguments passed to ``target-query``
+    target_bare.rest_args = ["--my-arg=example-plugin-value", "--some-other-unrelated-argument=1"]
+
+    # Register the plugin with the target.
+    plugin = target_bare.add_plugin(ExampleArgumentPlugin)
+
+    # Check if the possible arguments for this plugin were registered.
+    assert plugin.__args__ == [(("--my-arg",), {"help": "Example plugin argument"})]
+
+    # Check if we return the plugin argument.
+    args = plugin.get_args()
+    assert args.my_arg == "example-plugin-value"
+
+    # Check if the plugin function could access it's own argument.
+    assert next(plugin.example_func("foo")) == "foo"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1397,10 +1397,11 @@ def test_function_required_arguments(target_default: Target) -> None:
     assert envfile_fd
     assert envfile_fd.args == [
         (
-            ("--env-path",),
+            ("--path",),
             {
                 "help": "path to scan environment files in",
                 "required": True,
+                "type": Path,
             },
         ),
         (
@@ -1421,12 +1422,12 @@ def test_plugin_runtime_info() -> None:
     assert func_desc.cls is EnvironmentFilePlugin
     assert func_desc.func is EnvironmentFilePlugin.envfile
     assert func_desc.record is EnvironmentFilePlugin.envfile.__record__
-    assert func_desc.args == EnvironmentFilePlugin.envfile.__args__
+    assert func_desc.args == EnvironmentFilePlugin.__args__
 
 
 def test_find_by_record_field_type(target_default: Target) -> None:
     assert "filesystem.walkfs.walkfs" in [desc.path for desc in find_functions_by_record_field_type("path")]
-    assert "apps.other.env.envfile" in [
+    assert "filesystem.yara.yara" in [
         desc.path for desc in find_functions_by_record_field_type("path", target_default, compatibility=True)
     ]
 
@@ -1711,16 +1712,18 @@ def test_exported_plugin_format(descriptor: FunctionDescriptor) -> None:
         assert settings.get("help"), f"No help text for argument {names[0]} in function {descriptor.func.__qualname__}"
 
         dest = settings.get("dest") or names[-1].strip("-").replace("-", "_")
-        assert dest in annotations, (
-            f"Missing type annotation for argument {dest} in function {descriptor.func.__qualname__}"
-        )
 
-        # TODO: More strictly check type annotation, use a contains right now to also match optionals
-        type_ = "bool" if is_bool_action else getattr(settings.get("type"), "__name__", "str")
-        assert type_ in annotations[dest], (
-            f"Invalid type annotation for argument {dest} in function {descriptor.func.__qualname__} "
-            f"({annotations[dest]} instead of {type_})"
-        )
+        if dest not in {name[-1].strip("-").replace("-", "_") for name, _ in getattr(descriptor.cls, "__args__", [])}:
+            assert dest in annotations, (
+                f"Missing type annotation for argument {dest} in function {descriptor.func.__qualname__}"
+            )
+
+            # TODO: More strictly check type annotation, use a contains right now to also match optionals
+            type_ = "bool" if is_bool_action else getattr(settings.get("type"), "__name__", "str")
+            assert type_ in annotations[dest], (
+                f"Invalid type annotation for argument {dest} in function {descriptor.func.__qualname__} "
+                f"({annotations[dest]} instead of {type_})"
+            )
 
         assert settings.get("type") is not str, (
             f"Superfluous type of str for argument {names[0]} in function {descriptor.func.__qualname__}: "
@@ -1970,7 +1973,7 @@ class ExampleArgumentPlugin(Plugin):
 def test_plugin_arguments(target_bare: Target) -> None:
     """Test if we handle :class:`Plugin` arguments correctly."""
     # Simulate arguments passed to ``target-query``
-    target_bare.rest_args = ["--my-arg=example-plugin-value", "--some-other-unrelated-argument=1"]
+    target_bare.unknown_args = ["--my-arg=example-plugin-value", "--some-other-unrelated-argument=1"]
 
     # Register the plugin with the target.
     plugin = target_bare.add_plugin(ExampleArgumentPlugin)

--- a/tests/tools/test_query.py
+++ b/tests/tools/test_query.py
@@ -255,6 +255,12 @@ def test_filtered_functions(mock_plugins: PluginRegistry, monkeypatch: pytest.Mo
                 new_callable=PropertyMock,
                 side_effect=mock_query_plugin_args,
             ),
+            patch.object(
+                FunctionDescriptor,
+                "cls",
+                new_callable=PropertyMock,
+                side_effect=MockQueryArgsPlugin(MagicMock()),
+            ),
             patch(
                 "dissect.target.tools.utils.cli.find_functions",
                 autospec=True,
@@ -482,6 +488,12 @@ def test_arguments_passed_correctly(
                 "args",
                 new_callable=PropertyMock,
                 side_effect=mock_query_plugin_args,
+            ),
+            patch.object(
+                FunctionDescriptor,
+                "cls",
+                new_callable=PropertyMock,
+                side_effect=MockPlugin(MagicMock()),
             ),
             patch(
                 "dissect.target.tools.utils.cli.find_functions",

--- a/tests/tools/utils/test_cli.py
+++ b/tests/tools/utils/test_cli.py
@@ -10,6 +10,7 @@ import pytest
 
 from dissect.target.exceptions import UnsupportedPluginError
 from dissect.target.plugin import Plugin, arg, find_functions
+from dissect.target.tools.query import main as target_query
 from dissect.target.tools.utils.cli import (
     args_to_uri,
     configure_generic_arguments,
@@ -168,3 +169,20 @@ def test_namespace_plugin_args() -> None:
     _, result = execute_function_on_target(mock_target, Mock(), ["--a", "asdf", "--b", "123"])
 
     assert result == "asdf"
+
+
+def test_argparse_for_plugin(capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test if various argparse flows work as expected."""
+    # Test if plugins are correctly parsed by the argparser and not named as '__call__'
+    with monkeypatch.context() as m, patch("dissect.target.tools.utils.cli.sys.exit", return_value=1):
+        m.setattr("sys.argv", ["target-query", "-f", "example_namespace", "-h"])
+        target_query()
+        out, _ = capsys.readouterr()
+        assert out.startswith("usage: target-query -f example_namespace [-h]")
+
+    # Test if arguments from plugins and arguments from plugin functions are shown in argparse help
+    with monkeypatch.context() as m, patch("dissect.target.tools.utils.cli.sys.exit", return_value=1):
+        m.setattr("sys.argv", ["target-query", "-f", "example", "-h"])
+        target_query()
+        out, _ = capsys.readouterr()
+        assert out.startswith("usage: target-query -f example [-h] [--flag] [--plugin-flag]")


### PR DESCRIPTION
This PR implements and fixes https://github.com/fox-it/dissect.target/issues/1493. The `Plugin` class is extended with a `get_args()` method, which returns a custom `argparse.Namespace` object populated with rest arguments from `Target`.

This allows plugins to determine if they are compatible based on plugin arguments provided at runtime. For an example see the included changes for the `EnvironmentFilePlugin` plugin.

Interested to hear your thoughts on this @Schamper and @yunzheng, especially in combination with the proposed changes in https://github.com/fox-it/dissect.target/pull/1619.