### PR TITLE
Add Omnissa DEM loader

### DIFF
--- a/dissect/target/loader.py
+++ b/dissect/target/loader.py
@@ -275,6 +275,7 @@ register("cellebrite", "CellebriteLoader")
 register("target", "TargetLoader")
 # Disabling ResLoader because of DIS-536
 # register("res", "ResLoader")
+register("dem", "DemLoader")
 register("overlay2", "Overlay2Loader")
 register("overlay", "OverlayLoader")
 register("phobos", "PhobosLoader")

--- a/dissect/target/loaders/dem.py
+++ b/dissect/target/loaders/dem.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from dissect.target.filesystem import VirtualFilesystem
+from dissect.target.helpers import record
+from dissect.target.helpers.fsutil import TargetPath
+from dissect.target.helpers.regutil import RegFlex
+from dissect.target.loader import Loader
+from dissect.target.plugin import export
+from dissect.target.plugins.os.windows._os import WindowsPlugin
+from dissect.target.plugins.os.windows.registry import RegistryPlugin
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from typing_extensions import Self
+
+    from dissect.target.filesystem import Filesystem
+    from dissect.target.target import Target
+
+log = logging.getLogger(__name__)
+
+DEM_DIRS = (
+    "demData",
+    "demData_agt_wss",
+    "demData_fbu_wss",
+    "demData_wss_test",
+    "demDataPP",
+)
+
+DIR_MAPPING = {
+    "appdata": "AppData/Roaming",
+    "localappdata": "AppData/Local",
+    "recentfiles": "AppData/Roaming/Microsoft/Windows/Recent",
+}
+
+
+def find_dem_path(path: Path) -> Path | None:
+    """Find the DEM data directory within the given path."""
+    for dem in DEM_DIRS:
+        dem_path = path / dem
+        if dem_path.is_dir():
+            return dem_path  # man
+
+    return None
+
+
+class DemLoader(Loader):
+    """Load Omnissa Dynamic Environment Manager (DEM / FlexEngine) profile data.
+
+    The ``demData`` directory contains exported application- and roaming profile data.
+
+    Each category (e.g. ``Applications``, ``Windows Settings``) has one subdirectory per managed application or setting.
+
+    That subdirectory can contain:
+    - ``AppData/``      -> ``C:/Users/<user>/AppData/Roaming/``
+    - ``LocalAppData/`` -> ``C:/Users/<user>/AppData/Local/``
+    - ``RecentFiles/``  -> ``C:/Users/<user>/AppData/Roaming/Microsoft/Windows/Recent/``
+    - ``Registry/``     -> ``HKEY_CURRENT_USER`` registry entries (RegFlex ``.reg`` files)
+
+    The ``backup/`` and ``FlexRepository/`` subdirectories are explicitly ignored for now.
+
+    Resources:
+    - https://docs.omnissa.com/bundle/DEMInstallConfigGuideV2209/page/IntroductiontoDynamicEnvironmentManager.html
+    """
+
+    @staticmethod
+    def detect(path: Path) -> bool:
+        return find_dem_path(path) is not None
+
+    def map(self, target: Target) -> None:
+        dem_path = find_dem_path(self.absolute_path)
+        username = self.absolute_path.name
+
+        vfs = VirtualFilesystem(case_sensitive=False)
+        target.filesystems.add(vfs)
+        regflex = RegFlex()
+
+        # <category>/<app>/<entry>
+        # avoid nested looping and is_dir checks
+        for entry in dem_path.glob("*/*/*"):
+            if not entry.is_dir():
+                continue
+
+            name = entry.name.lower()
+            if name in DIR_MAPPING:
+                for file in entry.rglob("*"):
+                    if file.is_file():
+                        dest = f"Users/{username}/{DIR_MAPPING[name]}/{file.relative_to(entry).as_posix()}"
+                        vfs.map_file(dest, file)
+
+            elif name == "registry":
+                for reg_file in entry.rglob("*.reg"):
+                    with reg_file.open("r", encoding="utf-16") as fh:
+                        regflex.map_definition(fh)
+
+        target.props["username"] = username
+        target._os_plugin = DemOSPlugin.create(target, vfs)
+        target.add_plugin(RegistryPlugin, check_compatible=False)
+
+        for name, hive in regflex.hives.items():
+            target.registry.add_hive(name, "HKEY_USERS\\S-1-0-0", hive, TargetPath(target.fs, dem_path.name))
+
+
+class DemOSPlugin(WindowsPlugin):
+    @classmethod
+    def detect(cls, target: Target) -> Filesystem | None:
+        for fs in target.filesystems:
+            for dem_dir in DEM_DIRS:
+                if fs.exists(f"/{dem_dir}"):
+                    return fs
+        return None
+
+    @classmethod
+    def create(cls, target: Target, sysvol: Filesystem) -> Self:
+        target.fs.case_sensitive = False
+        target.fs.mount("sysvol", sysvol)
+        return cls(target)
+
+    @export(property=True)
+    def hostname(self) -> str:
+        return self.target.props.get("username", self.target.path)
+
+    @export(property=True)
+    def ips(self) -> list[str]:
+        return []
+
+    @export
+    def users(self) -> Iterator[record.WindowsUserRecord]:
+        yield record.WindowsUserRecord(
+            sid="S-1-0-0",
+            name=self.hostname,
+            home=f"sysvol/users/{self.hostname}",
+            _target=self.target,
+        )
+
+    @export(property=True)
+    def os(self) -> str:
+        return "windows"

--- a/tests/loaders/test_dem.py
+++ b/tests/loaders/test_dem.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from dissect.target.loader import open as loader_open
+from dissect.target.loaders.dem import DemLoader, DemOSPlugin
+from dissect.target.target import Target
+from tests._utils import mkdirs
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def mock_dem_dir(tmp_path: Path) -> Path:
+    root = tmp_path
+    mkdirs(
+        root,
+        [
+            "User/demData/Applications/Mozilla Firefox/AppData/Mozilla/Firefox",
+            "User/demData/Applications/Mozilla Firefox/Registry",
+            "User/demData/Windows Settings/Windows Explorer/AppData/Microsoft/Windows/Recent/AutomaticDestinations",
+            "User/demData/Microsoft Office 2069/Word/AppData/Microsoft/Word",
+            "User/demData/Applications/Edge Chromium/LocalAppData/Microsoft/Edge/User Data",
+            "User/demData/backup",  # These should be ignored
+            "User/demData/FlexRepository",
+        ],
+    )
+    file = root / "User/demData/Applications/Mozilla Firefox/AppData/Mozilla/Firefox/profiles.ini"
+    file.write_text("kusjes=1")
+
+    file = (
+        root / "User/demData/Windows Settings/Windows Explorer/AppData/Microsoft/Windows/Recent/"
+        "AutomaticDestinations/test.automaticDestinations-ms"
+    )
+    file.write_bytes(b"\x67\x67\x77\x70")
+
+    file = root / "User/demData/Microsoft Office 2069/Word/AppData/Microsoft/Word/backup.wbk"
+    file.write_bytes(b"\x64\x65\x6d\x73")
+
+    file = root / "User/demData/Applications/Edge Chromium/LocalAppData/Microsoft/Edge/User Data/Last Browser"
+    file.write_text("C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe")
+
+    reg_file = root / "User/demData/Applications/Mozilla Firefox/Registry/Flex Profiles.reg"
+    reg_file.write_text(
+        "Windows Registry Editor Version 5.00\r\n\r\n"
+        "[HKEY_CURRENT_USER\\Software\\Key]\r\n"
+        '"Version"="1.0"\r\n'
+        '"WheredYouFindThis"=dword:00001337\r\n',
+        encoding="utf-16",
+    )
+
+    return root / "User"
+
+
+def test_target_open(mock_dem_dir: Path) -> None:
+    """Test that we correctly use ``DemLoader`` when opening a ``Target``."""
+    loader = loader_open(mock_dem_dir)
+    assert isinstance(loader, DemLoader)
+    assert DemLoader.detect(mock_dem_dir)
+    assert loader.path == mock_dem_dir
+
+    target = Target()
+    loader.map(target)
+    target.apply()
+
+
+def test_dem_mapping(mock_dem_dir: Path) -> None:
+    """Test that we correctly map DEM data into the ``Target``."""
+    target = Target.open(mock_dem_dir)
+
+    vfs_path = target.fs.path("sysvol/Users/User/AppData/Roaming/Mozilla/Firefox/profiles.ini")
+    assert vfs_path.exists()
+    assert vfs_path.read_text() == "kusjes=1"
+
+    vfs_path = target.fs.path(
+        "sysvol/Users/User/AppData/Roaming/Microsoft/Windows/Recent/AutomaticDestinations/test.automaticDestinations-ms"
+    )
+    assert vfs_path.exists()
+    assert vfs_path.read_bytes() == b"\x67\x67\x77\x70"
+
+    vfs_path = target.fs.path("sysvol/Users/User/AppData/Roaming/Microsoft/Word/backup.wbk")
+    assert vfs_path.exists()
+    assert vfs_path.read_bytes() == b"\x64\x65\x6d\x73"
+
+    vfs_path = target.fs.path("sysvol/Users/User/AppData/Local/Microsoft/Edge/User Data/Last Browser")
+    assert vfs_path.exists()
+    assert vfs_path.read_text() == "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe"
+
+
+def test_dem_registry_mapping(mock_dem_dir: Path) -> None:
+    """Test that we correctly map registry entries from DEM data into the ``Target``."""
+    target = Target.open(mock_dem_dir)
+
+    name, hive, path = next(target.registry.iterhives())
+    assert name == "HKEY_CURRENT_USER"
+    assert path.as_posix() == "demData"
+
+    key = hive.key("Software\\Key")
+    assert key.value("Version").value == "1.0"
+    assert key.value("WheredYouFindThis").value == 0x1337
+
+
+def test_dem_os_plugin(mock_dem_dir: Path) -> None:
+    """Test that we correctly create a ``DemOSPlugin`` when mapping DEM data."""
+    target = Target.open(mock_dem_dir)
+
+    assert isinstance(target._os, DemOSPlugin)
+    assert target.os == "windows"
+    assert target.hostname == "User"
+    assert target.version is None
+
+    users = list(target.users())
+    assert len(users) == 1
+    assert users[0].name == "User"
+    assert users[0].sid == "S-1-0-0"


### PR DESCRIPTION
This PR adds Loader (`DemLoader`) and OS (`DemOSPlugin`) support for Omnissa Dynamic Environment Manager (DEM / FlexEngine) Windows profile data. 

Closes #1722
Depends on #1725 