### PR TITLE
Add zip and tar filesystem benchmarks

### DIFF
--- a/dissect/target/filesystems/dir.py
+++ b/dissect/target/filesystems/dir.py
@@ -109,12 +109,6 @@ class DirectoryFilesystemEntry(FilesystemEntry):
         for item in self._resolve().entry.iterdir():
             yield DirectoryDirEntry(self.fs, self.path, item.name, item)
 
-    def exists(self) -> bool:
-        try:
-            return self._resolve().entry.exists()
-        except FilesystemError:
-            return False
-
     def is_dir(self, follow_symlinks: bool = True) -> bool:
         try:
             return self._resolve(follow_symlinks=follow_symlinks).entry.is_dir()

--- a/dissect/target/filesystems/tar.py
+++ b/dissect/target/filesystems/tar.py
@@ -60,11 +60,11 @@ class TarFilesystem(Filesystem):
         self._fs = VirtualFilesystem(alt_separator=self.alt_separator, case_sensitive=self.case_sensitive)
 
         for member in self.tar.getmembers():
-            mname = member.name.removeprefix("./").strip("/")
+            mname = member.name.removeprefix("./")
             if not mname.startswith(self.base) or mname == ".":
                 continue
 
-            rel_name = fsutil.normpath(mname[len(self.base) :], alt_separator=self.alt_separator)
+            rel_name = fsutil.normpath(mname.removeprefix(self.base), alt_separator=self.alt_separator).strip("/")
 
             entry_cls = TarFilesystemDirectoryEntry if member.isdir() else TarFilesystemEntry
             file_entry = entry_cls(self, rel_name, member)

--- a/dissect/target/filesystems/zip.py
+++ b/dissect/target/filesystems/zip.py
@@ -60,11 +60,10 @@ class ZipFilesystem(Filesystem):
         self._fs = VirtualFilesystem(alt_separator=self.alt_separator, case_sensitive=self.case_sensitive)
 
         for member in self.zip.infolist():
-            mname = member.filename.strip("/")
-            if not mname.startswith(self.base) or mname == ".":
+            if not member.filename.startswith(self.base) or member.filename in (".", "./"):
                 continue
 
-            rel_name = self._resolve_path(mname)
+            rel_name = self._resolve_path(member.filename).strip("/")
             self._fs.map_file_entry(rel_name, ZipFilesystemEntry(self, rel_name, member))
 
     @staticmethod
@@ -73,7 +72,7 @@ class ZipFilesystem(Filesystem):
         return zipfile.is_zipfile(fh)
 
     def _resolve_path(self, path: str) -> str:
-        return fsutil.normpath(path[len(self.base) :], alt_separator=self.alt_separator)
+        return fsutil.normpath(path.removeprefix(self.base), alt_separator=self.alt_separator)
 
     def get(self, path: str, relentry: FilesystemEntry = None) -> FilesystemEntry:
         """Returns a ZipFilesystemEntry object corresponding to the given path."""

--- a/tests/filesystems/test_dir.py
+++ b/tests/filesystems/test_dir.py
@@ -25,7 +25,6 @@ def test_symlink_to_file(tmp_path: pathlib.Path) -> None:
         assert symlink_entry.is_file()
         assert not symlink_entry.is_file(follow_symlinks=False)
         assert not symlink_entry.is_dir()
-        assert symlink_entry.exists()
         assert symlink_entry.stat(follow_symlinks=False) == symlink_entry.lstat()
 
         assert symlink_entry.readlink() == f"/{tmpfile_path.name}"
@@ -53,7 +52,6 @@ def test_symlink_to_dir(tmp_path: pathlib.Path) -> None:
     assert not symlink_entry.is_file()
     assert symlink_entry.is_dir()
     assert not symlink_entry.is_dir(follow_symlinks=False)
-    assert symlink_entry.exists()
     assert symlink_entry.stat(follow_symlinks=False) == symlink_entry.lstat()
 
     assert symlink_entry.readlink() == "/nested"

--- a/tests/filesystems/test_tar.py
+++ b/tests/filesystems/test_tar.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import io
 import tarfile
+from typing import TYPE_CHECKING
 
 import pytest
 
 from dissect.target.exceptions import IsADirectoryError, NotADirectoryError
 from dissect.target.filesystems.tar import TarFilesystem, TarFilesystemEntry
+
+if TYPE_CHECKING:
+    from pytest_benchmark.fixture import BenchmarkFixture
 
 
 def _mkdir(tf: tarfile.TarFile, name: str) -> None:
@@ -48,20 +52,21 @@ def _mksym(tf: tarfile.TarFile, name: str, dest: str) -> None:
     tf.addfile(info)
 
 
-def _create_tar(prefix: str = "", tar_dir: bool = True, tar_sym: bool = False) -> io.BytesIO:
+def _create_tar(prefix: str = "", insert_dir: bool = True, tar_sym: bool = False) -> io.BytesIO:
     buf = io.BytesIO()
     tf = tarfile.TarFile(fileobj=buf, mode="w")
 
-    if prefix and tar_dir:
+    if prefix and insert_dir:
         cur = []
-        for p in prefix.strip("/").split("/"):
+        for p in (prefix.rstrip("/") if prefix != "/" else prefix).split("/"):
             cur.append(p)
-            _mkdir(tf, "/".join(cur))
+            if name := "/".join(cur):
+                _mkdir(tf, name)
 
     _mkfile(tf, f"{prefix}file_1", b"file 1 contents")
     _mkfile(tf, f"{prefix}file_2", b"file 2 contents")
 
-    if tar_dir:
+    if insert_dir:
         _mkdir(tf, f"{prefix}dir/")
 
     for i in range(100):
@@ -70,6 +75,12 @@ def _create_tar(prefix: str = "", tar_dir: bool = True, tar_sym: bool = False) -
     if tar_sym:
         _mksym(tf, f"{prefix}sym_1", f"{prefix}file_1")
         _mksym(tf, f"{prefix}sym_2", f"{prefix}dir")
+
+    if insert_dir:
+        _mkdir(tf, f"{prefix}LARGE/")
+
+    for i in range(1000):
+        _mkfile(tf, f"{prefix}LARGE/{i}", f"CAN. YOU. HEAR. ME. {i}".encode())
 
     tf.close()
     buf.seek(0)
@@ -106,18 +117,36 @@ def tar_symlink() -> io.BytesIO:
     return _create_tar("", tar_sym=True)
 
 
+@pytest.fixture
+def tar_absolute() -> io.BytesIO:
+    return _create_tar("/", False)
+
+
+@pytest.fixture
+def tar_absolute_base() -> io.BytesIO:
+    return _create_tar("/base/", False)
+
+
+@pytest.fixture
+def tar_absolute_base_dir() -> io.BytesIO:
+    return _create_tar("/base/")
+
+
 @pytest.mark.parametrize(
     ("obj", "base"),
     [
-        ("tar_simple", ""),
-        ("tar_base", "base/"),
-        ("tar_relative", ""),
-        ("tar_relative_dir", ""),
-        ("tar_virtual_dir", ""),
-        ("tar_symlink", ""),
+        pytest.param("tar_simple", None, id="simple"),
+        pytest.param("tar_base", "base/", id="base"),
+        pytest.param("tar_relative", None, id="relative"),
+        pytest.param("tar_relative_dir", None, id="relative-dir"),
+        pytest.param("tar_virtual_dir", None, id="virtual-dir"),
+        pytest.param("tar_symlink", None, id="symlink"),
+        pytest.param("tar_absolute", None, id="absolute"),
+        pytest.param("tar_absolute_base", "/base/", id="absolute-base"),
+        pytest.param("tar_absolute_base_dir", "/base/", id="absolute-base-dir"),
     ],
 )
-def test_filesystems_tar(obj: str, base: str, request: pytest.FixtureRequest) -> None:
+def test_tar(obj: str, base: str | None, request: pytest.FixtureRequest) -> None:
     fh = request.getfixturevalue(obj)
 
     assert TarFilesystem.detect(fh)
@@ -125,14 +154,14 @@ def test_filesystems_tar(obj: str, base: str, request: pytest.FixtureRequest) ->
     fs = TarFilesystem(fh, base)
     assert isinstance(fs, TarFilesystem)
 
-    assert len(fs.listdir("/")) == (5 if fs.lexists("sym_1") else 3)
+    assert len(fs.listdir("/")) == (6 if fs.lexists("sym_1") else 4)
 
-    assert fs.get("./file_1").open().read() == b"file 1 contents"
-    assert fs.get("./file_2").open().read() == b"file 2 contents"
-    assert len(list(fs.glob("./dir/*"))) == 100
+    assert fs.get("file_1").open().read() == b"file 1 contents"
+    assert fs.get("file_2").open().read() == b"file 2 contents"
+    assert len(list(fs.glob("dir/*"))) == 100
 
-    tfile = fs.get("./file_1")
-    tdir = fs.get("./dir")
+    tfile = fs.get("file_1")
+    tdir = fs.get("dir")
 
     assert tfile.is_file()
     assert not tfile.is_dir()
@@ -192,3 +221,47 @@ def test_filesystems_tar(obj: str, base: str, request: pytest.FixtureRequest) ->
             tsymd.open()
 
         assert len(list(tsymd.listdir())) == 100
+
+
+def test_tar_case_sensitivity(tar_simple: io.BytesIO) -> None:
+    fs = TarFilesystem(tar_simple)
+    with pytest.raises(FileNotFoundError):
+        fs.get("FILE_1")
+
+    assert fs.get("LARGE/1").open().read() == b"CAN. YOU. HEAR. ME. 1"
+
+    fs = TarFilesystem(tar_simple, case_sensitive=False)
+    assert fs.get("FILE_1").open().read() == b"file 1 contents"
+    assert fs.get("large/1").open().read() == b"CAN. YOU. HEAR. ME. 1"
+
+
+@pytest.mark.parametrize(
+    ("obj", "base"),
+    [
+        pytest.param("tar_simple", None, id="simple"),
+        pytest.param("tar_base", "base/", id="base"),
+        pytest.param("tar_relative", None, id="relative"),
+        pytest.param("tar_relative_dir", None, id="relative-dir"),
+        pytest.param("tar_virtual_dir", None, id="virtual-dir"),
+        pytest.param("tar_absolute", None, id="absolute"),
+        pytest.param("tar_absolute_base", "/base/", id="absolute-base"),
+        pytest.param("tar_absolute_base_dir", "/base/", id="absolute-base-virtual-dir"),
+    ],
+)
+@pytest.mark.benchmark
+def test_benchmark_tar_filesystem(
+    obj: str, base: str | None, request: pytest.FixtureRequest, benchmark: BenchmarkFixture
+) -> None:
+    fh = request.getfixturevalue(obj)
+
+    def benchy() -> None:
+        fs = TarFilesystem(fh, base)
+        fs.listdir("/")
+        list(fs.scandir("/"))
+        fs.get("file_1").open().read()
+        fs.get("dir").listdir()
+        list(fs.get("dir").scandir())
+        fs.get("LARGE").listdir()
+        list(fs.get("LARGE").scandir())
+
+    benchmark(benchy)

--- a/tests/filesystems/test_zip.py
+++ b/tests/filesystems/test_zip.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import zipfile
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -10,7 +11,10 @@ from dissect.target.exceptions import (
     NotADirectoryError,
     NotASymlinkError,
 )
-from dissect.target.filesystems.zip import ZipFilesystem, ZipFilesystemEntry
+from dissect.target.filesystems.zip import ZipFilesystem
+
+if TYPE_CHECKING:
+    from pytest_benchmark.fixture import BenchmarkFixture
 
 
 def _mkdir(zf: zipfile.ZipFile, name: str) -> None:
@@ -45,9 +49,10 @@ def _create_zip(prefix: str = "", zip_dir: bool = True) -> io.BytesIO:
 
     if prefix and zip_dir:
         cur = []
-        for p in prefix.strip("/").split("/"):
+        for p in (prefix.rstrip("/") if prefix != "/" else prefix).split("/"):
             cur.append(p)
-            _mkdir(zf, "/".join(cur))
+            if name := "/".join(cur):
+                _mkdir(zf, name)
 
     zf.writestr(zipfile.ZipInfo(f"{prefix}file_1", (1980, 0, 0, 0, 0, 0)), "file 1 contents")
     zf.writestr(zipfile.ZipInfo(f"{prefix}file_2", (2107, 1, 1, 0, 0, 0)), "file 2 contents")
@@ -68,6 +73,12 @@ def _create_zip(prefix: str = "", zip_dir: bool = True) -> io.BytesIO:
     symlink = zipfile.ZipInfo(f"{prefix}symlink_file")
     symlink.external_attr = 0o120777 << 16
     zf.writestr(symlink, "file_1")
+
+    if zip_dir:
+        _mkdir(zf, f"{prefix}large/")
+
+    for i in range(1000):
+        zf.writestr(f"{prefix}large/{i}", f"contents {i}")
 
     zf.close()
     buf.seek(0)
@@ -99,41 +110,59 @@ def zip_virtual_dir() -> io.BytesIO:
     return _create_zip("", False)
 
 
+@pytest.fixture
+def zip_absolute() -> io.BytesIO:
+    return _create_zip("/", False)
+
+
+@pytest.fixture
+def zip_absolute_base() -> io.BytesIO:
+    return _create_zip("/base/")
+
+
+@pytest.fixture
+def zip_absolute_base_virtual_dir() -> io.BytesIO:
+    return _create_zip("/base/", False)
+
+
 @pytest.mark.parametrize(
     ("obj", "base"),
     [
-        ("zip_simple", ""),
-        ("zip_base", "base/"),
-        ("zip_relative", ""),
-        ("zip_relative_dir", ""),
-        ("zip_virtual_dir", ""),
+        pytest.param("zip_simple", None, id="simple"),
+        pytest.param("zip_base", "base/", id="base"),
+        pytest.param("zip_relative", None, id="relative"),
+        pytest.param("zip_relative_dir", None, id="relative-dir"),
+        pytest.param("zip_virtual_dir", None, id="virtual-dir"),
+        pytest.param("zip_absolute", None, id="absolute"),
+        pytest.param("zip_absolute_base", "/base/", id="absolute-base"),
+        pytest.param("zip_absolute_base_virtual_dir", "/base/", id="absolute-base-virtual-dir"),
     ],
 )
-def test_filesystems_zip(obj: str, base: str, request: pytest.FixtureRequest) -> None:
+def test_filesystems_zip(obj: str, base: str | None, request: pytest.FixtureRequest) -> None:
     fh = request.getfixturevalue(obj)
 
     assert ZipFilesystem.detect(fh)
 
     fs = ZipFilesystem(fh, base)
     assert isinstance(fs, ZipFilesystem)
-    assert len(fs.listdir("/")) == 8
+    assert len(fs.listdir("/")) == 9
 
-    assert fs.get("./file_1").open().read() == b"file 1 contents"
-    assert fs.get("./file_2").open().read() == b"file 2 contents"
-    assert fs.get("./file_3").open().read() == b"file 3 contents"
-    assert fs.get("./file_1").lstat().st_mtime_ns == 315532800000000000
-    assert fs.get("./file_2").lstat().st_mtime_ns == 4323283200000000000
-    assert fs.get("./file_3").lstat().st_mtime_ns == 315532800000000000
-    assert fs.get("./file_4").lstat().st_mtime_ns == 4354819199000000000
-    assert fs.get("./file_5").lstat().st_mtime_ns == 1757327980000000000
-    assert fs.get("./symlink_file").open().read() == b"file 1 contents"
-    assert len(list(fs.glob("./dir/*"))) == 100
-    assert len(list(fs.glob("./symlink_dir/*"))) == 100
+    assert fs.get("file_1").open().read() == b"file 1 contents"
+    assert fs.get("file_2").open().read() == b"file 2 contents"
+    assert fs.get("file_3").open().read() == b"file 3 contents"
+    assert fs.get("file_1").lstat().st_mtime_ns == 315532800000000000
+    assert fs.get("file_2").lstat().st_mtime_ns == 4323283200000000000
+    assert fs.get("file_3").lstat().st_mtime_ns == 315532800000000000
+    assert fs.get("file_4").lstat().st_mtime_ns == 4354819199000000000
+    assert fs.get("file_5").lstat().st_mtime_ns == 1757327980000000000
+    assert fs.get("symlink_file").open().read() == b"file 1 contents"
+    assert len(list(fs.glob("dir/*"))) == 100
+    assert len(list(fs.glob("symlink_dir/*"))) == 100
 
-    zfile = fs.get("./file_1")
-    zdir = fs.get("./dir")
-    zsymd = fs.get("./symlink_dir")
-    zsymf = fs.get("./symlink_file")
+    zfile = fs.get("file_1")
+    zdir = fs.get("dir")
+    zsymd = fs.get("symlink_dir")
+    zsymf = fs.get("symlink_file")
 
     assert zfile.is_file()
     assert not zfile.is_dir()
@@ -173,10 +202,34 @@ def test_filesystems_zip(obj: str, base: str, request: pytest.FixtureRequest) ->
     assert not file1.is_symlink()
     assert file1.open().read() == b"contents 1"
 
-    assert file1.stat() == zsymd.get("1").stat()
+    assert file1.stat() == zsymd.readlink_ext().get("1").stat()
 
     assert zfile.stat().st_mode == 0o100600
     assert zfile.stat(follow_symlinks=False) == zfile.lstat()
 
-    if isinstance(zdir, ZipFilesystemEntry):
-        assert zdir.stat().st_mode == 0o40777
+
+@pytest.mark.parametrize(
+    ("obj", "base"),
+    [
+        pytest.param("zip_simple", None, id="simple"),
+        pytest.param("zip_base", "base/", id="base"),
+        pytest.param("zip_relative", None, id="relative"),
+        pytest.param("zip_relative_dir", None, id="relative-dir"),
+        pytest.param("zip_virtual_dir", None, id="virtual-dir"),
+        pytest.param("zip_absolute", None, id="absolute"),
+        pytest.param("zip_absolute_base", "/base/", id="absolute-base"),
+        pytest.param("zip_absolute_base_virtual_dir", "/base/", id="absolute-base-virtual-dir"),
+    ],
+)
+@pytest.mark.benchmark
+def test_benchmark(obj: str, base: str | None, request: pytest.FixtureRequest, benchmark: BenchmarkFixture) -> None:
+    fh = request.getfixturevalue(obj)
+
+    def benchy() -> None:
+        fs = ZipFilesystem(fh, base)
+        fs.listdir("/")
+        fs.get("file_1").open().read()
+        fs.get("dir").listdir()
+        fs.get("large").listdir()
+
+    benchmark(benchy)

--- a/tests/filesystems/test_zip.py
+++ b/tests/filesystems/test_zip.py
@@ -43,11 +43,11 @@ def _mkdir(zf: zipfile.ZipFile, name: str) -> None:
         zf.start_dir = zf.fp.tell()
 
 
-def _create_zip(prefix: str = "", zip_dir: bool = True) -> io.BytesIO:
+def _create_zip(prefix: str = "", insert_dir: bool = True) -> io.BytesIO:
     buf = io.BytesIO()
     zf = zipfile.ZipFile(buf, "w")
 
-    if prefix and zip_dir:
+    if prefix and insert_dir:
         cur = []
         for p in (prefix.rstrip("/") if prefix != "/" else prefix).split("/"):
             cur.append(p)
@@ -60,7 +60,7 @@ def _create_zip(prefix: str = "", zip_dir: bool = True) -> io.BytesIO:
     zf.writestr(zipfile.ZipInfo(f"{prefix}file_4", (2107, 13, 1, 0, 0, 0)), "file 4 contents")
     zf.writestr(zipfile.ZipInfo(f"{prefix}file_5", (2025, 9, 8, 10, 39, 40)), "file 5 contents")
 
-    if zip_dir:
+    if insert_dir:
         _mkdir(zf, f"{prefix}dir/")
 
     for i in range(100):
@@ -74,7 +74,7 @@ def _create_zip(prefix: str = "", zip_dir: bool = True) -> io.BytesIO:
     symlink.external_attr = 0o120777 << 16
     zf.writestr(symlink, "file_1")
 
-    if zip_dir:
+    if insert_dir:
         _mkdir(zf, f"{prefix}LARGE/")
 
     for i in range(1000):
@@ -121,7 +121,7 @@ def zip_absolute_base() -> io.BytesIO:
 
 
 @pytest.fixture
-def zip_absolute_base_virtual_dir() -> io.BytesIO:
+def zip_absolute_base_dir() -> io.BytesIO:
     return _create_zip("/base/", False)
 
 
@@ -135,7 +135,7 @@ def zip_absolute_base_virtual_dir() -> io.BytesIO:
         pytest.param("zip_virtual_dir", None, id="virtual-dir"),
         pytest.param("zip_absolute", None, id="absolute"),
         pytest.param("zip_absolute_base", "/base/", id="absolute-base"),
-        pytest.param("zip_absolute_base_virtual_dir", "/base/", id="absolute-base-virtual-dir"),
+        pytest.param("zip_absolute_base_dir", "/base/", id="absolute-base-dir"),
     ],
 )
 def test_zip(obj: str, base: str | None, request: pytest.FixtureRequest) -> None:
@@ -230,11 +230,13 @@ def test_zip_case_sensitivity(zip_simple: io.BytesIO) -> None:
         pytest.param("zip_virtual_dir", None, id="virtual-dir"),
         pytest.param("zip_absolute", None, id="absolute"),
         pytest.param("zip_absolute_base", "/base/", id="absolute-base"),
-        pytest.param("zip_absolute_base_virtual_dir", "/base/", id="absolute-base-virtual-dir"),
+        pytest.param("zip_absolute_base_dir", "/base/", id="absolute-base-dir"),
     ],
 )
 @pytest.mark.benchmark
-def test_benchmark(obj: str, base: str | None, request: pytest.FixtureRequest, benchmark: BenchmarkFixture) -> None:
+def test_benchmark_zip_filesystem(
+    obj: str, base: str | None, request: pytest.FixtureRequest, benchmark: BenchmarkFixture
+) -> None:
     fh = request.getfixturevalue(obj)
 
     def benchy() -> None:

--- a/tests/filesystems/test_zip.py
+++ b/tests/filesystems/test_zip.py
@@ -75,10 +75,10 @@ def _create_zip(prefix: str = "", zip_dir: bool = True) -> io.BytesIO:
     zf.writestr(symlink, "file_1")
 
     if zip_dir:
-        _mkdir(zf, f"{prefix}large/")
+        _mkdir(zf, f"{prefix}LARGE/")
 
     for i in range(1000):
-        zf.writestr(f"{prefix}large/{i}", f"contents {i}")
+        zf.writestr(f"{prefix}LARGE/{i}", f"CAN. YOU. HEAR. ME. {i}")
 
     zf.close()
     buf.seek(0)
@@ -138,7 +138,7 @@ def zip_absolute_base_virtual_dir() -> io.BytesIO:
         pytest.param("zip_absolute_base_virtual_dir", "/base/", id="absolute-base-virtual-dir"),
     ],
 )
-def test_filesystems_zip(obj: str, base: str | None, request: pytest.FixtureRequest) -> None:
+def test_zip(obj: str, base: str | None, request: pytest.FixtureRequest) -> None:
     fh = request.getfixturevalue(obj)
 
     assert ZipFilesystem.detect(fh)
@@ -208,6 +208,18 @@ def test_filesystems_zip(obj: str, base: str | None, request: pytest.FixtureRequ
     assert zfile.stat(follow_symlinks=False) == zfile.lstat()
 
 
+def test_zip_case_sensitivity(zip_simple: io.BytesIO) -> None:
+    fs = ZipFilesystem(zip_simple, case_sensitive=True)
+    with pytest.raises(FileNotFoundError):
+        fs.get("FILE_1")
+
+    assert fs.get("LARGE/1").open().read() == b"CAN. YOU. HEAR. ME. 1"
+
+    fs = ZipFilesystem(zip_simple, case_sensitive=False)
+    assert fs.get("FILE_1").open().read() == b"file 1 contents"
+    assert fs.get("large/1").open().read() == b"CAN. YOU. HEAR. ME. 1"
+
+
 @pytest.mark.parametrize(
     ("obj", "base"),
     [
@@ -228,8 +240,11 @@ def test_benchmark(obj: str, base: str | None, request: pytest.FixtureRequest, b
     def benchy() -> None:
         fs = ZipFilesystem(fh, base)
         fs.listdir("/")
+        list(fs.scandir("/"))
         fs.get("file_1").open().read()
         fs.get("dir").listdir()
-        fs.get("large").listdir()
+        list(fs.get("dir").scandir())
+        fs.get("LARGE").listdir()
+        list(fs.get("LARGE").scandir())
 
     benchmark(benchy)


### PR DESCRIPTION
Adds a simple benchmark for the zip and tar filesystem, as well as add tests for absolute pathed zips and tars.

Ominous. To test against a future change.

Also, remove the `exists` method on `DirFilesystemEntry`, no idea where that came from, it's not a method on the base class.