### PR TITLE
Add macOS install history plugin

### DIFF
--- a/dissect/target/plugins/os/unix/bsd/darwin/macos/installhistory.py
+++ b/dissect/target/plugins/os/unix/bsd/darwin/macos/installhistory.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import plistlib
+from typing import TYPE_CHECKING
+
+from dissect.target.exceptions import UnsupportedPluginError
+from dissect.target.helpers.record import TargetRecordDescriptor
+from dissect.target.plugin import Plugin, export
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+InstallHistoryRecord = TargetRecordDescriptor(
+    "macos/install_history",
+    [
+        ("datetime", "ts"),
+        ("string", "name"),
+        ("string", "version"),
+        ("string", "process"),
+        ("string", "content_type"),
+        ("stringlist", "package_ids"),
+        ("path", "source"),
+    ],
+)
+
+
+class InstallHistoryPlugin(Plugin):
+    """macOS install history plugin."""
+
+    PATH = "/Library/Receipts/InstallHistory.plist"
+
+    def check_compatible(self) -> None:
+        if not self.target.fs.path(self.PATH).exists():
+            raise UnsupportedPluginError("No InstallHistory.plist found")
+
+    @export(record=InstallHistoryRecord)
+    def install_history(self) -> Iterator[InstallHistoryRecord]:
+        """Yield software install events recorded by the macOS installer.
+
+        macOS writes a record to ``/Library/Receipts/InstallHistory.plist`` whenever the
+        installer daemon (``installd``/``softwareupdated``) completes an install, operating
+        system update, or configuration data delivery (XProtect, MRT, Gatekeeper).
+
+        Yields ``InstallHistoryRecord`` with the following fields:
+
+        .. code-block:: text
+
+            ts (datetime): Install timestamp.
+            name (string): Display name of the installed item.
+            version (string): Display version of the installed item.
+            process (string): Name of the process that performed the install.
+            content_type (string): Content type, e.g. ``config-data`` for XProtect/MRT payloads.
+            package_ids (stringlist): Package identifiers included in the install.
+            source (path): The source plist of the install history record.
+        """
+        source = self.target.fs.path(self.PATH)
+        with source.open("rb") as fh:
+            entries = plistlib.load(fh)
+
+        for entry in entries:
+            yield InstallHistoryRecord(
+                ts=entry.get("date"),
+                name=entry.get("displayName"),
+                version=entry.get("displayVersion"),
+                process=entry.get("processName"),
+                content_type=entry.get("contentType"),
+                package_ids=entry.get("packageIdentifiers") or [],
+                source=source,
+                _target=self.target,
+            )

--- a/tests/_data/plugins/os/unix/bsd/darwin/macos/installhistory/InstallHistory.plist
+++ b/tests/_data/plugins/os/unix/bsd/darwin/macos/installhistory/InstallHistory.plist
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16235c6033cab1b72fb3fcabd78f034fd706fd251a76af4193e8056e8d220bd2
+size 1067

--- a/tests/plugins/os/unix/bsd/darwin/macos/test_installhistory.py
+++ b/tests/plugins/os/unix/bsd/darwin/macos/test_installhistory.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from flow.record.fieldtypes import datetime as dt
+
+from dissect.target.plugins.os.unix.bsd.darwin.macos.installhistory import (
+    InstallHistoryPlugin,
+)
+from tests._utils import absolute_path
+
+if TYPE_CHECKING:
+    from dissect.target.filesystem import VirtualFilesystem
+    from dissect.target.target import Target
+
+
+@pytest.fixture
+def target_macos_installhistory(target_macos: Target, fs_macos: VirtualFilesystem) -> Target:
+    fs_macos.map_file(
+        "/Library/Receipts/InstallHistory.plist",
+        absolute_path("_data/plugins/os/unix/bsd/darwin/macos/installhistory/InstallHistory.plist"),
+    )
+    target_macos.add_plugin(InstallHistoryPlugin)
+    return target_macos
+
+
+def test_unix_bsd_darwin_macos_install_history(target_macos_installhistory: Target) -> None:
+    records = list(target_macos_installhistory.install_history())
+
+    assert len(records) == 6
+
+    # macOS system update: no contentType, no packageIdentifiers
+    r = records[0]
+    assert r.ts == dt("2025-07-25T13:09:46+00:00")
+    assert r.name == "macOS 15.5"
+    assert r.version == "15.5"
+    assert r.process == "softwareupdated"
+    assert r.content_type is None
+    assert r.package_ids == []
+    assert str(r.source) == "/Library/Receipts/InstallHistory.plist"
+
+    # XProtect: contentType=config-data, single packageIdentifier
+    r = records[1]
+    assert r.ts == dt("2025-07-30T15:24:26+00:00")
+    assert r.name == "XProtectPlistConfigData"
+    assert r.content_type == "config-data"
+    assert r.package_ids == ["com.apple.pkg.XProtectPlistConfigData_10_15.16U4380"]
+
+    # Command Line Tools: 9 packageIdentifiers
+    r = records[4]
+    assert r.name == "Command Line Tools for Xcode 26.0"
+    assert r.content_type is None
+    assert len(r.package_ids) == 9
+    assert "com.apple.pkg.CLTools_Executables" in r.package_ids
+
+    # Safari install
+    r = records[5]
+    assert r.name == "Safari"
+    assert r.version == "26.0.1"
+    assert r.package_ids == ["com.apple.pkg.Safari26.0.1SequoiaAuto"]


### PR DESCRIPTION
Add a macOS plugin that parses `/Library/Receipts/InstallHistory.plist`, the system-level install log written by `installd` / `softwareupdated` whenever an install, OS update, or configuration-data delivery (XProtect, MRT, Gatekeeper) completes.

The plugin emits one `InstallHistoryRecord` per install event with fields for timestamp, display name, version, process, content type, and package identifiers.

Implementation notes:
- Uses stdlib `plistlib` to parse the plist; no new helpers added.
- Follows the `macos/user.py` pattern: bare `Plugin` base, `UnsupportedPluginError` on missing path, `TargetRecordDescriptor` with the `macos/install_history` namespace.
- Test fixture is a real `InstallHistory.plist` trimmed to 6 Apple-system-only entries (`macOS 15.5`, `XProtectPlistConfigData`, `MRTConfigData`, `Gatekeeper Compatibility Data`, `Command Line Tools for Xcode 26.0`, `Safari 26.0.1`) to exclude any third-party software.