### PR TITLE
Add lcd, lpwd and shell commands to target-shell

### DIFF
--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -494,7 +494,9 @@ class ExtendedCmd(cmd.Cmd):
             line = os.path.expandvars(line)
             os.chdir(line)
             print("Local directory changed to", Path.cwd())
-            self._local_prev_dir = str(prev)  # only update after successful chdir
+            # only update after successful chdir and only if it's a different directory
+            if prev != Path.cwd():
+                self._local_prev_dir = str(prev)  
         except FileNotFoundError:
             print(f"cd: no such file or directory: {line}")
         except PermissionError:

--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -9,7 +9,6 @@ import io
 import itertools
 import logging
 import os
-import pathlib
 import platform
 import pydoc
 import random
@@ -206,7 +205,7 @@ class ExtendedCmd(cmd.Cmd):
 
         return object.__getattribute__(self, attr)
 
-    def _load_targetrc(self, path: pathlib.Path) -> None:
+    def _load_targetrc(self, path: Path) -> None:
         """Load and execute commands from the run commands file."""
         try:
             with path.open() as fh:
@@ -219,9 +218,9 @@ class ExtendedCmd(cmd.Cmd):
         except Exception as e:
             log.debug("Error processing .targetrc file: %s", e)
 
-    def _get_targetrc_path(self) -> pathlib.Path | None:
+    def _get_targetrc_path(self) -> Path | None:
         """Get the path to the run commands file. Can return ``None`` if ``DEFAULT_RUNCOMMANDS_FILE`` is not set."""
-        return pathlib.Path(self.DEFAULT_RUNCOMMANDS_FILE).expanduser() if self.DEFAULT_RUNCOMMANDS_FILE else None
+        return Path(self.DEFAULT_RUNCOMMANDS_FILE).expanduser() if self.DEFAULT_RUNCOMMANDS_FILE else None
 
     def preloop(self) -> None:
         super().preloop()
@@ -474,7 +473,7 @@ class ExtendedCmd(cmd.Cmd):
 
         # Handle `cd` as a special case, as it needs to change the state of our current process.
         if parts and parts[0] == "cd":
-            target = parts[1].strip() if len(parts) > 1 else pathlib.Path.home()
+            target = parts[1].strip() if len(parts) > 1 else Path.home()
             self.do_lcd(target)
         else:
             subprocess.run(line, shell=True, check=False)
@@ -527,11 +526,11 @@ class TargetCmd(ExtendedCmd):
 
         if self.histdir:
             self.histdirfmt = getattr(target._config, "HISTDIRFMT", self.DEFAULT_HISTDIRFMT)
-            self.histfile = pathlib.Path(self.histdir).resolve() / pathlib.Path(
+            self.histfile = Path(self.histdir).resolve() / Path(
                 self.histdirfmt.format(uid=os.getuid(), target=target.name)
             )
         else:
-            self.histfile = pathlib.Path(getattr(target._config, "HISTFILE", self.DEFAULT_HISTFILE)).expanduser()
+            self.histfile = Path(getattr(target._config, "HISTFILE", self.DEFAULT_HISTFILE)).expanduser()
 
         # prompt format
         self.prompt_ps1 = "{BOLD_GREEN}{base}{RESET}:{BOLD_BLUE}{cwd}{RESET}$ "
@@ -546,9 +545,9 @@ class TargetCmd(ExtendedCmd):
 
         super().__init__(self.target.props.get("cyber"))
 
-    def _get_targetrc_path(self) -> pathlib.Path:
+    def _get_targetrc_path(self) -> Path:
         """Get the path to the run commands file."""
-        return pathlib.Path(
+        return Path(
             getattr(self.target._config, self.CONFIG_KEY_RUNCOMMANDS_FILE, self.DEFAULT_RUNCOMMANDS_FILE)
         ).expanduser()
 
@@ -1200,7 +1199,7 @@ class TargetCli(TargetCmd):
     @arg("-v", "--verbose", action="store_true")
     def cmd_save(self, args: argparse.Namespace, stdout: TextIO) -> bool:
         """Save a common file or directory to the host filesystem."""
-        dst_path = pathlib.Path(args.out).resolve()
+        dst_path = Path(args.out).resolve()
 
         if len(args.path) > 1 and not dst_path.is_dir():
             # Saving multiple items to a non-directory is generally not very
@@ -1208,26 +1207,26 @@ class TargetCli(TargetCmd):
             # items are directories.
             print(f"{dst_path}: cannot save multiple files, destination is not a directory")
 
-        def log_saved_path(src_path: pathlib.Path, dst_path: pathlib.Path) -> None:
+        def log_saved_path(src_path: Path, dst_path: Path) -> None:
             if args.verbose:
                 print(f"{src_path} -> {dst_path}")
 
-        def get_diverging_path(path: pathlib.Path, reference_path: pathlib.Path) -> pathlib.Path:
+        def get_diverging_path(path: Path, reference_path: Path) -> Path:
             """Get the part of path where it diverges from reference_path."""
-            diverging_path = pathlib.Path()
+            diverging_path = Path()
 
             for diff_idx, path_part in enumerate(reference_path.parts):
                 if path_part != path.parts[diff_idx]:
                     diverging_parts = path.parts[diff_idx:]
                     if diverging_parts:
                         for part in diverging_parts:
-                            diverging_path = diverging_path.joinpath(pathlib.Path(part))
+                            diverging_path = diverging_path.joinpath(Path(part))
                     break
 
             return diverging_path
 
         def save_path(
-            src_path: pathlib.Path, dst_path: pathlib.Path, create_dst_subdir: pathlib.Path | None = None
+            src_path: Path, dst_path: Path, create_dst_subdir: Path | None = None
         ) -> None:
             """Save a common file or directory in src_path to dst_path.
 

--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -495,7 +495,7 @@ class ExtendedCmd(cmd.Cmd):
             print("Local directory changed to", Path.cwd())
             # only update after successful chdir and only if it's a different directory
             if prev != Path.cwd():
-                self._local_prev_dir = str(prev)  
+                self._local_prev_dir = str(prev)
         except FileNotFoundError:
             print(f"cd: no such file or directory: {line}")
         except PermissionError:
@@ -1158,7 +1158,7 @@ class TargetCli(TargetCmd):
             else:
                 tar.addfile(info)
 
-        fobj = stdout.buffer if args.file == "-" else pathlib.Path(args.file).open("wb")  # noqa: SIM115
+        fobj = stdout.buffer if args.file == "-" else Path(args.file).open("wb")  # noqa: SIM115
         mode = "w|"
         if args.gzip:
             mode = "w|gz"
@@ -1225,9 +1225,7 @@ class TargetCli(TargetCmd):
 
             return diverging_path
 
-        def save_path(
-            src_path: Path, dst_path: Path, create_dst_subdir: Path | None = None
-        ) -> None:
+        def save_path(src_path: Path, dst_path: Path, create_dst_subdir: Path | None = None) -> None:
             """Save a common file or directory in src_path to dst_path.
 
             If src_path is a file, dst_path can be either a directory or a file

--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -186,6 +186,7 @@ class ExtendedCmd(cmd.Cmd):
         self.debug = DebugMode.OFF
         self.cyber = cyber
         self.identchars += "."
+        self._local_prev_dir: str | None = None
 
         self.register_aliases()
 
@@ -420,7 +421,8 @@ class ExtendedCmd(cmd.Cmd):
 
     def do_clear(self, line: str) -> bool:
         """Clear the terminal screen."""
-        os.system("cls||clear")
+        clear_cmd = "cls" if os.name == "nt" else "clear"
+        subprocess.run(clear_cmd, shell=True, check=False)
         return False
 
     def do_cls(self, line: str) -> bool:
@@ -464,6 +466,45 @@ class ExtendedCmd(cmd.Cmd):
         else:
             print("Usage: debug [on|off|pm]")
 
+        return False
+
+    def do_shell(self, line: str) -> bool:
+        """Execute a local shell command. Usage: !<command>."""
+        parts = line.strip().split(maxsplit=1)
+
+        # Handle `cd` as a special case, as it needs to change the state of our current process.
+        if parts and parts[0] == "cd":
+            target = parts[1].strip() if len(parts) > 1 else pathlib.Path.home()
+            self.do_lcd(target)
+        else:
+            subprocess.run(line, shell=True, check=False)
+        return False
+
+    def do_lcd(self, line: str) -> bool:
+        """Change the local working directory. Usage: lcd <path>."""
+        if line == "-":
+            if self._local_prev_dir is None:
+                print("cd: no previous directory")
+                return False
+            line = self._local_prev_dir
+
+        try:
+            prev = Path.cwd()
+            line = str(Path(line).expanduser())
+            line = os.path.expandvars(line)
+            os.chdir(line)
+            print("Local directory changed to", Path.cwd())
+            self._local_prev_dir = str(prev)  # only update after successful chdir
+        except FileNotFoundError:
+            print(f"cd: no such file or directory: {line}")
+        except PermissionError:
+            print(f"cd: permission denied: {line}")
+
+        return False
+
+    def do_lpwd(self, line: str) -> bool:
+        """Print the current local working directory."""
+        print(Path.cwd())
         return False
 
 

--- a/tests/tools/test_shell.py
+++ b/tests/tools/test_shell.py
@@ -11,6 +11,7 @@ import sys
 import tarfile
 from collections import ChainMap
 from io import BytesIO, StringIO
+from pathlib import Path
 from typing import IO, TYPE_CHECKING, TextIO
 from unittest.mock import MagicMock, call, mock_open, patch
 
@@ -34,7 +35,6 @@ from tests._utils import absolute_path
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
-    from pathlib import Path
 
     from pytest_benchmark.fixture import BenchmarkFixture
 
@@ -155,6 +155,66 @@ def test_debug_mode_parsing() -> None:
 
     cli.do_debug("postmortem")
     assert cli.debug == DebugMode.POST_MORTEM
+
+
+def test_extended_cmd_lcd_and_lpwd(
+    tmp_path: Path, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that do_lcd correctly changes the local directory and do_lpwd prints the local working directory."""
+    cli = ExtendedCmd()
+    start_dir = tmp_path / "start"
+    next_dir = tmp_path / "next"
+    start_dir.mkdir()
+    next_dir.mkdir()
+
+    monkeypatch.chdir(start_dir)
+
+    assert cli.do_lcd(str(next_dir)) is False
+
+    # The current working directory should be updated to the new directory after a successful cd
+    assert str(Path.cwd()) == str(next_dir)
+
+    # _local_prev_dir should be updated to the previous directory after a successful cd
+    assert cli._local_prev_dir == str(start_dir)
+
+    # The output should indicate that the local directory has changed to the new directory
+    out = capsys.readouterr().out
+    assert f"Local directory changed to {next_dir}" in out
+
+    # do_lpwd should print the current local working directory, which should be the new directory
+    assert cli.do_lpwd("") is False
+    out = capsys.readouterr().out
+    assert out.strip() == str(next_dir)
+
+
+def test_extended_cmd_do_shell_runs_subprocess() -> None:
+    """Test that do_shell correctly runs a subprocess for non-cd commands."""
+    cli = ExtendedCmd()
+
+    with patch("dissect.target.tools.shell.subprocess.run") as mocked_run:
+        assert cli.do_shell("echo hello") is False
+
+    mocked_run.assert_called_once_with("echo hello", shell=True, check=False)
+
+
+def test_extended_cmd_do_shell_cd_delegates_to_lcd() -> None:
+    """Test that !cd (do_shell with a cd command) correctly delegates to do_lcd."""
+    cli = ExtendedCmd()
+
+    with patch.object(ExtendedCmd, "do_lcd", autospec=True, return_value=False) as mocked_do_lcd:
+        assert cli.do_shell("cd /tmp") is False
+
+    mocked_do_lcd.assert_called_once_with(cli, "/tmp")
+
+
+def test_extended_cmd_onecmd_bang_delegates_to_do_shell() -> None:
+    """Test that onecmd with a bang command correctly delegates to do_shell."""
+    cli = ExtendedCmd()
+
+    with patch.object(ExtendedCmd, "do_shell", autospec=True, return_value=False) as mocked_do_shell:
+        cli.onecmd("!echo hello")
+
+    mocked_do_shell.assert_called_once_with(cli, "echo hello")
 
 
 def test_run_cli_postmortem() -> None:


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request. Please:

* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Associate the PR with an issue. If it doesn't exist, create it. Use 
  closing keywords in the body during creation, e.g.:
    * close(|s|d) #<nr>
    * fix(|es|ed) #<nr>
    * resolve(|s|d) #<nr>
-->

# Add lcd, lpwd and shell commands to target-shell

This PR adds the following new commands to `target-shell`:

 * `lcd <path>` -> change local working directory, also handles `-` for previous local directory or '~' for home directory.
 * `lpwd` -> prints the current local working directory.
 * `shell <cmd>` -> execute a local command, eg: `shell mkdir /tmp/test` to create a local directory.
 * `!<cmd>` -> shorthand for `shell` (automatically handled by Python's Cmd)


resolves #1606

## Proposed Changes

The changes a trivial and by adding the `do_shell` method, we automatically get `!<cmd>` for free.

However, we also want to catch `!cd /tmp` to not spawn a new process but handle this locally for the current process. This is implemented in `do_shell`.

It also tracks previous working directory so `lcd -` can be used.
It also expands "~" and environment variables (eg: $HOME), but there is no test for this.


You could say that `lcd` and `lpwd` are not necessary because we can do `!cd <path>` and `!pwd` respectively, but think it's still nice to have them available.

## Checklist

- [x] PR Title is descriptive of the changes
- [x] The description is descriptive of the changes
- [x] Tests are included and pass
- [x] Closes `related issue number`

