### PR TITLE
Add Chromium cache plugin function

### DIFF
--- a/dissect/target/plugins/apps/browser/brave.py
+++ b/dissect/target/plugins/apps/browser/brave.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from dissect.target.helpers.descriptor_extensions import UserRecordDescriptorExtension
 from dissect.target.helpers.record import create_extended_descriptor
-from dissect.target.plugin import export
+from dissect.target.plugin import arg, export
 from dissect.target.plugins.apps.browser.browser import (
+    GENERIC_CACHE_FIELDS,
     GENERIC_COOKIE_FIELDS,
     GENERIC_DOWNLOAD_RECORD_FIELDS,
     GENERIC_EXTENSION_RECORD_FIELDS,
@@ -55,6 +57,11 @@ class BravePlugin(ChromiumMixin, BrowserPlugin):
         "application/browser/brave/cookie", GENERIC_COOKIE_FIELDS
     )
 
+    BrowserCacheRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
+        "application/browser/brave/cache",
+        GENERIC_CACHE_FIELDS,
+    )
+
     BrowserDownloadRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
         "application/browser/brave/download", GENERIC_DOWNLOAD_RECORD_FIELDS + CHROMIUM_DOWNLOAD_RECORD_FIELDS
     )
@@ -76,6 +83,12 @@ class BravePlugin(ChromiumMixin, BrowserPlugin):
     def cookies(self) -> Iterator[BrowserCookieRecord]:
         """Return browser cookie records for Brave."""
         yield from super().cookies("brave")
+
+    @export(record=BrowserCacheRecord)
+    @arg("--export", type=Path, help="export cache files to provided directory")
+    def cache(self, export: Path | None = None) -> Iterator[BrowserCacheRecord]:
+        """Return browser cache records for Brave."""
+        yield from super().cache("brave", export)
 
     @export(record=BrowserDownloadRecord)
     def downloads(self) -> Iterator[BrowserDownloadRecord]:

--- a/dissect/target/plugins/apps/browser/browser.py
+++ b/dissect/target/plugins/apps/browser/browser.py
@@ -105,6 +105,15 @@ BrowserPasswordRecord = create_extended_descriptor([UserRecordDescriptorExtensio
     "application/browser/password", GENERIC_PASSWORD_RECORD_FIELDS
 )
 
+GENERIC_CACHE_FIELDS = [
+    ("datetime", "ts_created"),
+    ("string", "browser"),
+    ("string", "url"),
+    ("string", "mimetype"),
+    ("digest", "digest"),
+    ("path", "source"),
+]
+
 
 class BrowserPlugin(NamespacePlugin):
     __namespace__ = "browser"

--- a/dissect/target/plugins/apps/browser/chrome.py
+++ b/dissect/target/plugins/apps/browser/chrome.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from dissect.target.helpers.descriptor_extensions import UserRecordDescriptorExtension
 from dissect.target.helpers.record import create_extended_descriptor
-from dissect.target.plugin import export
+from dissect.target.plugin import arg, export
 from dissect.target.plugins.apps.browser.browser import (
+    GENERIC_CACHE_FIELDS,
     GENERIC_COOKIE_FIELDS,
     GENERIC_DOWNLOAD_RECORD_FIELDS,
     GENERIC_EXTENSION_RECORD_FIELDS,
@@ -55,6 +57,11 @@ class ChromePlugin(ChromiumMixin, BrowserPlugin):
         "application/browser/chrome/cookie", GENERIC_COOKIE_FIELDS
     )
 
+    BrowserCacheRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
+        "application/browser/chrome/cache",
+        GENERIC_CACHE_FIELDS,
+    )
+
     BrowserDownloadRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
         "application/browser/chrome/download", GENERIC_DOWNLOAD_RECORD_FIELDS + CHROMIUM_DOWNLOAD_RECORD_FIELDS
     )
@@ -76,6 +83,12 @@ class ChromePlugin(ChromiumMixin, BrowserPlugin):
     def cookies(self) -> Iterator[BrowserCookieRecord]:
         """Return browser cookie records for Google Chrome."""
         yield from super().cookies("chrome")
+
+    @export(record=BrowserCacheRecord)
+    @arg("--export", type=Path, help="export cache files to provided directory")
+    def cache(self, export: Path | None = None) -> Iterator[BrowserCacheRecord]:
+        """Return browser cache records for Microsoft Edge."""
+        yield from super().cache("chrome", export)
 
     @export(record=BrowserDownloadRecord)
     def downloads(self) -> Iterator[BrowserDownloadRecord]:

--- a/dissect/target/plugins/apps/browser/chromium.py
+++ b/dissect/target/plugins/apps/browser/chromium.py
@@ -5,18 +5,26 @@ import itertools
 import json
 from collections import defaultdict
 from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 from dissect.cstruct import cstruct
+from dissect.database.chromium.cache import DiskCache, SimpleDiskCache
+from dissect.database.chromium.cache.cache import CacheEntryStore
+from dissect.database.chromium.cache.simple import SimpleCacheFile
 from dissect.database.exception import Error as DBError
 from dissect.database.sqlite3 import SQLite3
 from dissect.util.ts import webkittimestamp
 
 from dissect.target.exceptions import FileNotFoundError, UnsupportedPluginError
+from dissect.target.helpers import hashutil, magic
 from dissect.target.helpers.descriptor_extensions import UserRecordDescriptorExtension
 from dissect.target.helpers.record import create_extended_descriptor
-from dissect.target.plugin import OperatingSystem, export
+from dissect.target.plugin import OperatingSystem, arg, export
 from dissect.target.plugins.apps.browser.browser import (
+    GENERIC_CACHE_FIELDS,
     GENERIC_COOKIE_FIELDS,
     GENERIC_DOWNLOAD_RECORD_FIELDS,
     GENERIC_EXTENSION_RECORD_FIELDS,
@@ -28,7 +36,6 @@ from dissect.target.plugins.apps.browser.browser import (
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from pathlib import Path
 
     from dissect.target.plugins.general.users import UserDetails
     from dissect.target.target import Target
@@ -83,6 +90,8 @@ DOWNLOAD_STATES = {
 class ChromiumMixin:
     """Mixin class with methods for Chromium-based browsers."""
 
+    target: Target
+
     DIRS = ()
 
     BrowserHistoryRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
@@ -91,6 +100,11 @@ class ChromiumMixin:
 
     BrowserCookieRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
         "application/browser/chromium/cookie", GENERIC_COOKIE_FIELDS
+    )
+
+    BrowserCacheRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
+        "application/browser/chromium/cache",
+        GENERIC_CACHE_FIELDS,
     )
 
     BrowserDownloadRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
@@ -128,7 +142,12 @@ class ChromiumMixin:
                         users_dirs.add((user_details, cur_dir))
         return users_dirs
 
-    def _iter_db(self, filename: str, subdirs: list[str] | None = None) -> Iterator[tuple[UserDetails, Path, SQLite3]]:
+    def _iter_db(
+        self,
+        filename: str,
+        subdirs: list[str] | None = None,
+        db_type: SQLite3 | DiskCache | SimpleDiskCache = SQLite3,
+    ) -> Iterator[tuple[UserDetails, Path, SQLite3 | DiskCache | SimpleDiskCache]]:
         """Iterate database files of all users.
 
         Args:
@@ -136,7 +155,8 @@ class ChromiumMixin:
             subdirs: Optional list of subdirectory names to iterate for every user directory.
 
         Yields:
-            Tuple of :class:`UserDetails`, :class:`Path` of SQLite3 file and :class:`SQLite3` instance.
+            Tuple of :class:`UserDetails`, :class:`Path` of database file
+            and :class:`SQLite3`, :class:`DiskCache` or :class:`SimpleDiskCache` instance.
         """
         seen = set()
         userdirs = self.userdirs
@@ -150,18 +170,24 @@ class ChromiumMixin:
                 },
             )
 
+        if db_type not in (SQLite3, DiskCache, SimpleDiskCache):
+            raise ValueError(f"Unknown db_type {db_type!r}")
+
         for user, cur_dir in userdirs:
             db_file = cur_dir.joinpath(filename)
+
+            if not db_file.exists():
+                continue
 
             if db_file in seen:
                 continue
             seen.add(db_file)
 
             try:
-                yield user, db_file, SQLite3(db_file)
+                yield user, db_file, db_type(db_file)
             except FileNotFoundError:
                 self.target.log.warning("Could not find %s file: %s", filename, db_file)
-            except DBError as e:
+            except (DBError, ValueError) as e:
                 self.target.log.warning("Could not open %s file: %s", filename, db_file)
                 self.target.log.debug("", exc_info=e)
 
@@ -333,6 +359,50 @@ class ChromiumMixin:
             except DBError as e:
                 self.target.log.warning("Error processing cookie file %s: %s", db_file, e)
                 self.target.log.debug("", exc_info=e)
+
+    @arg("--export", type=Path, help="export cache files to provided directory")
+    def cache(self, browser_name: str | None = None, export: Path | None = None) -> Iterator[BrowserCacheRecord]:
+        """Return browser cache records from supported Chromium-based browsers."""
+        if export:
+            if not export.is_dir():
+                self.target.log.error("Output directory %s does not exist", export)
+                return
+            if list(export.iterdir()):
+                self.target.log.error("Output directory %s is not empty", export)
+                return
+
+        for user, db_file, db in itertools.chain(
+            self._iter_db("Cache/Cache_Data", db_type=DiskCache),
+            self._iter_db("Cache/Cache_Data", db_type=SimpleDiskCache),
+        ):
+            for entry in db.entries():
+                if export:
+                    url_path = urlparse(entry.resource_url).path
+                    file_path = Path(url_path).name
+                    out = export.joinpath(file_path)
+                    print(f"Exporting {file_path} to {out}..", end="")
+                    out.write_bytes(entry.data)
+                    print(" done")
+                    continue
+
+                if isinstance(entry, CacheEntryStore):
+                    ts_created = entry.creation_time
+                    source = db_file
+
+                elif isinstance(entry, SimpleCacheFile):
+                    ts_created = entry.path.stat().st_mtime
+                    source = entry.path
+
+                yield self.BrowserCacheRecord(
+                    ts_created=ts_created,
+                    browser=browser_name,
+                    url=entry.resource_url,
+                    mimetype=magic.from_buffer(entry.data, mime=True),
+                    digest=hashutil.common(BytesIO(entry.data)),
+                    source=source,
+                    _user=user.user,
+                    _target=self.target,
+                )
 
     def downloads(self, browser_name: str | None = None) -> Iterator[BrowserDownloadRecord]:
         """Return browser download records from supported Chromium-based browsers.
@@ -721,6 +791,12 @@ class ChromiumPlugin(ChromiumMixin, BrowserPlugin):
     def cookies(self) -> Iterator[ChromiumMixin.BrowserCookieRecord]:
         """Return browser cookie records for Chromium browser."""
         yield from super().cookies("chromium")
+
+    @export(record=ChromiumMixin.BrowserCacheRecord)
+    @arg("--export", type=Path, help="export cache files to provided directory")
+    def cache(self, export: Path | None = None) -> Iterator[ChromiumMixin.BrowserCacheRecord]:
+        """Return browser cache records for Chromium browser."""
+        yield from super().cache("chromium", export)
 
     @export(record=ChromiumMixin.BrowserDownloadRecord)
     def downloads(self) -> Iterator[ChromiumMixin.BrowserDownloadRecord]:

--- a/dissect/target/plugins/apps/browser/edge.py
+++ b/dissect/target/plugins/apps/browser/edge.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from dissect.target.helpers.descriptor_extensions import UserRecordDescriptorExtension
 from dissect.target.helpers.record import create_extended_descriptor
-from dissect.target.plugin import export
+from dissect.target.plugin import arg, export
 from dissect.target.plugins.apps.browser.browser import (
+    GENERIC_CACHE_FIELDS,
     GENERIC_COOKIE_FIELDS,
     GENERIC_DOWNLOAD_RECORD_FIELDS,
     GENERIC_EXTENSION_RECORD_FIELDS,
@@ -51,6 +53,11 @@ class EdgePlugin(ChromiumMixin, BrowserPlugin):
         "application/browser/edge/cookie", GENERIC_COOKIE_FIELDS
     )
 
+    BrowserCacheRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
+        "application/browser/edge/cache",
+        GENERIC_CACHE_FIELDS,
+    )
+
     BrowserDownloadRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
         "application/browser/edge/download", GENERIC_DOWNLOAD_RECORD_FIELDS + CHROMIUM_DOWNLOAD_RECORD_FIELDS
     )
@@ -72,6 +79,12 @@ class EdgePlugin(ChromiumMixin, BrowserPlugin):
     def cookies(self) -> Iterator[BrowserCookieRecord]:
         """Return browser cookie records for Microsoft Edge."""
         yield from super().cookies("edge")
+
+    @export(record=BrowserCacheRecord)
+    @arg("--export", type=Path, help="export cache files to provided directory")
+    def cache(self, export: Path | None = None) -> Iterator[BrowserCacheRecord]:
+        """Return browser cache records for Microsoft Edge."""
+        yield from super().cache("edge", export)
 
     @export(record=BrowserDownloadRecord)
     def downloads(self) -> Iterator[BrowserDownloadRecord]:

--- a/dissect/target/plugins/apps/browser/opera.py
+++ b/dissect/target/plugins/apps/browser/opera.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from dissect.util.ts import webkittimestamp
 
 from dissect.target.helpers.descriptor_extensions import UserRecordDescriptorExtension
 from dissect.target.helpers.record import create_extended_descriptor
-from dissect.target.plugin import export
+from dissect.target.plugin import arg, export
 from dissect.target.plugins.apps.browser.browser import (
+    GENERIC_CACHE_FIELDS,
     GENERIC_COOKIE_FIELDS,
     GENERIC_DOWNLOAD_RECORD_FIELDS,
     GENERIC_EXTENSION_RECORD_FIELDS,
@@ -63,6 +65,11 @@ class OperaPlugin(ChromiumMixin, BrowserPlugin):
         GENERIC_COOKIE_FIELDS,
     )
 
+    BrowserCacheRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
+        "application/browser/opera/cache",
+        GENERIC_CACHE_FIELDS,
+    )
+
     BrowserDownloadRecord = create_extended_descriptor([UserRecordDescriptorExtension])(
         "application/browser/opera/download",
         GENERIC_DOWNLOAD_RECORD_FIELDS + CHROMIUM_DOWNLOAD_RECORD_FIELDS,
@@ -87,6 +94,12 @@ class OperaPlugin(ChromiumMixin, BrowserPlugin):
     def cookies(self) -> Iterator[BrowserCookieRecord]:
         """Return browser cookie records for Opera (and Opera GX)."""
         yield from super().cookies("opera")
+
+    @export(record=BrowserCacheRecord)
+    @arg("--export", type=Path, help="export cache files to provided directory")
+    def cache(self, export: Path | None = None) -> Iterator[BrowserCacheRecord]:
+        """Return browser cache records for Opera (and Opera GX)."""
+        yield from super().cache("opera", export)
 
     @export(record=BrowserDownloadRecord)
     def downloads(self) -> Iterator[BrowserDownloadRecord]:

--- a/tests/_data/plugins/apps/browser/chrome/Linux_Cache_Data.tgz
+++ b/tests/_data/plugins/apps/browser/chrome/Linux_Cache_Data.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e58f665133fb14f3ba4a9c9d128cc34cc8c3097e621386896bb18ecf7a3470e4
+size 976979

--- a/tests/_data/plugins/apps/browser/chrome/Windows_Cache_Data.tgz
+++ b/tests/_data/plugins/apps/browser/chrome/Windows_Cache_Data.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab0f0821a0ea97dbe81ca5305789cd30436501686e9fa765850e3f8634e7d065
+size 6415601

--- a/tests/plugins/apps/browser/test_chrome.py
+++ b/tests/plugins/apps/browser/test_chrome.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 import pytest
@@ -499,3 +500,41 @@ def test_benchmark_chrome_userdirs(
     benchmark(
         lambda: target_win_users.add_plugin(ChromePlugin, check_compatible=True) and list(target_win_users.chrome())
     )
+
+
+def test_chrome_windows_11_cache(target_win_users: Target, fs_win: VirtualFilesystem) -> None:
+    """Test if we can detect and parse Chromium Disk Cache."""
+    fs_win.map_dir_from_tar(
+        "Users/John/AppData/Local/Google/Chrome/User Data/Default/Cache/Cache_Data",
+        absolute_path("_data/plugins/apps/browser/chrome/Windows_Cache_Data.tgz"),
+    )
+
+    records = sorted(target_win_users.chrome.cache(), key=lambda r: r.url)
+    assert len(records) == 18
+
+    assert records[0].ts_created == datetime(2026, 4, 30, 12, 11, 48, 207695, tzinfo=timezone.utc)
+    assert records[0].url == "http://172.16.82.1:8000/"
+    assert records[0].mimetype == "text/html"
+    assert records[0].digest.sha1 == "6e97ee99cb8da5960da3b6f41238a498552a3805"
+    assert (
+        records[0].source == "\\C:\\Users\\John\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\Cache\\Cache_Data"
+    )
+    assert records[0].username == "John"
+
+
+def test_chrome_linux_cache(target_unix_users: Target, fs_unix: VirtualFilesystem) -> None:
+    """Test if we can detect and parse Chromium Simple Cache."""
+    fs_unix.map_dir_from_tar(
+        "/root/.config/google-chrome/Default/Cache/Cache_Data",
+        absolute_path("_data/plugins/apps/browser/chrome/Linux_Cache_Data.tgz"),
+    )
+
+    records = sorted(target_unix_users.chrome.cache(), key=lambda r: r.url)
+    assert len(records) == 19
+
+    assert records[0].ts_created
+    assert records[0].url == "http://172.16.82.1:8000/"
+    assert records[0].mimetype == "text/html"
+    assert records[0].digest.sha1 == "6e97ee99cb8da5960da3b6f41238a498552a3805"
+    assert records[0].source == "/root/.config/google-chrome/Default/Cache/Cache_Data/dedf005cc082b363_0"
+    assert records[0].username == "root"


### PR DESCRIPTION
This PR adds the `cache` plugin function to all Chromium-based browser plugins.

Records contain basic metadata information of the cached HTTP responses (URL, mimetype, ts, response body digest). Does not yet expose HTTP response headers present in `entry.meta`.

Also exposes an `--export Path` argument to export the cached files to an arbitrary location.

Depends on https://github.com/fox-it/dissect.database/pull/13.