### PR TITLE
Fix authlog plugin for missing key information

### DIFF
--- a/dissect/target/plugins/os/unix/log/auth.py
+++ b/dissect/target/plugins/os/unix/log/auth.py
@@ -386,4 +386,4 @@ class AuthPlugin(Plugin):
                 iterable = year_rollover_helper(auth_file, RE_TS, "%b %d %H:%M:%S", target_tz)
 
             for ts, line in iterable:
-                self._auth_log_builder.build_record(ts, auth_file, line)
+                yield self._auth_log_builder.build_record(ts, auth_file, line)

--- a/dissect/target/plugins/os/unix/log/auth.py
+++ b/dissect/target/plugins/os/unix/log/auth.py
@@ -80,14 +80,22 @@ class SshdService(BaseService):
             additional_fields["port"] = int(port.group(1))
         if user := cls.RE_USER.search(message):
             additional_fields["user"] = user.group(1)
-        # Accepted publickey for test_user from 8.8.8.8 IP port 12345 ssh2: RSA SHA256:123456789asdfghjklertzuio
+
         if "Accepted publickey" in message:
-            ssh_protocol, encryption_algo, key_info = message.split()[-3:]
-            hash_algo, key_hash = key_info.split(":")
-            additional_fields["ssh_protocol"] = ssh_protocol.strip(":")
-            additional_fields["encryption_algorithm"] = encryption_algo
-            additional_fields["hash_algorithm"] = hash_algo
-            additional_fields["key_hash"] = key_hash
+            try:
+                # Accepted publickey for test_user from 8.8.8.8 IP port 12345 ssh2: RSA SHA256:123456789asdfghjklertzuio
+                if message.split()[-3].endswith(":"):
+                    ssh_protocol, encryption_algo, key_info = message.split()[-3:]
+                    hash_algo, key_hash = key_info.split(":")
+                    additional_fields["ssh_protocol"] = ssh_protocol.strip(":")
+                    additional_fields["encryption_algorithm"] = encryption_algo
+                    additional_fields["hash_algorithm"] = hash_algo
+                    additional_fields["key_hash"] = key_hash
+                # Accepted publickey for test_user from 8.8.8.8 IP port 12345 ssh2
+                else:
+                    additional_fields["ssh_protocol"] = message.split()[-1]
+            except ValueError:
+                pass
         if (failed := "Failed" in message) or "Accepted" in message:
             action_type = "failed" if failed else "accepted"
             additional_fields["action"] = f"{action_type} authentication"
@@ -378,4 +386,4 @@ class AuthPlugin(Plugin):
                 iterable = year_rollover_helper(auth_file, RE_TS, "%b %d %H:%M:%S", target_tz)
 
             for ts, line in iterable:
-                yield self._auth_log_builder.build_record(ts, auth_file, line)
+                self._auth_log_builder.build_record(ts, auth_file, line)

--- a/tests/_data/plugins/os/unix/log/auth/auth.log
+++ b/tests/_data/plugins/os/unix/log/auth/auth.log
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:12aa01e4a9d35e769f330318a3a5395e56a53059adfb32a608f0d0651aaeff3d
-size 958
+oid sha256:e829aa8811a4d3bc5127eac8f2538ed2b395ddf8bb2def3ee05caac088f96720
+size 1055


### PR DESCRIPTION
When the algo information is missing in the message (which happens on certain machines) the authlog plugin currently doesn't work anymore. The proposed changes makes sure it supports this format, and even if it still fails the plugin will continue.

Fixes #1728

