### PR TITLE
Fix EOFError in MRU plugin on mru.opensave

### DIFF
--- a/dissect/target/plugins/os/windows/regf/shellbags.py
+++ b/dissect/target/plugins/os/windows/regf/shellbags.py
@@ -460,7 +460,10 @@ class URI(SHITEM):
         super().__init__(buf)
         self.uri = None
         if self.item.data_size < self.size - 6:
-            self.data = self.fh.read(self.item.data_size - 2)
+            if self.item.data_size > 2:
+                self.data = self.fh.read(self.item.data_size - 2)
+            else:
+                self.fh.seek(8)  # No data, URI string starts at offset 0x8
             if self.item.flags & 0x80:
                 self.uri = c_bag.wchar[None](self.fh)
             else:

--- a/tests/plugins/os/windows/test_mru.py
+++ b/tests/plugins/os/windows/test_mru.py
@@ -109,6 +109,24 @@ def target_win_mru(target_win_users: Target) -> Target:
         ),
     )
 
+    opensave_pidl_contacts_subkey = VirtualKey(user_hive, opensave_pidl_key.path + "\\info/contacts")
+    opensave_pidl_contacts_subkey.add_value(
+        "MRUListEx",
+        VirtualValue(user_hive, "MRUListEx", b"\x00\x00\x00\x00\xff\xff\xff\xff"),
+    )
+    contacts_data = bytes.fromhex(
+        "14001F6880531C87A0426910A2EA08002B30309D"
+        "4A0061800000000068007400740070003A002F00"
+        "2F007700770077002E0074006500730074003000"
+        "31002E0069006E0066006F002F0063006F006E00"
+        "74006100630074007300000000000000"
+    )
+    opensave_pidl_contacts_subkey.add_value(
+        "0",
+        VirtualValue(user_hive, "0", contacts_data),
+    )
+    opensave_pidl_key.add_subkey("info/contacts", opensave_pidl_contacts_subkey)
+
     # ACMru
     acmru_key = VirtualKey(user_hive, "Software\\Microsoft\\Search Assistant\\ACMru\\5603")
     acmru_key.add_value("000", VirtualValue(user_hive, "000", "value"))
@@ -187,9 +205,10 @@ def test_mru_plugin(target_win_mru: Target) -> None:
 
     assert len(run) == 2
     assert len(recentdocs) == 1
-    assert len(opensave) == 5
+    assert len(opensave) == 6
     # test if opensave_pidl_key is correctly resolved
     assert opensave[4].value == "My Computer\\Z:\\Web Optimizer.zip"
+    assert any("http://www.test01.info/contacts" in r.value for r in opensave)
     assert len(lastvisited) == 3
     # test if lastvisited_pidl_key is correctly resolved
     assert lastvisited[2].filename == "KeePass.exe"
@@ -199,4 +218,4 @@ def test_mru_plugin(target_win_mru: Target) -> None:
     assert len(mstsc) == 3
     assert len(msoffice) == 6
 
-    assert len(list(target_win_mru.mru())) == 25
+    assert len(list(target_win_mru.mru())) == 26


### PR DESCRIPTION
Got another exception in MRU plugin on `mru.opensave`, on multiple machines:

```
Traceback (most recent call last):
  File "/home/user/venv/bin/target-query", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/tools/utils/cli.py", line 475, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/tools/query.py", line 260, in main
    for record in record_generator:
                  ^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/plugins/os/windows/regf/mru.py", line 184, in opensave
    yield from parse_mru_ex_key(self.target, key, OpenSaveMRURecord)
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/plugins/os/windows/regf/mru.py", line 419, in parse_mru_ex_key
    yield from parse_mru_ex_key(target, subkey, record)
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/plugins/os/windows/regf/mru.py", line 383, in parse_mru_ex_key
    parsed_bag = list(parse_shell_item_list(bag))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/plugins/os/windows/regf/shellbags.py", line 860, in parse_shell_item_list
    entry = entry(item_buf)
            ^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/plugins/os/windows/regf/shellbags.py", line 465, in __init__
    self.uri = c_bag.wchar[None](self.fh)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/cstruct/types/base.py", line 44, in __call__
    return cls._read(stream)
           ^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/cstruct/types/wchar.py", line 20, in _read
    return type.__call__(cls, super()._read(stream, context))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/cstruct/types/base.py", line 255, in _read
    return cls.type._read_0(stream, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/cstruct/types/wchar.py", line 71, in _read_0
    raise EOFError(f"Read {bytes_read} bytes, but expected 2")
EOFError: Read 0 bytes, but expected 2
```

This happened when parsing values in `OpenSavePidlMRU\\info/contacts`, one of values there had URI type, which can have `data_size` field set to 0 and still have URI string data (as per https://github.com/libyal/libfwsi/blob/main/documentation/Windows%20Shell%20Item%20format.asciidoc#36-uri-shell-item)