### PR TITLE
Enable pretty output in shell hexdump commands

### DIFF
--- a/dissect/target/tools/inspect.py
+++ b/dissect/target/tools/inspect.py
@@ -99,7 +99,7 @@ def cmd_hexdump(t: Target, args: argparse.Namespace) -> None:
         print(f"# {obj}")
 
         obj.seek(args.skip)
-        hexdump(obj.read(args.length), offset=args.skip)
+        hexdump(obj.read(args.length), offset=args.skip, pretty=True)
 
         print()
 

--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -1390,7 +1390,7 @@ class TargetCli(TargetCmd):
                 if args.hex:
                     print(fh.read(args.length).hex(), file=stdout)
                 else:
-                    print(hexdump(fh.read(args.length), output="string"), file=stdout)
+                    print(hexdump(fh.read(args.length), output="string", pretty=True), file=stdout)
 
         return False
 
@@ -1666,7 +1666,7 @@ class RegistryCli(TargetCmd):
         if args.hex:
             print(value.value.hex(), file=stdout)
         else:
-            print(hexdump(value.value, output="string"), file=stdout)
+            print(hexdump(value.value, output="string", pretty=True), file=stdout)
 
         return False
 


### PR DESCRIPTION
Enables pretty hexdump output introduced in https://github.com/fox-it/dissect.cstruct/pull/155.