### PR TITLE
Fix ValueError in amcache.application_files

### DIFF
--- a/dissect/target/plugins/os/windows/amcache.py
+++ b/dissect/target/plugins/os/windows/amcache.py
@@ -710,7 +710,10 @@ class AmcachePlugin(AmcachePluginOldMixin, Plugin):
 
 def parse_win_datetime(value: str) -> datetime | None:
     if value:
-        return datetime.strptime(value, "%m/%d/%Y %H:%M:%S").replace(tzinfo=timezone.utc)
+        try:
+            return datetime.strptime(value, "%m/%d/%Y %H:%M:%S").replace(tzinfo=timezone.utc)
+        except ValueError:
+            return None
     return None
 
 

--- a/tests/plugins/os/windows/test_amcache.py
+++ b/tests/plugins/os/windows/test_amcache.py
@@ -176,6 +176,54 @@ def test_parse_inventory_application_file(
         assert call_kwargs.get("digest", None) == (None, expected_file_id, None)
 
 
+def mock_read_key_subkeys_bad_link_date(self: AmcachePlugin, key: str) -> Iterator[Mock]:
+    base_values = {
+        "AppxPackageFullName": "Microsoft.Microsoft3DViewer_7.2105.4012.0_x64__8wekyb3d8bbwe",
+        "AppxPackageRelativeId": "Microsoft.Microsoft3DViewer",
+        "BinFileVersion": "7.2105.4012.0",
+        "BinProductVersion": "7.2105.4012.0",
+        "BinaryType": "pe64_amd64",
+        "Language": 0,
+        "LinkDate": "7.2105.4012.0",
+        "LongPathHash": "3dviewer.exe|40f275349895ac70",
+        "LowerCaseLongPath": "c:\\program files\\windowsapps\\microsoft.0_x64__8wekyb3d8bbwe\\3dviewer.exe",
+        "Name": "3DViewer.exe",
+        "OriginalFileName": "3dviewer.exe",
+        "ProductName": "view 3d",
+        "ProductVersion": "7.2105.4012.0",
+        "ProgramId": "0000df892556c2f7a6b7fa69f7009b5c08cb00000904",
+        "Publisher": "microsoft corporation",
+        "Size": 19456,
+        "Usn": 32259776,
+        "Version": "7.2105.4012.0",
+        "FileId": "00008e01cdeb9a1c23cee421a647f29c45f67623be97",
+    }
+
+    mock_values = []
+    for key, value in base_values.items():
+        mock_value = Mock()
+        mock_value.name = key
+        mock_value.value = value
+        mock_values.append(mock_value)
+
+    mock_entry = Mock()
+    mock_entry.timestamp = datetime.datetime(2021, 12, 31, tzinfo=datetime.timezone.utc)
+    mock_entry.values = Mock(return_value=mock_values)
+
+    yield mock_entry
+
+
+@patch.object(AmcachePlugin, "read_key_subkeys", mock_read_key_subkeys_bad_link_date)
+def test_parse_inventory_application_file_bad_link_date(target_win: Target) -> None:
+    with patch("dissect.target.plugins.os.windows.amcache.ApplicationFileAppcompatRecord") as mock_record:
+        amcache_plugin = AmcachePlugin(target_win)
+        list(amcache_plugin.parse_inventory_application_file())
+
+        call_kwargs = mock_record.call_args.kwargs
+        assert call_kwargs["link_date"] is None
+        assert call_kwargs["name"] == "3DViewer.exe"
+
+
 def test_amcache_install_entry(target_win: Target) -> None:
     amcache_install_plugin = AmcacheInstallPlugin(target_win)
 


### PR DESCRIPTION
Another exception, now in `amcache.application_files`:

```
Traceback (most recent call last):
  File "/home/user/venv/bin/target-query", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/user/dissect/dissect.target/dissect/target/tools/utils/cli.py", line 475, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/dissect/dissect.target/dissect/target/tools/query.py", line 260, in main
    for record in record_generator:
                  ^^^^^^^^^^^^^^^^
  File "/home/user/dissect/dissect.target/dissect/target/plugins/os/windows/amcache.py", line 603, in application_files
    yield from self.parse_inventory_application_file()
  File "/home/user/dissect/dissect.target/dissect/target/plugins/os/windows/amcache.py", line 500, in parse_inventory_application_file
    link_date=parse_win_datetime(entry_data.get("LinkDate")),
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/dissect/dissect.target/dissect/target/plugins/os/windows/amcache.py", line 714, in parse_win_datetime
    return datetime.strptime(value, "%m/%d/%Y %H:%M:%S").replace(tzinfo=timezone.utc)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/_strptime.py", line 653, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/_strptime.py", line 432, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data '8.3.27.1719' does not match format '%m/%d/%Y %H:%M:%S'
```

Happened on multiple machines which had amcache records that have `LinkDate` value set not to timestamp, but to verison string (same as `ProductVersion`, `BinFileVersion` etc.), which breaks timestamp parsing
