### PR TITLE
Replace `OperatingSystem.*.value` with `OperatingSystem.*`

### DIFF
--- a/dissect/target/helpers/arch.py
+++ b/dissect/target/helpers/arch.py
@@ -63,11 +63,11 @@ MACHINE_MAP_DARWIN = {
 # Translate the operating system to it's corresponding vendor name.
 # Linux derivatives generally translate to 'unknown', except Android, which translates to 'linux'.
 OS_TO_VENDOR = {
-    OperatingSystem.WINDOWS.value: "pc",
-    OperatingSystem.MACOS.value: "apple",
-    OperatingSystem.OSX.value: "apple",
-    OperatingSystem.IOS.value: "apple",
-    OperatingSystem.ANDROID.value: "linux",  # yes, really..
+    OperatingSystem.WINDOWS: "pc",
+    OperatingSystem.MACOS: "apple",
+    OperatingSystem.OSX: "apple",
+    OperatingSystem.IOS: "apple",
+    OperatingSystem.ANDROID: "linux",  # yes, really..
 }
 
 
@@ -97,12 +97,12 @@ def target_triple(os: str, machine: str | int, bitness: int | None = None, endia
     """
     vendor = OS_TO_VENDOR.get(os, "unknown")
 
-    if os == OperatingSystem.WINDOWS.value:
+    if os == OperatingSystem.WINDOWS:
         if not isinstance(machine, str):
             raise ValueError(f"Unexpected machine type for windows: {machine!r}")
         machine = MACHINE_MAP_WINDOWS.get(machine, machine)
 
-    elif os in (OperatingSystem.MACOS.value, OperatingSystem.OSX.value, OperatingSystem.IOS.value):
+    elif os in (OperatingSystem.MACOS, OperatingSystem.OSX, OperatingSystem.IOS):
         if not isinstance(machine, int):
             raise ValueError(f"Unexpected machine type for darwin: {machine!r}")
         machine = MACHINE_MAP_DARWIN.get(machine, machine)

--- a/dissect/target/plugins/apps/browser/chromium.py
+++ b/dissect/target/plugins/apps/browser/chromium.py
@@ -83,6 +83,8 @@ DOWNLOAD_STATES = {
 class ChromiumMixin:
     """Mixin class with methods for Chromium-based browsers."""
 
+    target: Target
+
     DIRS = ()
 
     BrowserHistoryRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
@@ -283,7 +285,7 @@ class ChromiumMixin:
         for user, db_file, db in self._iter_db("Cookies", subdirs=["Network"]):
             keys = {}
 
-            if self.target.os == OperatingSystem.WINDOWS.value:
+            if self.target.os == OperatingSystem.WINDOWS:
                 try:
                     local_state_parent = db_file.parent.parent
                     if db_file.parent.name == "Network":
@@ -513,7 +515,7 @@ class ChromiumMixin:
         for user, db_file, db in self._iter_db("Login Data"):
             keys = {}
 
-            if self.target.os == OperatingSystem.WINDOWS.value:
+            if self.target.os == OperatingSystem.WINDOWS:
                 try:
                     local_state_path = db_file.parent.parent.joinpath("Local State")
                     keys = self.decryption_keys(local_state_path, user.user.name)
@@ -679,16 +681,16 @@ class ChromiumMixin:
     def decrypt_value(self, user: UserDetails, keys: ChromiumKeys, encrypted: bytes) -> bytes:
         """Attempt to decrypt the given encrypted bytes."""
         DECRYPT_MAP = {
-            OperatingSystem.WINDOWS.value: {
+            OperatingSystem.WINDOWS: {
                 b"\x01\x00\x00": decrypt_dpapi,  # First three bytes of DPAPI blob signature.
                 b"v10": decrypt_v10_windows,
                 b"v20": decrypt_v20_windows,
             },
-            OperatingSystem.UNIX.value: {
+            OperatingSystem.UNIX: {
                 b"v10": decrypt_v10_linux,
                 b"v11": decrypt_v11_linux,
             },
-            OperatingSystem.LINUX.value: {
+            OperatingSystem.LINUX: {
                 b"v10": decrypt_v10_linux,
                 b"v11": decrypt_v11_linux,
             },

--- a/dissect/target/plugins/apps/vpn/openvpn.py
+++ b/dissect/target/plugins/apps/vpn/openvpn.py
@@ -129,8 +129,8 @@ class OpenVPNPlugin(Plugin):
     )
 
     user_config_paths: Final[dict[str, list[str]]] = {
-        OperatingSystem.WINDOWS.value: ["OpenVPN/config/"],
-        OperatingSystem.OSX.value: ["Library/Application Support/OpenVPN Connect/profiles/"],
+        OperatingSystem.WINDOWS: ["OpenVPN/config/"],
+        OperatingSystem.OSX: ["Library/Application Support/OpenVPN Connect/profiles/"],
     }
 
     def __init__(self, target: Target):

--- a/dissect/target/plugins/apps/vpn/openvpn.py
+++ b/dissect/target/plugins/apps/vpn/openvpn.py
@@ -128,7 +128,7 @@ class OpenVPNPlugin(Plugin):
         "sysvol/Program Files/OpenVPN/config/",
     )
 
-    user_config_paths: Final[dict[str, list[str]]] = {
+    user_config_paths: Final[dict[OperatingSystem, list[str]]] = {
         OperatingSystem.WINDOWS: ["OpenVPN/config/"],
         OperatingSystem.OSX: ["Library/Application Support/OpenVPN Connect/profiles/"],
     }

--- a/dissect/target/plugins/child/esxi.py
+++ b/dissect/target/plugins/child/esxi.py
@@ -6,7 +6,7 @@ from dissect.hypervisor import vmx
 
 from dissect.target.exceptions import UnsupportedPluginError
 from dissect.target.helpers.record import ChildTargetRecord
-from dissect.target.plugin import ChildTargetPlugin
+from dissect.target.plugin import ChildTargetPlugin, OperatingSystem
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -18,7 +18,7 @@ class ESXiChildTargetPlugin(ChildTargetPlugin):
     __type__ = "esxi"
 
     def check_compatible(self) -> None:
-        if self.target.os != "esxi":
+        if self.target.os != OperatingSystem.ESXI:
             raise UnsupportedPluginError("Not an ESXi operating system")
 
     def list_children(self) -> Iterator[ChildTargetRecord]:

--- a/dissect/target/plugins/child/proxmox.py
+++ b/dissect/target/plugins/child/proxmox.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from dissect.target.exceptions import UnsupportedPluginError
 from dissect.target.helpers.record import ChildTargetRecord
-from dissect.target.plugin import ChildTargetPlugin
+from dissect.target.plugin import ChildTargetPlugin, OperatingSystem
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -16,7 +16,7 @@ class ProxmoxChildTargetPlugin(ChildTargetPlugin):
     __type__ = "proxmox"
 
     def check_compatible(self) -> None:
-        if self.target.os != "proxmox":
+        if self.target.os != OperatingSystem.PROXMOX:
             raise UnsupportedPluginError("Not a Proxmox operating system")
 
     def list_children(self) -> Iterator[ChildTargetRecord]:

--- a/dissect/target/plugins/filesystem/unix/suid.py
+++ b/dissect/target/plugins/filesystem/unix/suid.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from dissect.target.exceptions import UnsupportedPluginError
 from dissect.target.helpers.record import TargetRecordDescriptor
-from dissect.target.plugin import Plugin, export
+from dissect.target.plugin import OperatingSystem, Plugin, export
 from dissect.target.plugins.filesystem.walkfs import FilesystemRecord
 
 if TYPE_CHECKING:
@@ -21,7 +21,7 @@ class SuidPlugin(Plugin):
     """Unix SUID binary plugin."""
 
     def check_compatible(self) -> None:
-        if not self.target.has_function("walkfs") or self.target.os == "windows":
+        if not self.target.has_function("walkfs") or self.target.os == OperatingSystem.WINDOWS:
             raise UnsupportedPluginError("Unsupported plugin")
 
     @export(record=SuidRecord)

--- a/dissect/target/plugins/general/users.py
+++ b/dissect/target/plugins/general/users.py
@@ -10,7 +10,7 @@ from dissect.target.helpers.record import (
     UnixUserRecord,
     WindowsUserRecord,
 )
-from dissect.target.plugin import InternalPlugin
+from dissect.target.plugin import InternalPlugin, OperatingSystem
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -51,7 +51,7 @@ class UsersPlugin(InternalPlugin):
             raise ValueError("Either sid or uid or username is expected")
 
         def is_name_matching(name: str) -> bool:
-            if force_case_sensitive or self.target.os != "windows":
+            if force_case_sensitive or self.target.os != OperatingSystem.WINDOWS:
                 # always do case-sensitive match for non-Windows OSes
                 return name == username
             return name.lower() == username.lower()

--- a/dissect/target/plugins/os/unix/bsd/citrix/generic.py
+++ b/dissect/target/plugins/os/unix/bsd/citrix/generic.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from dissect.util import ts
 
 from dissect.target.exceptions import UnsupportedPluginError
-from dissect.target.plugin import Plugin, export
+from dissect.target.plugin import OperatingSystem, Plugin, export
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -15,7 +15,7 @@ class GenericPlugin(Plugin):
     """Generic Citrix plugin."""
 
     def check_compatible(self) -> None:
-        if self.target.os != "citrix-netscaler":
+        if self.target.os != OperatingSystem.CITRIX:
             raise UnsupportedPluginError("Citrix Netscaler specific plugin loaded on non-Citrix target")
 
     @export(property=True)

--- a/dissect/target/plugins/os/unix/bsd/citrix/locale.py
+++ b/dissect/target/plugins/os/unix/bsd/citrix/locale.py
@@ -5,7 +5,7 @@ import re
 
 from dissect.target.exceptions import UnsupportedPluginError
 from dissect.target.helpers.localeutil import normalize_language
-from dissect.target.plugin import export
+from dissect.target.plugin import OperatingSystem, export
 from dissect.target.plugins.os.default.locale import LocalePlugin
 
 RE_CONFIG_TIMEZONE = re.compile(
@@ -17,7 +17,7 @@ class CitrixLocalePlugin(LocalePlugin):
     """Citrix Netscaler locale plugin."""
 
     def check_compatible(self) -> None:
-        if self.target.os != "citrix-netscaler":
+        if self.target.os != OperatingSystem.CITRIX:
             raise UnsupportedPluginError("Citrix Netscaler specific plugin loaded on non-Citrix target")
 
     @export(property=True)

--- a/dissect/target/plugins/os/unix/esxi/esxconf.py
+++ b/dissect/target/plugins/os/unix/esxi/esxconf.py
@@ -4,7 +4,7 @@ import json as jsonlib
 from typing import TYPE_CHECKING, TextIO, TypeAlias
 
 from dissect.target.exceptions import UnsupportedPluginError
-from dissect.target.plugin import Plugin, arg, export, internal
+from dissect.target.plugin import OperatingSystem, Plugin, arg, export, internal
 
 if TYPE_CHECKING:
     from dissect.target.target import Target
@@ -26,7 +26,7 @@ class EsxConfPlugin(Plugin):
                 self._config = parse_esx_conf(fh)
 
     def check_compatible(self) -> None:
-        if self.target.os != "esxi":
+        if self.target.os != OperatingSystem.ESXI:
             raise UnsupportedPluginError("ESXi specific plugin loaded on non-ESXi target")
 
         if not self._config:

--- a/dissect/target/plugins/os/unix/esxi/vm.py
+++ b/dissect/target/plugins/os/unix/esxi/vm.py
@@ -6,7 +6,7 @@ from defusedxml import ElementTree
 
 from dissect.target.exceptions import UnsupportedPluginError
 from dissect.target.helpers.record import TargetRecordDescriptor
-from dissect.target.plugin import Plugin, export
+from dissect.target.plugin import OperatingSystem, Plugin, export
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -33,7 +33,7 @@ class VirtualMachinePlugin(Plugin):
     __namespace__ = "vm"
 
     def check_compatible(self) -> None:
-        if self.target.os != "esxi":
+        if self.target.os != OperatingSystem.ESXI:
             raise UnsupportedPluginError("ESXi specific plugin loaded on non-ESXi target")
 
         if not self.target.fs.path("/etc/vmware/hostd/vmInventory.xml").exists():

--- a/dissect/target/plugins/os/unix/linux/debian/proxmox/vm.py
+++ b/dissect/target/plugins/os/unix/linux/debian/proxmox/vm.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from dissect.target.exceptions import UnsupportedPluginError
 from dissect.target.helpers.record import TargetRecordDescriptor
-from dissect.target.plugin import Plugin, export
+from dissect.target.plugin import OperatingSystem, Plugin, export
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -21,7 +21,7 @@ class VirtualMachinePlugin(Plugin):
     """Plugin to list Proxmox virtual machines."""
 
     def check_compatible(self) -> None:
-        if self.target.os != "proxmox":
+        if self.target.os != OperatingSystem.PROXMOX:
             raise UnsupportedPluginError("Not a Proxmox operating system")
 
     @export(record=VirtualMachineRecord)

--- a/dissect/target/plugins/os/unix/linux/fortios/generic.py
+++ b/dissect/target/plugins/os/unix/linux/fortios/generic.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from dissect.util import ts
 
 from dissect.target.exceptions import UnsupportedPluginError
-from dissect.target.plugin import Plugin, export
+from dissect.target.plugin import OperatingSystem, Plugin, export
 from dissect.target.plugins.os.unix.generic import calculate_last_activity
 
 if TYPE_CHECKING:
@@ -16,7 +16,7 @@ class GenericPlugin(Plugin):
     """Generic FortiOS plugin."""
 
     def check_compatible(self) -> None:
-        if self.target.os != "fortios":
+        if self.target.os != OperatingSystem.FORTIOS:
             raise UnsupportedPluginError("FortiOS specific plugin loaded on non-FortiOS target")
 
     @export(property=True)

--- a/dissect/target/plugins/os/unix/linux/fortios/locale.py
+++ b/dissect/target/plugins/os/unix/linux/fortios/locale.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dissect.target.exceptions import UnsupportedPluginError
-from dissect.target.plugin import export
+from dissect.target.plugin import OperatingSystem, export
 from dissect.target.plugins.os.default.locale import LocalePlugin
 
 
@@ -9,7 +9,7 @@ class FortiOSLocalePlugin(LocalePlugin):
     """FortiOS locale plugin."""
 
     def check_compatible(self) -> None:
-        if self.target.os != "fortios":
+        if self.target.os != OperatingSystem.FORTIOS:
             raise UnsupportedPluginError("FortiOS specific plugin loaded on non-FortiOS target")
 
     @export(property=True)

--- a/tests/loaders/test_cellebrite.py
+++ b/tests/loaders/test_cellebrite.py
@@ -6,6 +6,7 @@ import pytest
 
 from dissect.target.loader import open as loader_open
 from dissect.target.loaders.cellebrite import CellebriteFilesystem, CellebriteLoader
+from dissect.target.plugin import OperatingSystem
 from dissect.target.target import Target
 from tests._utils import absolute_path
 
@@ -83,5 +84,5 @@ def test_loader() -> None:
         "/var",
     ]
 
-    assert t.os == "linux"
+    assert t.os == OperatingSystem.LINUX == "linux"
     assert t.hostname == "example"

--- a/tests/plugins/apps/virtualization/test_vmware_workstation.py
+++ b/tests/plugins/apps/virtualization/test_vmware_workstation.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from dissect.target.plugin import OperatingSystem
 from dissect.target.plugins.apps.virtualization.vmware_workstation import (
     VmwareWorkstationPlugin,
 )
@@ -70,7 +71,7 @@ def test_vmware_workstation_vm_configs(
         str(absolute_path(f"_data/plugins/apps/virtualization/vmware_workstation/inventory-{target.os}.vmls")),
     )
     fs.map_file(
-        "first.vmx" if target.os == "windows" else "/path/to/first.vmx",
+        "first.vmx" if target.os == OperatingSystem.WINDOWS else "/path/to/first.vmx",
         str(absolute_path("_data/plugins/apps/virtualization/vmware_workstation/first.vmx")),
     )
 

--- a/tests/plugins/os/unix/bsd/citrix/test__os.py
+++ b/tests/plugins/os/unix/bsd/citrix/test__os.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from flow.record.fieldtypes import posix_path
 
+from dissect.target.plugin import OperatingSystem
 from dissect.target.plugins.os.unix.bsd.citrix._os import CitrixPlugin
 
 if TYPE_CHECKING:
@@ -31,7 +32,7 @@ def test_citrix_os(target_citrix: Target, fs_bsd: VirtualFilesystem) -> None:
 
     target_citrix.add_plugin(CitrixPlugin)
 
-    assert target_citrix.os == "citrix-netscaler"
+    assert target_citrix.os == OperatingSystem.CITRIX == "citrix-netscaler"
     hostname = target_citrix.hostname
     version = target_citrix.version
     users = sorted(target_citrix.users(), key=lambda user: (user.name, str(user.home) if user.home else ""))

--- a/tests/plugins/os/unix/bsd/darwin/ios/test__os.py
+++ b/tests/plugins/os/unix/bsd/darwin/ios/test__os.py
@@ -37,7 +37,7 @@ def test_ios_os(target_ios: Target, fs_ios: VirtualFilesystem) -> None:
     target_ios.add_plugin(IOSApplicationsPlugin)
     target_ios.apply()
 
-    assert target_ios.os == OperatingSystem.IOS
+    assert target_ios.os == OperatingSystem.IOS == "ios"
     assert target_ios.version == "iPhone OS 17.3 (21D50)"
     assert target_ios.architecture == "aarch64-apple-ios"
     assert target_ios.hostname == "This-Iss-iPhone"

--- a/tests/plugins/os/unix/bsd/darwin/macos/test__os.py
+++ b/tests/plugins/os/unix/bsd/darwin/macos/test__os.py
@@ -29,7 +29,7 @@ def test_macos_os(target_macos_users: Target, fs_macos: VirtualFilesystem) -> No
     dissect_user = users[0]
     test_user = users[1]
 
-    assert target_macos_users.os == OperatingSystem.MACOS
+    assert target_macos_users.os == OperatingSystem.MACOS == "macos"
     assert target_macos_users.hostname == "dummys-Mac"
     assert target_macos_users.version == "macOS 11.7.5 (20G1225)"
 

--- a/tests/plugins/os/unix/esxi/test__os.py
+++ b/tests/plugins/os/unix/esxi/test__os.py
@@ -97,7 +97,7 @@ def test_esxi_os_detection(target_bare: Target, fs_esxi: VirtualFilesystem) -> N
 
     assert ESXiPlugin.detect(target_bare)
     assert isinstance(target_bare._os, ESXiPlugin)
-    assert target_bare.os == OperatingSystem.ESXI
+    assert target_bare.os == OperatingSystem.ESXI == "esxi"
     assert target_bare.hostname == "localhost"
     assert target_bare.version == "6.7.0"
     assert target_bare.ips == ["192.168.56.101"]

--- a/tests/plugins/os/unix/linux/android/test__os.py
+++ b/tests/plugins/os/unix/linux/android/test__os.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from dissect.target.filesystem import VirtualFilesystem
+from dissect.target.plugin import OperatingSystem
 from dissect.target.plugins.os.unix.linux.android._os import AndroidPlugin
 from tests._utils import absolute_path
 
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 def test_android_os(target_android: Target) -> None:
     target_android.add_plugin(AndroidPlugin)
 
-    assert target_android.os == "android"
+    assert target_android.os == OperatingSystem.ANDROID == "android"
     assert target_android.version == "Android 4.4.2 (2013-10-31)"
     assert target_android.hostname == "TMG28071935"
 
@@ -49,7 +50,7 @@ def test_android_os_detect_props(target_bare: Target, build_prop_locations: list
 
     target_bare.add_plugin(AndroidPlugin)
 
-    assert target_bare.os == "android"
+    assert target_bare.os == OperatingSystem.ANDROID == "android"
     assert sorted(map(str, target_bare._os.build_prop_paths)) == sorted(p for p, _ in build_prop_locations)
     assert target_bare._os.props
     assert target_bare.hostname == "TMG28071935"

--- a/tests/plugins/os/unix/linux/debian/proxmox/test__os.py
+++ b/tests/plugins/os/unix/linux/debian/proxmox/test__os.py
@@ -4,6 +4,7 @@ from io import BytesIO
 from typing import TYPE_CHECKING
 
 from dissect.target.filesystem import VirtualFilesystem
+from dissect.target.plugin import OperatingSystem
 from dissect.target.plugins.os.unix.linux.debian.proxmox._os import ProxmoxPlugin
 from tests._utils import absolute_path
 
@@ -27,7 +28,7 @@ def test_proxmox_os(target_bare: Target) -> None:
     target_bare._os_plugin = ProxmoxPlugin
     target_bare.apply()
 
-    assert target_bare.os == "proxmox"
+    assert target_bare.os == OperatingSystem.PROXMOX == "proxmox"
     assert sorted(map(str, target_bare.fs.path("/etc/pve").rglob("*"))) == [
         "/etc/pve/__version__",
         "/etc/pve/authkey.pub",

--- a/tests/plugins/os/unix/linux/fortios/test__os.py
+++ b/tests/plugins/os/unix/linux/fortios/test__os.py
@@ -4,6 +4,7 @@ import gzip
 from io import BytesIO
 from typing import TYPE_CHECKING
 
+from dissect.target.plugin import OperatingSystem
 from dissect.target.plugins.os.unix.linux.fortios._os import FortiOSPlugin
 from dissect.target.plugins.os.unix.linux.fortios.generic import GenericPlugin
 from dissect.target.plugins.os.unix.linux.fortios.locale import FortiOSLocalePlugin
@@ -73,12 +74,12 @@ def test_fortigate_os(target_unix: Target, fs_unix: VirtualFilesystem) -> None:
     target_unix.add_plugin(GenericPlugin)
 
     # tests FortiOSPlugin.detect() indirectly
-    assert target_unix.os == "fortios"
+    assert target_unix.os == OperatingSystem.FORTIOS == "fortios"
 
     target_unix._os_plugin = FortiOSPlugin
     target_unix.apply()
 
-    assert target_unix.os == "fortios"
+    assert target_unix.os == OperatingSystem.FORTIOS == "fortios"
     assert target_unix.hostname == "FortiGate-VM64"
     assert target_unix.version == "FortiGate VM 7.4.2 (build 2571, 2023-12-19)"
     assert target_unix.ips == ["1.2.3.4"]

--- a/tests/plugins/os/unix/linux/redhat/test__os.py
+++ b/tests/plugins/os/unix/linux/redhat/test__os.py
@@ -32,4 +32,4 @@ def test_unix_linux_redhat_os_detection(target_bare: Target, file_name: str) -> 
 
     assert RedHatPlugin.detect(target_bare)
     assert isinstance(target_bare._os, RedHatPlugin)
-    assert target_bare.os == OperatingSystem.LINUX
+    assert target_bare.os == OperatingSystem.LINUX == "linux"

--- a/tests/plugins/os/unix/linux/test__os.py
+++ b/tests/plugins/os/unix/linux/test__os.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from dissect.target.filesystem import VirtualFilesystem
+from dissect.target.plugin import OperatingSystem
 from dissect.target.plugins.os.unix.linux._os import LinuxPlugin
 from tests.conftest import make_os_target
 
@@ -36,15 +37,15 @@ def target_linux_windows_folder(tmp_path: pathlib.Path) -> Target:
 def test_linux_os(target_linux: Target) -> None:
     target_linux.add_plugin(LinuxPlugin)
 
-    assert target_linux.os == "linux"
+    assert target_linux.os == OperatingSystem.LINUX == "linux"
 
 
 def test_linux_os_windows_folder(target_linux_windows_folder: Target) -> None:
     target_linux_windows_folder.add_plugin(LinuxPlugin)
     assert target_linux_windows_folder._os_plugin.detect(target_linux_windows_folder) is not None
-    assert target_linux_windows_folder.os == "linux"
+    assert target_linux_windows_folder.os == OperatingSystem.LINUX == "linux"
 
 
 def test_linux_os_proc_sys(target_linux_proc_sys: Target) -> None:
     assert target_linux_proc_sys._os_plugin.detect(target_linux_proc_sys) is not None
-    assert target_linux_proc_sys.os == "linux"
+    assert target_linux_proc_sys.os == OperatingSystem.LINUX == "linux"

--- a/tests/plugins/os/windows/test__os.py
+++ b/tests/plugins/os/windows/test__os.py
@@ -7,6 +7,7 @@ import pytest
 from flow.record.fieldtypes import windows_path
 
 from dissect.target.helpers.regutil import VirtualKey, VirtualValue
+from dissect.target.plugin import OperatingSystem
 from dissect.target.plugins.os.unix.linux._os import LinuxPlugin
 from dissect.target.plugins.os.windows._os import WindowsPlugin
 from dissect.target.plugins.os.windows.generic import ComputerSidRecord
@@ -345,5 +346,5 @@ def test_windows_architecture(
     key.add_value("PROCESSOR_ARCHITECTURE", reg_value)
     hive_hklm.map_key(key_name, key)
 
-    assert target_win_users.os == "windows"
+    assert target_win_users.os == OperatingSystem.WINDOWS == "windows"
     assert target_win_users.architecture == expected_triple


### PR DESCRIPTION
Renames `OperatingSystem.*.value` invocations and s `OperatingSystem` instances instead of raw strings where possible.

Fixes #1735.