### PR TITLE
Fix plugin argparse help messages

### DIFF
--- a/dissect/target/tools/utils/cli.py
+++ b/dissect/target/tools/utils/cli.py
@@ -164,15 +164,20 @@ def process_plugin_arguments(parser: argparse.ArgumentParser, args: argparse.Nam
         plugin_class = load(func)
         if issubclass(plugin_class, OSPlugin):
             obj = getattr(OSPlugin, func.method_name)
+        elif func.method_name == "__call__":
+            obj = plugin_class
         else:
             obj = getattr(plugin_class, func.method_name)
 
         if isinstance(obj, type) and issubclass(obj, Plugin):
             parser = generate_argparse_for_plugin_class(obj, usage_tmpl=USAGE_FORMAT_TMPL)
         elif isinstance(obj, (Callable, property)):
-            parser = generate_argparse_for_method(getattr(obj, "fget", obj), usage_tmpl=USAGE_FORMAT_TMPL)
+            parser = generate_argparse_for_method(
+                getattr(obj, "fget", obj), usage_tmpl=USAGE_FORMAT_TMPL, plugin=getattr(func, "cls", None)
+            )
         else:
             parser.error(f"can't find plugin with function `{func.method_name}`")
+
         parser.print_help()
         parser.exit(0)
 
@@ -321,6 +326,7 @@ def list_children(args: argparse.Namespace) -> None:
 def generate_argparse_for_method(
     method: Callable,
     usage_tmpl: str | None = None,
+    plugin: Plugin | None = None,
 ) -> argparse.ArgumentParser:
     """Generate an ``argparse.ArgumentParser`` for a bound or unbound ``Plugin`` class method."""
     # allow functools.partial wrapped method
@@ -339,6 +345,9 @@ def generate_argparse_for_method(
     parser = argparse.ArgumentParser(description=desc, formatter_class=help_formatter, conflict_handler="resolve")
 
     _add_args_to_parser(parser, getattr(method, "__args__", []))
+
+    if plugin:
+        _add_args_to_parser(parser, getattr(plugin, "__args__", []))
 
     usage = parser.format_usage()
     offset = usage.find(parser.prog) + len(parser.prog)
@@ -364,6 +373,7 @@ def generate_argparse_for_plugin_class(
     parser = argparse.ArgumentParser(description=desc, formatter_class=help_formatter, conflict_handler="resolve")
 
     _add_args_to_parser(parser, getattr(plugin_cls.__call__, "__args__", []))
+    _add_args_to_parser(parser, getattr(plugin_cls, "__args__", []))
 
     usage = parser.format_usage()
     offset = usage.find(parser.prog) + len(parser.prog)

--- a/tests/tools/utils/test_cli.py
+++ b/tests/tools/utils/test_cli.py
@@ -10,6 +10,7 @@ import pytest
 
 from dissect.target.exceptions import UnsupportedPluginError
 from dissect.target.plugin import Plugin, arg, find_functions
+from dissect.target.tools.query import main as target_query
 from dissect.target.tools.utils.cli import (
     args_to_uri,
     configure_generic_arguments,
@@ -183,3 +184,20 @@ def test_namespace_plugin_args() -> None:
     _, result = execute_function_on_target(mock_target, Mock(), ["--a", "asdf", "--b", "123"])
 
     assert result == "asdf"
+
+
+def test_argparse_for_plugin(capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test if various argparse flows work as expected."""
+    # Test if plugins are correctly parsed by the argparser and not named as '__call__'
+    with monkeypatch.context() as m, patch("dissect.target.tools.utils.cli.sys.exit", return_value=1):
+        m.setattr("sys.argv", ["target-query", "-f", "example_namespace", "-h"])
+        target_query()
+        out, _ = capsys.readouterr()
+        assert out.startswith("usage: target-query -f example_namespace [-h]")
+
+    # Test if arguments from plugins and arguments from plugin functions are shown in argparse help
+    with monkeypatch.context() as m, patch("dissect.target.tools.utils.cli.sys.exit", return_value=1):
+        m.setattr("sys.argv", ["target-query", "-f", "example", "-h"])
+        target_query()
+        out, _ = capsys.readouterr()
+        assert out.startswith("usage: target-query -f example [-h] [--flag] [--plugin-flag]")


### PR DESCRIPTION
This PR fixes some bugs in the current argparse usage template generation for plugins.

Before:
```
$ target-query -f example_namespace -h
usage: target-query -f __call__ [-h]

Return the records of all exported methods.

Raises:
    PluginError: If the subclass is not a namespace plugin.

options:
  -h, --help  show this help message and exit
```

After:
```
$ target-query -f example_namespace -h
usage: target-query -f example_namespace [-h]

`ExampleNamespacePlugin` (`dissect.target.plugins.general.example.ExampleNamespacePlugin`)

    Example namespace plugin.

    `example_namespace.example_record` (output: records)

        Example namespace export.

options:
  -h, --help  show this help message and exit
```

The last test in `test_cli.py` depends on #1644 