### PR TITLE
Add atime, ctime, and btime timestamps to YaraMatchRecord

### DIFF
--- a/dissect/target/plugins/filesystem/yara.py
+++ b/dissect/target/plugins/filesystem/yara.py
@@ -33,6 +33,9 @@ YaraMatchRecord = TargetRecordDescriptor(
     "filesystem/yara/match",
     [
         ("datetime", "ts_mtime"),
+        ("datetime", "ts_atime"),
+        ("datetime", "ts_ctime"),
+        ("datetime", "ts_btime"),
         ("path", "path"),
         ("string", "rule"),
         ("string[]", "matches"),
@@ -103,8 +106,9 @@ class YaraPlugin(Plugin):
             for file in files:
                 fhandles = []
                 try:
-                    if (file_size := file.stat().st_size) > max_size:
-                        self.target.log.info("Not scanning file of %s MB: '%s'", (file_size // 1024 // 1024), file)
+                    fstat = file.stat()
+                    if fstat.st_size > max_size:
+                        self.target.log.info("Not scanning file of %s MB: '%s'", (fstat.st_size // 1024 // 1024), file)
                         continue
 
                     fh_original = file.open()
@@ -132,7 +136,10 @@ class YaraPlugin(Plugin):
                                 string_matches.extend(f"{string}={instance}" for instance in string.instances)
 
                             yield YaraMatchRecord(
-                                ts_mtime=file.stat().st_mtime,
+                                ts_mtime=fstat.st_mtime,
+                                ts_atime=fstat.st_atime,
+                                ts_ctime=fstat.st_ctime,
+                                ts_btime=fstat.st_birthtime if hasattr(fstat, "st_birthtime") else None,
                                 path=self.target.fs.path(file.path),
                                 rule=match.rule,
                                 matches=string_matches,

--- a/tests/tools/test_yara.py
+++ b/tests/tools/test_yara.py
@@ -94,8 +94,10 @@ def test_yara_decompress(
 
         out, _ = capsys.readouterr()
 
-        ts_ctime = fieldtypes.datetime(gzip_path.stat().st_ctime)
-        hit = f"<filesystem/yara/match hostname=None domain=None ts_mtime=1970-01-01 00:00:00+00:00 ts_atime=1970-01-01 00:00:00+00:00 ts_ctime={ts_ctime} ts_btime=1970-01-01 00:00:00+00:00 path='/var/log/messages.gz' rule='test_rule_name' matches=['$=test string'] tags=['tag1', 'tag2', 'tag3'] digest=(md5=485a4c5e37cd08a0cdf028cc2b1f32b4, sha1=7716bff4d3282184a17f35f5f0dde25aede762f9, sha256=d175bb08145c0be3338b058f8b7a775cc08967ba6aa7448fa2af9957eb1ab37f)"  # noqa E501
+        gzstat = gzip_path.stat()
+        ts_ctime = fieldtypes.datetime(gzstat.st_ctime)
+        ts_btime = fieldtypes.datetime(gzstat.st_birthtime) if hasattr(gzstat, "st_birthtime") else None
+        hit = f"<filesystem/yara/match hostname=None domain=None ts_mtime=1970-01-01 00:00:00+00:00 ts_atime=1970-01-01 00:00:00+00:00 ts_ctime={ts_ctime} ts_btime={ts_btime} path='/var/log/messages.gz' rule='test_rule_name' matches=['$=test string'] tags=['tag1', 'tag2', 'tag3'] digest=(md5=485a4c5e37cd08a0cdf028cc2b1f32b4, sha1=7716bff4d3282184a17f35f5f0dde25aede762f9, sha256=d175bb08145c0be3338b058f8b7a775cc08967ba6aa7448fa2af9957eb1ab37f)"  # noqa E501
 
         if no_decompress:
             assert len(out.splitlines()) == 0

--- a/tests/tools/test_yara.py
+++ b/tests/tools/test_yara.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
+from flow.record import fieldtypes
 
 from dissect.target.filesystem import VirtualFilesystem
 from dissect.target.tools.yara import HAS_YARA
@@ -45,8 +46,8 @@ def test_yara(target_default: Target, monkeypatch: pytest.MonkeyPatch, capsys: p
 
         out, _ = capsys.readouterr()
 
-        hit1 = "<filesystem/yara/match hostname=None domain=None ts_mtime=1970-01-01 00:00:00+00:00 path='/test_file' rule='test_rule_name' matches=['$=test string'] tags=['tag1', 'tag2', 'tag3'] digest=(md5=d690ba32b59d28614aebefe9b03c74d4, sha1=4b1ced217aabe37138e96fb93bf40026639b9d3b, sha256=7a644118588ff0dcf2fadbe198ae1f1629c29374bac491ba41d5cf957edf0dfc)"  # noqa E501
-        hit2 = "<filesystem/yara/match hostname=None domain=None ts_mtime=1970-01-01 00:00:00+00:00 path='/test/dir/to/test_file' rule='test_rule_name' matches=['$=test string'] tags=['tag1', 'tag2', 'tag3'] digest=(md5=bd7490dd2978ce983e2e1613ac8444c0, sha1=849a062cf09280f5c7dce4c7f87c69a1d9262e08, sha256=9bf7629a67c7ce8019910f1c1251fe44b61b3fff55a59a5e148af3c207dc102f)"  # noqa E501
+        hit1 = "<filesystem/yara/match hostname=None domain=None ts_mtime=1970-01-01 00:00:00+00:00 ts_atime=1970-01-01 00:00:00+00:00 ts_ctime=1970-01-01 00:00:00+00:00 ts_btime=None path='/test_file' rule='test_rule_name' matches=['$=test string'] tags=['tag1', 'tag2', 'tag3'] digest=(md5=d690ba32b59d28614aebefe9b03c74d4, sha1=4b1ced217aabe37138e96fb93bf40026639b9d3b, sha256=7a644118588ff0dcf2fadbe198ae1f1629c29374bac491ba41d5cf957edf0dfc)"  # noqa E501
+        hit2 = "<filesystem/yara/match hostname=None domain=None ts_mtime=1970-01-01 00:00:00+00:00 ts_atime=1970-01-01 00:00:00+00:00 ts_ctime=1970-01-01 00:00:00+00:00 ts_btime=None path='/test/dir/to/test_file' rule='test_rule_name' matches=['$=test string'] tags=['tag1', 'tag2', 'tag3'] digest=(md5=bd7490dd2978ce983e2e1613ac8444c0, sha1=849a062cf09280f5c7dce4c7f87c69a1d9262e08, sha256=9bf7629a67c7ce8019910f1c1251fe44b61b3fff55a59a5e148af3c207dc102f)"  # noqa E501
 
         assert len(out.splitlines()) == 2
 
@@ -93,7 +94,8 @@ def test_yara_decompress(
 
         out, _ = capsys.readouterr()
 
-        hit = "<filesystem/yara/match hostname=None domain=None ts_mtime=1970-01-01 00:00:00+00:00 path='/var/log/messages.gz' rule='test_rule_name' matches=['$=test string'] tags=['tag1', 'tag2', 'tag3'] digest=(md5=485a4c5e37cd08a0cdf028cc2b1f32b4, sha1=7716bff4d3282184a17f35f5f0dde25aede762f9, sha256=d175bb08145c0be3338b058f8b7a775cc08967ba6aa7448fa2af9957eb1ab37f)"  # noqa E501
+        ts_ctime = fieldtypes.datetime(gzip_path.stat().st_ctime)
+        hit = f"<filesystem/yara/match hostname=None domain=None ts_mtime=1970-01-01 00:00:00+00:00 ts_atime=1970-01-01 00:00:00+00:00 ts_ctime={ts_ctime} ts_btime=1970-01-01 00:00:00+00:00 path='/var/log/messages.gz' rule='test_rule_name' matches=['$=test string'] tags=['tag1', 'tag2', 'tag3'] digest=(md5=485a4c5e37cd08a0cdf028cc2b1f32b4, sha1=7716bff4d3282184a17f35f5f0dde25aede762f9, sha256=d175bb08145c0be3338b058f8b7a775cc08967ba6aa7448fa2af9957eb1ab37f)"  # noqa E501
 
         if no_decompress:
             assert len(out.splitlines()) == 0


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request. Please:

* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Associate the PR with an issue. If it doesn't exist, create it. Use 
  closing keywords in the body during creation, e.g.:
    * close(|s|d) #<nr>
    * fix(|es|ed) #<nr>
    * resolve(|s|d) #<nr>
-->

# Add atime, ctime, and btime timestamps to YaraMatchRecord

This PR adds `atime`, `ctime` and `btime` metadata to YaraMatchRecord in the yara plugin.
Before this PR only the `mtime` was present.

Having these extra timestamp fields can be useful.

resolves #1652

## Proposed Changes

Added the extra datetime fields to the YaraMatchRecord RecordDescriptor and ensure that the existing tests pass.

`birthtime` is not always available, in that case it will be `None`.

## Checklist

- [x] PR Title is descriptive of the changes
- [x] The description is descriptive of the changes
- [x] Tests are included and pass
- [x] Closes `related issue number`

