### PR TITLE
Refactor zip filesystem

### DIFF
--- a/dissect/target/filesystems/zip.py
+++ b/dissect/target/filesystems/zip.py
@@ -125,19 +125,22 @@ class ZipFilesystemEntry(FilesystemEntry):
             return False
         return fsutil.dirname(path.strip("/"), alt_separator=self.fs.alt_separator) == self.path.strip("/")
 
-    def iterdir(self) -> Iterator[str]:
+    def _iterdir(self) -> Iterator[str]:
         if not self.is_dir():
             raise NotADirectoryError(self.path)
 
         if self.is_symlink():
-            yield from self.readlink_ext().iterdir()
+            yield from self.readlink_ext()._iterdir()
         else:
             yield from filter(self._is_child, self.fs._namemap.keys())
 
+    def iterdir(self) -> Iterator[str]:
+        yield from map(fsutil.basename, self._iterdir())
+
     def scandir(self) -> Iterator[DirEntry]:
-        for name in self.iterdir():
+        for name in self._iterdir():
             entry = self.fs.zip.getinfo(self.fs._namemap.get(name, name))
-            yield ZipDirEntry(self.fs, self.path, name, entry)
+            yield ZipDirEntry(self.fs, self.path, fsutil.basename(name), entry)
 
     def is_dir(self, follow_symlinks: bool = True) -> bool:
         try:

--- a/dissect/target/filesystems/zip.py
+++ b/dissect/target/filesystems/zip.py
@@ -65,18 +65,10 @@ class ZipFilesystem(Filesystem):
         return zf.is_zipfile(fh)
 
     def _resolve_path(self, path: str) -> str:
-        while path:
-            if path[0] == "/":
-                path = path[1:]
-            elif path[:2] == "./":
-                path = path[2:]
-            else:
-                break
-
         if not self.case_sensitive:
             path = path.lower()
 
-        return fsutil.normpath(path, alt_separator=self.alt_separator)
+        return fsutil.normpath(path, alt_separator=self.alt_separator).lstrip("/")
 
     def get(self, path: str) -> FilesystemEntry:
         """Returns a ZipFilesystemEntry object corresponding to the given path."""

--- a/dissect/target/filesystems/zip.py
+++ b/dissect/target/filesystems/zip.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import stat
-import zipfile
+import zipfile as zf
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, BinaryIO
-
-from dissect.util.stream import BufferedStream
 
 from dissect.target.exceptions import (
     FileNotFoundError,
@@ -14,24 +12,11 @@ from dissect.target.exceptions import (
     NotADirectoryError,
     NotASymlinkError,
 )
-from dissect.target.filesystem import (
-    Filesystem,
-    FilesystemEntry,
-    VirtualDirectory,
-    VirtualFilesystem,
-)
+from dissect.target.filesystem import DirEntry, Filesystem, FilesystemEntry
 from dissect.target.helpers import fsutil
-from dissect.target.helpers.logging import get_logger
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-
-    from dissect.target.filesystem import (
-        DirEntry,
-    )
-
-
-log = get_logger(__name__)
 
 
 class ZipFilesystem(Filesystem):
@@ -47,47 +32,81 @@ class ZipFilesystem(Filesystem):
         self,
         fh: BinaryIO,
         base: str | None = None,
-        *args,
+        *,
+        zipfile: zf.ZipFile | None = None,
         **kwargs,
     ):
-        super().__init__(fh, *args, **kwargs)
+        super().__init__(fh, **kwargs)
 
-        fh.seek(0)
+        if zipfile:
+            self.zip = zipfile
+        else:
+            fh.seek(0)
+            self.zip = zf.ZipFile(fh, mode="r")
 
-        self.zip = zipfile.ZipFile(fh, mode="r")
-        self.base = base or ""
+        self.base = self._resolve_path(base) if base else ""
+        if self.base and not self.base.endswith("/"):
+            self.base += "/"
 
-        self._fs = VirtualFilesystem(alt_separator=self.alt_separator, case_sensitive=self.case_sensitive)
-
-        for member in self.zip.infolist():
-            if not member.filename.startswith(self.base) or member.filename in (".", "./"):
-                continue
-
-            rel_name = self._resolve_path(member.filename).strip("/")
-            self._fs.map_file_entry(rel_name, ZipFilesystemEntry(self, rel_name, member))
+        # Ideally we just use zf.Path, but it doesn't handle absolute paths or relative paths (e.g., "./") correctly
+        # We can at least steal the namelist with implied directories and go from there
+        self._namemap = {}
+        for name in zf.Path(self.zip).root.namelist():
+            normalized = self._resolve_path(name)
+            if self.base:
+                if not normalized.startswith(self.base):
+                    continue
+                normalized = normalized.removeprefix(self.base)
+            self._namemap[normalized] = name
 
     @staticmethod
     def _detect(fh: BinaryIO) -> bool:
         """Detect a zip file on a given file-like object."""
-        return zipfile.is_zipfile(fh)
+        return zf.is_zipfile(fh)
 
     def _resolve_path(self, path: str) -> str:
-        return fsutil.normpath(path.removeprefix(self.base), alt_separator=self.alt_separator)
+        while path:
+            if path[0] == "/":
+                path = path[1:]
+            elif path[:2] == "./":
+                path = path[2:]
+            else:
+                break
 
-    def get(self, path: str, relentry: FilesystemEntry = None) -> FilesystemEntry:
+        if not self.case_sensitive:
+            path = path.lower()
+
+        return fsutil.normpath(path, alt_separator=self.alt_separator)
+
+    def get(self, path: str) -> FilesystemEntry:
         """Returns a ZipFilesystemEntry object corresponding to the given path."""
-        return self._fs.get(path, relentry=relentry)
+        path = fsutil.normpath(path.strip("/"))
+        path = path.lower() if not self.case_sensitive else path
+        if (normpath := self._namemap.get(path)) is None:
+            if path == "":
+                return ZipFilesystemEntry(self, "/", zf.ZipInfo(filename=self.base or "/"))
+            raise FileNotFoundError(path)
+
+        return ZipFilesystemEntry(self, path, self.zip.getinfo(normpath))
 
 
-# Note: We subclass from VirtualDirectory because VirtualFilesystem is currently only compatible with VirtualDirectory
-# Subclass from VirtualDirectory so we get that compatibility for free, and override the rest to do our own thing
-class ZipFilesystemEntry(VirtualDirectory):
+class ZipDirEntry(DirEntry):
     fs: ZipFilesystem
-    entry: zipfile.ZipInfo
+    entry: zf.ZipInfo
 
-    def __init__(self, fs: ZipFilesystem, path: str, entry: zipfile.ZipInfo):
-        super().__init__(fs, path)
-        self.entry = entry
+    def get(self) -> FilesystemEntry:
+        return ZipFilesystemEntry(self.fs, self.path, self.entry)
+
+    def stat(self, *, follow_symlinks: bool = True) -> fsutil.stat_result:
+        return self.get().stat(follow_symlinks=follow_symlinks)
+
+
+class ZipFilesystemEntry(FilesystemEntry):
+    fs: ZipFilesystem
+    entry: zf.ZipInfo
+
+    def get(self, path: str) -> FilesystemEntry:
+        return self.fs.get(fsutil.join(self.path, path, alt_separator=self.fs.alt_separator))
 
     def open(self) -> BinaryIO:
         if self.is_dir():
@@ -97,77 +116,76 @@ class ZipFilesystemEntry(VirtualDirectory):
             return self._resolve().open()
 
         try:
-            return BufferedStream(self.fs.zip.open(self.entry), size=self.entry.file_size)
+            return self.fs.zip.open(self.entry)
         except Exception:
             raise FileNotFoundError(self.path)
 
-    def scandir(self) -> Iterator[DirEntry]:
+    def _is_child(self, path: str) -> bool:
+        if path == "":
+            return False
+        return fsutil.dirname(path.strip("/"), alt_separator=self.fs.alt_separator) == self.path.strip("/")
+
+    def iterdir(self) -> Iterator[str]:
         if not self.is_dir():
             raise NotADirectoryError(self.path)
 
-        if isinstance(entry := self._resolve(), ZipFilesystemEntry):
-            return super(ZipFilesystemEntry, entry).scandir()
-        return entry.scandir()
+        if self.is_symlink():
+            yield from self.readlink_ext().iterdir()
+        else:
+            yield from filter(self._is_child, self.fs._namemap.keys())
+
+    def scandir(self) -> Iterator[DirEntry]:
+        for name in self.iterdir():
+            entry = self.fs.zip.getinfo(self.fs._namemap.get(name, name))
+            yield ZipDirEntry(self.fs, self.path, name, entry)
 
     def is_dir(self, follow_symlinks: bool = True) -> bool:
         try:
-            entry = self._resolve(follow_symlinks=follow_symlinks)
+            return self._resolve(follow_symlinks=follow_symlinks).entry.is_dir()
         except FilesystemError:
             return False
-
-        if isinstance(entry, ZipFilesystemEntry):
-            return entry.entry.is_dir()
-        return isinstance(entry, VirtualDirectory)
 
     def is_file(self, follow_symlinks: bool = True) -> bool:
-        try:
-            entry = self._resolve(follow_symlinks=follow_symlinks)
-        except FilesystemError:
-            return False
-
-        if isinstance(entry, ZipFilesystemEntry):
-            return not entry.entry.is_dir()
-        return False
+        return not self.is_dir(follow_symlinks=follow_symlinks)
 
     def is_symlink(self) -> bool:
-        return stat.S_ISLNK(self.entry.external_attr >> 16)
+        return stat.S_ISLNK(self.lstat().st_mode)
 
     def readlink(self) -> str:
         if not self.is_symlink():
             raise NotASymlinkError
-        return self.fs.zip.open(self.entry).read().decode()
-
-    def readlink_ext(self) -> FilesystemEntry:
-        return FilesystemEntry.readlink_ext(self)
+        return self.fs.zip.open(self.entry).read().decode("utf-8")
 
     def stat(self, follow_symlinks: bool = True) -> fsutil.stat_result:
         return self._resolve(follow_symlinks=follow_symlinks).lstat()
 
     def lstat(self) -> fsutil.stat_result:
-        """Return the stat information of the given path, without resolving links."""
-        # ['mode', 'addr', 'dev', 'nlink', 'uid', 'gid', 'size', 'atime', 'mtime', 'ctime']
-        mode = self.entry.external_attr >> 16
+        info = self.entry
 
-        if self.entry.is_dir() and not stat.S_ISDIR(mode):
+        if not (mode := info.external_attr >> 16):
+            mode = 0o777
+
+        if info.is_dir() and not stat.S_ISDIR(mode):
             mode = stat.S_IFDIR | mode
-        elif not self.entry.is_dir() and not stat.S_ISREG(mode):
+        elif not info.is_dir() and not stat.S_ISREG(mode):
             mode = stat.S_IFREG | mode
 
         try:
-            mtime = datetime(*self.entry.date_time, tzinfo=timezone.utc)
+            mtime = datetime(*info.date_time, tzinfo=timezone.utc)
         except ValueError:
-            mtime_tuple = (2107, 12, 31, 23, 59, 59) if self.entry.date_time[0] >= 2107 else (1980, 1, 1, 0, 0, 0)
+            mtime_tuple = (2107, 12, 31, 23, 59, 59) if info.date_time[0] >= 2107 else (1980, 1, 1, 0, 0, 0)
             mtime = datetime(*mtime_tuple, tzinfo=timezone.utc)
 
+        # ['mode', 'addr', 'dev', 'nlink', 'uid', 'gid', 'size', 'atime', 'mtime', 'ctime']
         return fsutil.stat_result(
             [
                 mode,
-                self.entry.header_offset,
+                getattr(info, "header_offset", id(info)),
                 id(self.fs),
                 1,
                 0,
                 0,
-                self.entry.file_size,
+                info.file_size,
                 0,
                 mtime.timestamp(),
                 0,

--- a/dissect/target/helpers/polypath.py
+++ b/dissect/target/helpers/polypath.py
@@ -49,7 +49,11 @@ def dirname(path: str, alt_separator: str = "") -> str:
 
 
 def normpath(path: str, alt_separator: str = "") -> str:
-    return posixpath.normpath(normalize(path, alt_separator=alt_separator))
+    path = posixpath.normpath(normalize(path, alt_separator=alt_separator))
+    # TODO: to hold us over until the path changes are merged
+    if path == ".":
+        path = ""
+    return path
 
 
 def abspath(path: str, cwd: str = "", alt_separator: str = "") -> str:

--- a/tests/filesystems/test_zip.py
+++ b/tests/filesystems/test_zip.py
@@ -183,6 +183,8 @@ def test_zip(obj: str, base: str | None, request: pytest.FixtureRequest) -> None
     assert len(list(zdir.iterdir())) == 100
     assert len(list(zdir.scandir())) == 100
 
+    assert zdir.listdir() == [str(i) for i in range(100)]
+
     with pytest.raises(IsADirectoryError):
         zdir.open()
 

--- a/tests/filesystems/test_zip.py
+++ b/tests/filesystems/test_zip.py
@@ -43,15 +43,15 @@ def _mkdir(zf: zipfile.ZipFile, name: str) -> None:
         zf.start_dir = zf.fp.tell()
 
 
-def _create_zip(prefix: str = "", insert_dir: bool = True) -> io.BytesIO:
+def _create_zip(prefix: str = "", insert_dir: bool = True, sep: str = "/") -> io.BytesIO:
     buf = io.BytesIO()
     zf = zipfile.ZipFile(buf, "w")
 
     if prefix and insert_dir:
         cur = []
-        for p in (prefix.rstrip("/") if prefix != "/" else prefix).split("/"):
+        for p in (prefix.rstrip(sep) if prefix != sep else prefix).split(sep):
             cur.append(p)
-            if name := "/".join(cur):
+            if name := sep.join(cur):
                 _mkdir(zf, name)
 
     zf.writestr(zipfile.ZipInfo(f"{prefix}file_1", (1980, 0, 0, 0, 0, 0)), "file 1 contents")
@@ -61,24 +61,24 @@ def _create_zip(prefix: str = "", insert_dir: bool = True) -> io.BytesIO:
     zf.writestr(zipfile.ZipInfo(f"{prefix}file_5", (2025, 9, 8, 10, 39, 40)), "file 5 contents")
 
     if insert_dir:
-        _mkdir(zf, f"{prefix}dir/")
+        _mkdir(zf, f"{prefix}dir{sep}")
 
     for i in range(100):
-        zf.writestr(f"{prefix}dir/{i}", f"contents {i}")
+        zf.writestr(f"{prefix}dir{sep}{i}", f"contents {i}")
 
     symlink = zipfile.ZipInfo(f"{prefix}symlink_dir")
     symlink.external_attr = 0o120777 << 16
-    zf.writestr(symlink, "dir/")
+    zf.writestr(symlink, f"dir{sep}")
 
     symlink = zipfile.ZipInfo(f"{prefix}symlink_file")
     symlink.external_attr = 0o120777 << 16
     zf.writestr(symlink, "file_1")
 
     if insert_dir:
-        _mkdir(zf, f"{prefix}LARGE/")
+        _mkdir(zf, f"{prefix}LARGE{sep}")
 
     for i in range(1000):
-        zf.writestr(f"{prefix}LARGE/{i}", f"CAN. YOU. HEAR. ME. {i}")
+        zf.writestr(f"{prefix}LARGE{sep}{i}", f"CAN. YOU. HEAR. ME. {i}")
 
     zf.close()
     buf.seek(0)


### PR DESCRIPTION
As a follow up to https://github.com/fox-it/dissect.target/pull/1772, this PR aims to simplify and speed up the zip filesystem implementation a bit by getting rid of the dependency of the virtual filesystem, as well as hopefully dealing with some more edge cases.

I took some inspiration from how `zipfile.ZipPath` works for this.

Correctly dealing with all the paths and variations is a bit tricky, so I'm sure there's room for improvement. This is also a bit of a test run before I commit to the tar variant, since that has a lot of loaders that depend on the implementation details of the current tar filesystem.

Fingers crossed that Codspeed agrees this is faster.