### PR TITLE
Fix stored ZIP random access

### DIFF
--- a/dissect/target/filesystems/zip.py
+++ b/dissect/target/filesystems/zip.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import io
+import os
 import stat
 import zipfile
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO
 
 from dissect.util.stream import BufferedStream
@@ -98,6 +101,8 @@ class ZipFilesystemEntry(VirtualDirectory):
             return self._resolve().open()
 
         try:
+            if self.entry.compress_type == zipfile.ZIP_STORED and (zip_file := _reopen_zip_file(self.fs.zip)):
+                return _ZipFilesystemEntryStream(*zip_file, self.entry, self.fs.zip.pwd)
             return BufferedStream(self.fs.zip.open(self.entry), size=self.entry.file_size)
         except Exception:
             raise FileNotFoundError(self.path)
@@ -174,3 +179,52 @@ class ZipFilesystemEntry(VirtualDirectory):
                 0,
             ]
         )
+
+
+def _reopen_zip_file(zip_file: zipfile.ZipFile) -> tuple[zipfile.ZipFile, BinaryIO | None] | None:
+    if not isinstance(zip_file.filename, (str, os.PathLike)):
+        if isinstance(zip_file.fp, io.BytesIO):
+            fh = io.BytesIO(zip_file.fp.getvalue())
+            try:
+                return zipfile.ZipFile(fh, mode="r"), fh
+            except Exception:
+                fh.close()
+                raise
+
+        return None
+
+    path = Path(zip_file.filename)
+    return (zipfile.ZipFile(path, mode="r"), None) if path.is_file() else None
+
+
+class _ZipFilesystemEntryStream(BufferedStream):
+    """Seekable stream for a ZIP entry from an isolated archive handle."""
+
+    def __init__(
+        self,
+        zip_file: zipfile.ZipFile,
+        fh: BinaryIO | None,
+        entry: zipfile.ZipInfo,
+        pwd: bytes | None = None,
+    ):
+        self._zip_file = zip_file
+        self._fh = fh
+        try:
+            self._entry_fh = self._zip_file.open(entry, pwd=pwd)
+        except Exception:
+            self._zip_file.close()
+            if self._fh:
+                self._fh.close()
+            raise
+        super().__init__(self._entry_fh, size=entry.file_size)
+
+    def close(self) -> None:
+        try:
+            self._entry_fh.close()
+        finally:
+            try:
+                self._zip_file.close()
+            finally:
+                if self._fh:
+                    self._fh.close()
+                super().close()

--- a/tests/filesystems/test_zip.py
+++ b/tests/filesystems/test_zip.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import zipfile
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -11,6 +12,9 @@ from dissect.target.exceptions import (
     NotASymlinkError,
 )
 from dissect.target.filesystems.zip import ZipFilesystem, ZipFilesystemEntry
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _mkdir(zf: zipfile.ZipFile, name: str) -> None:
@@ -99,6 +103,10 @@ def zip_virtual_dir() -> io.BytesIO:
     return _create_zip("", False)
 
 
+def _payload(seed: int, size: int) -> bytes:
+    return bytes((offset + seed) % 251 for offset in range(size))
+
+
 @pytest.mark.parametrize(
     ("obj", "base"),
     [
@@ -180,3 +188,35 @@ def test_filesystems_zip(obj: str, base: str, request: pytest.FixtureRequest) ->
 
     if isinstance(zdir, ZipFilesystemEntry):
         assert zdir.stat().st_mode == 0o40777
+
+
+@pytest.mark.parametrize("compression", [zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED])
+@pytest.mark.parametrize("path_backed", [True, False])
+def test_filesystems_zip_interleaved_seek_reads(tmp_path: Path, compression: int, path_backed: bool) -> None:
+    payload_size = 16 * 1024
+    read_offset = 8 * 1024
+    read_size = 1024
+    payloads = [_payload(index * 37, payload_size) for index in range(3)]
+
+    zip_obj = tmp_path / "test.zip" if path_backed else io.BytesIO()
+    with zipfile.ZipFile(zip_obj, "w", compression=compression) as zf:
+        for index, payload in enumerate(payloads):
+            zf.writestr(f"file_{index}", payload)
+
+    if path_backed:
+        fh = zip_obj.open("rb")
+    else:
+        zip_obj.seek(0)
+        fh = zip_obj
+
+    with fh:
+        fs = ZipFilesystem(fh)
+        handles = [fs.get(f"file_{index}").open() for index in range(len(payloads))]
+
+        try:
+            for index, handle in enumerate(handles):
+                handle.seek(read_offset)
+                assert handle.read(read_size) == payloads[index][read_offset : read_offset + read_size]
+        finally:
+            for handle in handles:
+                handle.close()


### PR DESCRIPTION
Uncompressed files inside a ZIP could be read incorrectly when multiple
files from the same ZIP were open at the same time. This happened with
Velociraptor collection ZIPs, where registry and EVTX parsing can jump
around inside several files.

This PR gives those uncompressed ZIP files their own ZIP handle when
possible. That keeps reads from one file from affecting reads from
another file. Compressed ZIP files keep the existing behavior.

Proposed Changes

- Open uncompressed files inside ZIP archives with their own ZIP handle.
- Keep the existing behavior for compressed ZIP files.
- Support ZIP files opened from disk and ZIP files opened from memory.
- Add tests that open multiple files inside a ZIP and seek/read from them.

Tested with:

```bash
ruff check dissect/target/filesystems/zip.py tests/filesystems/test_zip.py
ruff format --check dissect/target/filesystems/zip.py tests/filesystems/test_zip.py
pytest tests/filesystems/test_zip.py -q
pytest tests/loaders/test_velociraptor.py -q
```

Also verified against a Velociraptor collection ZIP

## Checklist

- [x] PR Title is descriptive of the changes
- [x] The description is descriptive of the changes
- [x] Tests are included and pass
- [x] Closes related issue number

Closes #1746

Let me know if changes are needed.
