### PR TITLE
Fix ValueError in MRU plugin when running mru.msoffice

### DIFF
--- a/dissect/target/plugins/os/windows/regf/mru.py
+++ b/dissect/target/plugins/os/windows/regf/mru.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import struct
 from typing import TYPE_CHECKING
 
@@ -113,8 +114,12 @@ MSOfficeMRURecord = UserRegistryRecordDescriptor(
         ("varint", "index"),
         ("string", "value"),
         ("string", "key"),
+        ("string", "metadata"),
     ],
 )
+
+RE_OFFICEMRU_VALUE_NAME = re.compile(r"^Item (\d+)$")
+RE_OFFICEMRU_METADATA_VALUE_NAME = re.compile(r"^Item Metadata (\d+)$")
 
 
 class MRUPlugin(Plugin):
@@ -434,20 +439,25 @@ def parse_office_mru(target: Target, key: RegistryKey, record: TargetRecordDescr
 def parse_office_mru_key(target: Target, key: RegistryKey, record: TargetRecordDescriptor) -> Iterator[Record]:
     user = target.registry.get_user(key)
 
+    mru_metadata = {}
+    mru_data = []
+
     for value in key.values():
-        if not value.name.startswith("Item"):
-            continue
+        if match := RE_OFFICEMRU_METADATA_VALUE_NAME.fullmatch(value.name):
+            mru_metadata[int(match.group(1))] = value.value
+        elif match := RE_OFFICEMRU_VALUE_NAME.fullmatch(value.name):
+            entry_index = int(match.group(1))
+            info_str, path = value.value.split("*", 1)
+            info = {part[0]: int(part[1:], 16) for part in info_str.strip("[]").split("][")}
+            mru_data.append((entry_index, info, path))
 
-        entry_index = int(value.name.split(" ")[1])
-        info_str, path = value.value.split("*", 1)
-
-        info = {part[0]: int(part[1:], 16) for part in info_str.strip("[]").split("][")}
-
+    for entry_index, info, path in mru_data:
         yield record(
             ts=wintimestamp(info["T"]),
             regf_mtime=key.ts,
             index=entry_index,
             value=path,
+            metadata=mru_metadata.get(entry_index),
             _target=target,
             _user=user,
             _key=key,

--- a/tests/plugins/os/windows/test_mru.py
+++ b/tests/plugins/os/windows/test_mru.py
@@ -158,6 +158,8 @@ def target_win_mru(target_win_users: Target) -> Target:
     excel_15_file_key = VirtualKey(user_hive, "Software\\Microsoft\\Office\\15.0\\Excel\\File MRU")
     excel_15_file_key.add_value("Item 1", VirtualValue(user_hive, "Item 1", office_value))
     excel_15_file_key.add_value("Item 2", VirtualValue(user_hive, "Item 2", office_value))
+    metadata_value = "<Metadata><AppSpecific><OneNoteNotebookUrl>C:\\Path</OneNoteNotebookUrl></AppSpecific></Metadata>"
+    excel_15_file_key.add_value("Item Metadata 1", VirtualValue(user_hive, "Item Metadata 1", metadata_value))
     excel_16_place_key = VirtualKey(user_hive, "Software\\Microsoft\\Office\\16.0\\Excel\\Place MRU")
     excel_16_place_key.add_value("Item 1", VirtualValue(user_hive, "Item 1", office_value))
     excel_16_place_key.add_value("Item 2", VirtualValue(user_hive, "Item 2", office_value))
@@ -221,5 +223,11 @@ def test_mru_plugin(target_win_mru: Target) -> None:
     assert len(networkdrive) == 2
     assert len(mstsc) == 3
     assert len(msoffice) == 6
+
+    msoffice_with_metadata = [r for r in msoffice if r.metadata is not None]
+    assert len(msoffice_with_metadata) == 1
+    assert msoffice_with_metadata[0].metadata == (
+        "<Metadata><AppSpecific><OneNoteNotebookUrl>C:\\Path</OneNoteNotebookUrl></AppSpecific></Metadata>"
+    )
 
     assert len(list(target_win_mru.mru())) == 27


### PR DESCRIPTION
Got this exception when running `mru.msoffice`:

```
Traceback (most recent call last):
  File "/home/user/venv/bin/target-query", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/tools/utils/cli.py", line 475, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/tools/query.py", line 260, in main
    for record in record_generator:
                  ^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/plugins/os/windows/regf/mru.py", line 307, in msoffice
    yield from parse_office_mru(self.target, subkey, MSOfficeMRURecord)
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/plugins/os/windows/regf/mru.py", line 435, in parse_office_mru
    yield from parse_office_mru(target, subkey, record)
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/plugins/os/windows/regf/mru.py", line 429, in parse_office_mru
    yield from parse_office_mru_key(target, key.subkey("Place MRU"), record)
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/plugins/os/windows/regf/mru.py", line 447, in parse_office_mru_key
    entry_index = int(value.name.split(" ")[1])
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'Metadata'
```

In my case in addition to regular registry office MRU values like `Item 1, Item 2` in File/Place MRU there were extra values with names like `Item Metadata 1` and data like this: `<Metadata><AppSpecific><OneNoteNotebookUrl>C:\Path</OneNoteNotebookUrl></AppSpecific></Metadata>`