### PR TITLE
Return None instead of skipping lines without timestamp in year_rollo…

### DIFF
--- a/dissect/target/helpers/utils.py
+++ b/dissect/target/helpers/utils.py
@@ -110,7 +110,7 @@ STRIP_RE = re.compile(r"^[\s\x00]*|[\s\x00]*$")
 
 def year_rollover_helper(
     path: Path, re_ts: str | re.Pattern, ts_format: str, tzinfo: tzinfo = timezone.utc
-) -> Iterator[tuple[datetime, str]]:
+) -> Iterator[tuple[datetime | None, str]]:
     """Helper function for determining the correct timestamps for log files without year notation.
 
     Supports compressed files by using :func:`open_decompress`.
@@ -142,7 +142,7 @@ def year_rollover_helper(
                 if not warned:
                     log.warning("No timestamp found in one of the lines in %s!", path)
                     warned = True
-                log.debug("Skipping line: %s", line)
+                yield None, line
                 continue
 
             # We have to append the current_year to strptime instead of adding it using replace later.

--- a/tests/plugins/os/unix/log/test_messages.py
+++ b/tests/plugins/os/unix/log/test_messages.py
@@ -84,11 +84,11 @@ def test_unix_log_messages_compressed_timezone_year_rollover() -> None:
     results = list(target.messages())
     results.reverse()
 
-    assert len(results) == 2
+    assert len(results) == 3
     assert isinstance(results[0], type(MessagesRecord()))
-    assert isinstance(results[1], type(MessagesRecord()))
+    assert isinstance(results[2], type(MessagesRecord()))
     assert results[0].ts == datetime(2020, 12, 31, 3, 14, 0, tzinfo=ZoneInfo("America/Chicago"))
-    assert results[1].ts == datetime(2021, 1, 1, 13, 37, 0, tzinfo=ZoneInfo("America/Chicago"))
+    assert results[2].ts == datetime(2021, 1, 1, 13, 37, 0, tzinfo=ZoneInfo("America/Chicago"))
 
 
 def test_unix_log_messages_malformed_log_year_rollover(target_unix_users: Target, fs_unix: VirtualFilesystem) -> None:
@@ -109,7 +109,7 @@ def test_unix_log_messages_malformed_log_year_rollover(target_unix_users: Target
         target_unix_users.add_plugin(MessagesPlugin)
 
         results = list(target_unix_users.messages())
-        assert len(results) == 2
+        assert len(results) == 3
 
         assert results[0].ts
         assert results[0].service == "systemd"


### PR DESCRIPTION
# Yield ts as None instead of skipping lines in year_rollover_helper that have no timestamp

This way the helper is also compatible with multiline logs. Also updated test_messages.py, since the new logic caused the number of results for the year_rollover tests to change from 2 to 3. Maybe worth looking into if messages plugin should be updated with the new logic. @JSCU-CNI was there a reason that the original implemention skipped lines without a valid timestamp fully instead of just yielding ts as None?