### PR TITLE
Change target-dump output to use plugin name for files

### DIFF
--- a/dissect/target/tools/dump.py
+++ b/dissect/target/tools/dump.py
@@ -546,30 +546,14 @@ def get_nested_attr(obj: Any, nested_attr: str) -> Any:
     return functools.reduce(getattr, [obj, *parts])
 
 
-@functools.lru_cache(maxsize=DEST_DIR_CACHE_SIZE)
-def get_sink_dir_by_target(target: Target, function: FunctionDescriptor) -> Path:
-    func_first_name, _, _ = function.name.partition(".")
-    return Path(target.name) / func_first_name
-
-
-@functools.lru_cache(maxsize=DEST_DIR_CACHE_SIZE)
-def get_sink_dir_by_func(target: Target, function: FunctionDescriptor) -> Path:
-    func_first_name, _, _ = function.name.partition(".")
-    return Path(func_first_name) / target.name
-
-
-def slugify_descriptor_name(descriptor_name: str) -> str:
-    return descriptor_name.replace("/", "_")
-
-
 @functools.lru_cache(maxsize=DEST_FILENAME_CACHE_SIZE)
 def get_sink_filename(
-    record_descriptor: RecordDescriptor,
+    function_descriptor: FunctionDescriptor,
     serialization: Serialization,
     compression: Compression | None = None,
 ) -> str:
     """Return a sink filename for provided record descriptor, serialization and compression."""
-    record_type = slugify_descriptor_name(record_descriptor.name)
+    record_type = function_descriptor.name.replace(".", "_")
 
     serialization_details = SERIALIZERS[serialization]
     serialization_ext = serialization_details["ext"]
@@ -587,8 +571,8 @@ def get_relative_sink_path(
     element: RecordStreamElement, serialization: str, compression: Compression | None = None
 ) -> Path:
     """Return a sink path relative to an output directory."""
-    sink_dir = get_sink_dir_by_target(element.target, element.func)
-    sink_filename = get_sink_filename(element.record._desc, serialization, compression)
+    sink_dir = Path(element.target.name)
+    sink_filename = get_sink_filename(element.func, serialization, compression)
     return sink_dir / sink_filename
 
 

--- a/dissect/target/tools/dump.py
+++ b/dissect/target/tools/dump.py
@@ -553,13 +553,13 @@ def get_sink_filename(
     serialization: Serialization,
     compression: Compression | None = None,
 ) -> str:
-    """Return a sink filename for provided record descriptor, serialization and compression."""
-    record_type = function_descriptor.name.replace(".", "_")
+    """Return a sink filename for provided function name, serialization and compression."""
+    function_name = function_descriptor.name.replace(".", "_")
 
     serialization_details = SERIALIZERS[serialization]
     serialization_ext = serialization_details["ext"]
 
-    parts = [record_type, serialization_ext]
+    parts = [function_name, serialization_ext]
 
     compression_ext = COMPRESSION_TO_EXT[compression]
     if compression_ext:

--- a/dissect/target/tools/dump.py
+++ b/dissect/target/tools/dump.py
@@ -143,7 +143,7 @@ def produce_target_func_pairs(
 
     for target in targets:
         for func_def in find_and_filter_plugins(state.functions, target, state.excluded_functions):
-            if state and (target.path, func_def.name) in pairs_to_skip:
+            if state and (str(target.path), func_def.name) in pairs_to_skip:
                 log.info(
                     "Skipping target/func pair since its marked as done in provided state",
                     target=target.path,
@@ -409,13 +409,14 @@ class DumpState:
         """Return sinks that have a mismatch between recorded size and a real file size."""
         invalid_sinks = []
         for sink in self.sinks:
+            full_sink_path = self.get_full_sink_path(sink)
             # sink file does not exist
-            if not self.get_full_sink_path(sink).exists():
+            if not full_sink_path.exists():
                 invalid_sinks.append(sink)
                 continue
 
             # recorded file size for a clean sink is incorrect
-            if not sink.is_dirty and sink.size_bytes != sink.path.stat().st_size:
+            if not sink.is_dirty and sink.size_bytes != full_sink_path.stat().st_size:
                 invalid_sinks.append(sink)
                 continue
 

--- a/tests/tools/test_dump.py
+++ b/tests/tools/test_dump.py
@@ -100,28 +100,18 @@ def test_execute_pipeline(
 
         target_name = target_win_iis_amcache.name
 
-        # verify that iis records are in place
-
-        assert (output_dir / target_name / "iis").exists()
-
         serialization_ext = SERIALIZERS[serialization]["ext"]
         compression_ext = COMPRESSION_TO_EXT[compression]
 
-        iis_sink_filename = f"application_webserver_iis_log.{serialization_ext}"
+        iis_sink_filename = f"iis_logs.{serialization_ext}"
         if compression_ext:
             iis_sink_filename += f".{compression_ext}"
 
-        assert (output_dir / target_name / "iis" / iis_sink_filename).exists()
-
-        # verify that amcache.applications records are in place
-
-        assert (output_dir / target_name / "amcache").exists()
-
-        amcache_sink_filename = f"windows_appcompat_InventoryApplication.{serialization_ext}"
+        amcache_sink_filename = f"amcache_applications.{serialization_ext}"
         if compression_ext:
             amcache_sink_filename += f".{compression_ext}"
 
-        assert (output_dir / target_name / "amcache" / amcache_sink_filename).exists()
+        assert (output_dir / target_name / amcache_sink_filename).exists()
 
         # verify that serialized state is in place
         state_path = output_dir / STATE_FILE_NAME
@@ -145,13 +135,13 @@ def test_execute_pipeline(
         iis_sink_blob = next(s for s in state_blob["sinks"] if s["func"] == "iis.logs")
         assert iis_sink_blob["record_count"] == 10
         assert iis_sink_blob["target_path"] == str(target_win_iis_amcache.path)
-        assert iis_sink_blob["path"] == str(pathlib.Path(target_name) / "iis" / iis_sink_filename)
+        assert iis_sink_blob["path"] == str(pathlib.Path(target_name) / iis_sink_filename)
 
         # validate amcache sink blob
         amcache_sink_blob = next(s for s in state_blob["sinks"] if s["func"] == "amcache.applications")
         assert amcache_sink_blob["record_count"] == 118
         assert amcache_sink_blob["target_path"] == str(target_win_iis_amcache.path)
-        assert amcache_sink_blob["path"] == str(pathlib.Path(target_name) / "amcache" / amcache_sink_filename)
+        assert amcache_sink_blob["path"] == str(pathlib.Path(target_name) / amcache_sink_filename)
 
 
 @pytest.mark.parametrize("limit", [5, 15, None])
@@ -196,13 +186,10 @@ def test_execute_pipeline_limited(limit: int | None, target_win_iis_amcache: Tar
 
         target_name = target_win_iis_amcache.name
 
-        # verify that iis records are in place
-        assert (output_dir / target_name / "iis").exists()
-
         serialization_ext = SERIALIZERS[Serialization.JSONLINES]["ext"]
-        iis_sink_filename = f"application_webserver_iis_log.{serialization_ext}"
+        iis_sink_filename = f"iis_logs.{serialization_ext}"
 
-        assert (output_dir / target_name / "iis" / iis_sink_filename).exists()
+        assert (output_dir / target_name / iis_sink_filename).exists()
 
         # verify that serialized state is in place
         state_path = output_dir / STATE_FILE_NAME
@@ -218,7 +205,7 @@ def test_execute_pipeline_limited(limit: int | None, target_win_iis_amcache: Tar
         # verify that amcache.applications records are absent if `limit` is smaller/equal than 10 (the number
         # of iis records), and present if `limit` is `None` or larger than 10.
         if limit and limit <= 10:
-            assert not (output_dir / target_name / "amcache").exists()
+            assert not (output_dir / target_name / f"amcache_applications.{serialization_ext}").exists()
 
             assert len(sink_blobs) == 1
             assert {s["func"] for s in sink_blobs} == {"iis.logs"}
@@ -231,9 +218,8 @@ def test_execute_pipeline_limited(limit: int | None, target_win_iis_amcache: Tar
                 assert not iis_sink_blob["is_dirty"]
 
         else:
-            assert (output_dir / target_name / "amcache").exists()
-            amcache_sink_filename = f"windows_appcompat_InventoryApplication.{serialization_ext}"
-            assert (output_dir / target_name / "amcache" / amcache_sink_filename).exists()
+            amcache_sink_filename = f"amcache_applications.{serialization_ext}"
+            assert (output_dir / target_name / amcache_sink_filename).exists()
 
             assert len(sink_blobs) == 2
             assert {s["func"] for s in sink_blobs} == set(functions.split(","))
@@ -298,7 +284,7 @@ def test_dump(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
 
         assert tmp_path.joinpath("target-dump.state.json").exists()
 
-        entry = tmp_path.joinpath("test-archive.tar.gz/walkfs/filesystem_entry.jsonl")
+        entry = tmp_path.joinpath("test-archive.tar.gz/walkfs.jsonl")
         assert entry.exists()
         assert "test-file.txt" in entry.read_text()
 
@@ -323,8 +309,8 @@ def test_dump_excluded_plugins(monkeypatch: pytest.MonkeyPatch, tmp_path: pathli
 
         assert tmp_path.joinpath("target-dump.state.json").exists()
 
-        entry = tmp_path.joinpath("test-archive.tar.gz/walkfs/filesystem_entry.jsonl")
+        entry = tmp_path.joinpath("test-archive.tar.gz/walkfs.jsonl")
         assert entry.exists()
         assert "test-file.txt" in entry.read_text()
 
-        assert not tmp_path.joinpath("test-archive.tar.gz/mft").exists()
+        assert not tmp_path.joinpath("test-archive.tar.gz/mft.jsonl").exists()


### PR DESCRIPTION
- **Change the output file to use FunctionDescriptor name instead of the RecordDescriptor.name**
- **Fix some consistency issues where things didn't function as intended**
- **Adjust tests for changes to target-dump**

<!--
Thank you for submitting a Pull Request. Please:

* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Associate the PR with an issue. If it doesn't exist, create it. Use 
  closing keywords in the body during creation, e.g.:
    * close(|s|d) #<nr>
    * fix(|es|ed) #<nr>
    * resolve(|s|d) #<nr>
-->

# Change target-dump output to use plugin names

Target-dump can't write to the same file multiple times, and as the record descriptor name was used
there is sometimes a collision depending on which plugins get used.

## Suggested changes

The solution proposed is to use the name of the plugin for the file instead.

E.g for `-f webserver.access` it will change the output structure from 

- `<OUTPUT_DIR>/<TARGET_NAME>/webserver/application_webserver_log_access.jsonl`

to

- `<OUTPUT_DIR>/<TARGET_NAME>/webserver_access.jsonl`


Closes #1489

