### PR TITLE
Add filesystem allocation support

### DIFF
--- a/dissect/target/filesystem.py
+++ b/dissect/target/filesystem.py
@@ -7,7 +7,10 @@ import pathlib
 import stat
 from collections import defaultdict
 from functools import cache, cached_property
+from itertools import zip_longest
 from typing import TYPE_CHECKING, Any, BinaryIO, Final
+
+from dissect.util.stream import MappingStream
 
 from dissect.target.exceptions import (
     FileNotFoundError,
@@ -173,6 +176,24 @@ class Filesystem:
             A :class:`FilesystemEntry` for the path.
         """
         raise NotImplementedError
+
+    def allocated_space_iter(self) -> Iterator[BinaryIO]:
+        """Iteratively yield streams of allocated data on the filesystem."""
+        raise NotImplementedError
+
+    def unallocated_space_iter(self) -> Iterator[BinaryIO]:
+        """Iteratively yield streams of unallocated data on the filesystem."""
+        raise NotImplementedError
+
+    def space_allocation_iter(self) -> Iterator[tuple[BinaryIO, BinaryIO]]:
+        """Iteratively yield tuples of [unallocated, allocated] streams. Sometimes the same bytes need to be parsed to
+        determine both allocated and unallocated space, so this method allows filesystems to expose a method of parsing
+        those bytes once rather than seperately for unallocated and allocated.
+
+        This default implementation just yields from allocated_space_iter and unallocated_space_iter, padding with None
+        values if one is exhausted before the other.
+        """
+        yield from zip_longest(self.unallocated_space_iter(), self.allocated_space_iter())
 
     def open(self, path: str) -> BinaryIO:
         """Open a filesystem entry.
@@ -499,6 +520,34 @@ class Filesystem:
             The digests of the contents of ``path``.
         """
         return self.get(path).hash(algos)
+
+    def allocated_space(self) -> BinaryIO:
+        """Expose the allocated space of this filesystem as one contiguous stream."""
+        return self._stream_list_to_contiguous(list(self.allocated_space_iter()))
+
+    def unallocated_space(self) -> BinaryIO:
+        """Expose the unallocated space on this filesystem as one contiguous stream."""
+        return self._stream_list_to_contiguous(list(self.unallocated_space_iter()))
+
+    def space_allocation(self) -> tuple[BinaryIO, BinaryIO]:
+        """Fully iterates the underlying filesystem's space allocation iterator function to convert individual 'runs' of
+        unallocated/allocated space into one, contiguous stream for each. Depending on the underlying filesystem, using
+        this function rather than allocated_space() and unallocated_space() seperately may be much faster as
+        space_allocation_iter is called once rather than twice (once for unallocated and once for allocated).
+        """
+        unallocated, allocated = zip(*self.space_allocation_iter(), strict=True)
+        return self._stream_list_to_contiguous(
+            [stream for stream in unallocated if stream is not None]
+        ), self._stream_list_to_contiguous([stream for stream in allocated if stream is not None])
+
+    def _stream_list_to_contiguous(self, streams: list[BinaryIO]) -> MappingStream:
+        """Convert a list of streams into one contiguous stream."""
+        merged_stream = MappingStream(sum(stream.size for stream in streams))
+        offset = 0
+        for stream in streams:
+            merged_stream.add(offset, stream.size, stream)
+            offset += stream.size
+        return merged_stream
 
     @cached_property
     def uuid(self) -> UUID | None:

--- a/dissect/target/filesystems/extfs.py
+++ b/dissect/target/filesystems/extfs.py
@@ -52,6 +52,20 @@ class ExtFilesystem(Filesystem):
     def uuid(self) -> UUID | None:
         return self.extfs.uuid
 
+    def allocated_space_iter(self) -> Iterator[BinaryIO]:
+        for group_num in range(self.extfs.groups_count):
+            _, allocated = self.extfs.get_group_data_block_allocation(group_num)
+            yield allocated
+
+    def unallocated_space_iter(self) -> Iterator[BinaryIO]:
+        for group_num in range(self.extfs.groups_count):
+            unallocated, _ = self.extfs.get_group_data_block_allocation(group_num)
+            yield unallocated
+
+    def space_allocation_iter(self) -> Iterator[tuple[BinaryIO, BinaryIO]]:
+        for group_num in range(self.extfs.groups_count):
+            yield self.extfs.get_group_data_block_allocation(group_num)
+
 
 class ExtDirEntry(DirEntry):
     fs: ExtFilesystem

--- a/dissect/target/filesystems/ntfs.py
+++ b/dissect/target/filesystems/ntfs.py
@@ -6,6 +6,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, BinaryIO
 
 from dissect.ntfs import NTFS, NTFS_SIGNATURE
+from dissect.ntfs.bitmap import Bitmap
 from dissect.ntfs.exceptions import Error as NtfsError
 from dissect.ntfs.exceptions import FileNotFoundError as NtfsFileNotFoundError
 from dissect.ntfs.exceptions import NotADirectoryError as NtfsNotADirectoryError
@@ -66,6 +67,18 @@ class NtfsFilesystem(Filesystem):
     @cached_property
     def serial(self) -> int | str | None:
         return self.ntfs.serial
+
+    def allocated_space_iter(self) -> Iterator[BinaryIO]:
+        """Iteratively yield streams of allocated data on the filesystem."""
+        yield from (allocated_stream for _, allocated_stream in Bitmap(self.ntfs).iter())
+
+    def unallocated_space_iter(self) -> Iterator[BinaryIO]:
+        """Iteratively yield streams of unallocated data on the filesystem."""
+        yield from (unallocated_stream for unallocated_stream, _ in Bitmap(self.ntfs).iter())
+
+    def space_allocation_iter(self) -> Iterator[tuple[BinaryIO, BinaryIO]]:
+        """Iteratively yield tuples of [unallocated, allocated] data streams on the filesystem."""
+        yield from Bitmap(self.ntfs).iter()
 
 
 class NtfsDirEntry(DirEntry):

--- a/dissect/target/tools/mount.py
+++ b/dissect/target/tools/mount.py
@@ -80,6 +80,11 @@ def main() -> int:
         vnames.setdefault(basename, []).append(v)
         vfs.map_file_fh(f"volumes/{fname}", v)
 
+        if v.fs is not None and (allocation_implementation := getattr(v.fs, "space_allocation", None)):
+            unallocated, allocated = allocation_implementation()
+            vfs.map_file_fh(f"volumes/{fname}_unallocated", unallocated)
+            vfs.map_file_fh(f"volumes/{fname}_allocated", allocated)
+
     fake_ntfs = set()
     for i, fs in enumerate(t.filesystems):
         ntfs_obj = getattr(fs, "ntfs", None)

--- a/dissect/target/tools/mount.py
+++ b/dissect/target/tools/mount.py
@@ -81,9 +81,12 @@ def main() -> int:
         vfs.map_file_fh(f"volumes/{fname}", v)
 
         if v.fs is not None and (allocation_implementation := getattr(v.fs, "space_allocation", None)):
-            unallocated, allocated = allocation_implementation()
-            vfs.map_file_fh(f"volumes/{fname}_unallocated", unallocated)
-            vfs.map_file_fh(f"volumes/{fname}_allocated", allocated)
+            try:
+                unallocated, allocated = allocation_implementation()
+                vfs.map_file_fh(f"volumes/{fname}_unallocated", unallocated)
+                vfs.map_file_fh(f"volumes/{fname}_allocated", allocated)
+            except NotImplementedError:
+                pass
 
     fake_ntfs = set()
     for i, fs in enumerate(t.filesystems):


### PR DESCRIPTION
This pull requests adds support for distinguishing which parts of a filesystem are in use and which ones are not. `Filesystem` classes can implement a few functions that yield unallocated or allocated streams, or a tuple containing one stream for each.

The PR includes implementations of these functions for NTFS and EXTFS. They depend on functionality added in https://github.com/fox-it/dissect.ntfs/pull/58 and https://github.com/fox-it/dissect.extfs/pull/52 which themselves depend on https://github.com/fox-it/dissect.util/pull/127 .

We have added one small extension to `target-mount` to expose the different streams when filesystems support it. 

In the future we hope more scraping functionality can use the distinction between the allocated/unallocated space. In particular we were thinking about https://github.com/fox-it/dissect.target/pull/1329. It would be nice to have one function that can assemble streams for scraping while taking some preferences into account (in this case, allocated only, unallocated only, or don't care). `create_streams` seems to be a good candidate.