### PR TITLE
Support CacheMainSdb in shimcache plugin and fix EOFError in it

### DIFF
--- a/dissect/target/plugins/os/windows/regf/shimcache.py
+++ b/dissect/target/plugins/os/windows/regf/shimcache.py
@@ -226,6 +226,9 @@ class ShimCache:
             self.noheader = True
             return SHIMCACHE_WIN_TYPE.VERSION_WIN81_NO_HEADER
 
+        if magic == MAGIC_WIN81 and self.noheader:
+            return SHIMCACHE_WIN_TYPE.VERSION_WIN81_NO_HEADER
+
         if len(d) >= 0x84 and c_shim.uint32(d[0x80:0x84]) == MAGIC_WIN81:
             return SHIMCACHE_WIN_TYPE.VERSION_WIN81
 

--- a/tests/plugins/os/windows/test_defender.py
+++ b/tests/plugins/os/windows/test_defender.py
@@ -76,7 +76,7 @@ def test_defender_quarantine_entries(target_win: Target, fs_win: VirtualFilesyst
 
     target_win.add_plugin(MicrosoftDefenderPlugin)
 
-    records = list(target_win.defender.quarantine())
+    records = sorted(target_win.defender.quarantine(), key=lambda r: r.ts)
 
     assert len(records) == 8
 
@@ -98,7 +98,9 @@ def test_defender_quarantine_entries(target_win: Target, fs_win: VirtualFilesyst
     assert mimikatz_record.scan_id == "cdbe4600e43a964b8dc2416b0ef7a207"
     assert mimikatz_record.threat_id == 2147705511
 
-    ie_records = [r for r in records if r.quarantine_id == "229c0170000000004d02ef183c202f42"]
+    ie_records = sorted(
+        [r for r in records if r.quarantine_id == "229c0170000000004d02ef183c202f42"], key=lambda r: r.ts
+    )
     assert len(ie_records) == 2
 
     ie_file_record = ie_records[0]
@@ -114,10 +116,12 @@ def test_defender_quarantine_entries(target_win: Target, fs_win: VirtualFilesyst
         "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Internet Explorer.lnk"
     )
 
-    tasksched_records = [r for r in records if r.quarantine_id == "3c1f228000000000270c270b71d096cd"]
+    tasksched_records = sorted(
+        [r for r in records if r.quarantine_id == "3c1f228000000000270c270b71d096cd"], key=lambda r: r.ts
+    )
     assert len(tasksched_records) == 5
 
-    regkey_records = [r for r in tasksched_records if r.detection_type == "regkey"]
+    regkey_records = sorted([r for r in tasksched_records if r.detection_type == "regkey"], key=lambda r: r.ts)
     assert len(regkey_records) == 2
     assert regkey_records[0].detection_name == "HackTool:Win32/AutoKMS"
     assert regkey_records[0].detection_path == (
@@ -128,7 +132,7 @@ def test_defender_quarantine_entries(target_win: Target, fs_win: VirtualFilesyst
         "Tasks\\{EBCB386F-05C8-4545-9455-922990114435}"
     )
 
-    file_records = [r for r in tasksched_records if r.detection_type == "file"]
+    file_records = sorted([r for r in tasksched_records if r.detection_type == "file"], key=lambda r: r.ts)
     assert len(file_records) == 2
     assert file_records[0].detection_path == "C:\\WINDOWS\\System32\\Tasks\\KMSAuto"
     assert file_records[0].resource_id == "FCC63B61E24395BA6AA3E40EA16E3D2DD24A2916"
@@ -136,7 +140,7 @@ def test_defender_quarantine_entries(target_win: Target, fs_win: VirtualFilesyst
     assert file_records[1].detection_path == "C:\\Windows\\KMSAutoS\\KMSAuto x64.exe"
     assert file_records[1].file_size == 1711464
 
-    ts_records = [r for r in tasksched_records if r.detection_type == "taskscheduler"]
+    ts_records = sorted([r for r in tasksched_records if r.detection_type == "taskscheduler"], key=lambda r: r.ts)
     assert len(ts_records) == 1
     ts_record = ts_records[0]
     assert ts_record.detection_type == "taskscheduler"

--- a/tests/plugins/os/windows/test_shimcache.py
+++ b/tests/plugins/os/windows/test_shimcache.py
@@ -276,3 +276,19 @@ def test_gracefull_shutdown_crc(target_win: Target, mocked_shimcache: ShimCache)
     with patch(f"{ShimcachePlugin.__module__}.ShimcacheRecord") as mocked_record:
         list_gen = list_generator([CRCMismatchException(), (0, "path")])
         assert list(plugin._get_records(None, list_gen)) == [mocked_record.return_value]
+
+
+def test_shimcache_cachemainsdb_entry() -> None:
+    cache_data = bytes.fromhex(
+        "31307473ddeab51228000000220049004300450073006f0075006e006400410050004f00360034002e0064006c006c0000040000"
+    )
+
+    cache = ShimCache(fh=BytesIO(cache_data), ntversion="10.0", noheader=True)
+
+    assert cache.version == SHIMCACHE_WIN_TYPE.VERSION_WIN81_NO_HEADER
+
+    results = list(cache)
+    assert len(results) == 1
+    ts, path = results[0]
+    assert ts is None
+    assert path == "ICEsoundAPO64.dll"


### PR DESCRIPTION
On one machine got this exception while running `shimcache`:

```
Traceback (most recent call last):
  File "/home/user/venv/bin/target-query", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/user/dissect/dissect.target/dissect/target/tools/utils/cli.py", line 475, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/dissect/dissect.target/dissect/target/tools/query.py", line 260, in main
    for record in record_generator:
                  ^^^^^^^^^^^^^^^^
  File "/home/user/dissect/dissect.target/dissect/target/plugins/os/windows/regf/shimcache.py", line 341, in shimcache
    yield from self._get_records(value_name, cache)
  File "/home/user/dissect/dissect.target/dissect/target/plugins/os/windows/regf/shimcache.py", line 344, in _get_records
    for index, item in enumerate(cache):
                       ^^^^^^^^^^^^^^^^
  File "/home/user/dissect/dissect.target/dissect/target/plugins/os/windows/regf/shimcache.py", line 261, in iter_win_8_plus
    ed = data_header(entry.data)
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/cstruct/types/structure.py", line 88, in __call__
    return super().__call__(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/cstruct/types/base.py", line 51, in __call__
    return cls.reads(stream)
           ^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/cstruct/types/base.py", line 83, in reads
    return cls._read(BytesIO(data))
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "<compiled WIN10_ENTRY_DATA._read>", line 19, in _read
EOFError
```

It was raised while parsing `CacheMainSdb` value in `AppCompatCache`.

`CacheMainSdb` is included for parsing in `shimcache.py`, but on all machines I checked (500+) it was not supported - shimcache returned this warning: `[warning  ] <Target ...>: Not implemented ShimCache version: <RegfKey AppCompatCache> CacheMainSdb` (except one that returned excetion above).

This PR should fix both exception and support - `CacheMainSdb` now correctly parses for me even on those machines that returned `NotImplementedError`.

I'm not entirely sure about the fix though. It works and does not cause regressions in current tests, but it covers only machines I encountered - they all have `CacheMainSdb` entries with this structure (also struct namings is a bit off - struct is named `WIN81`, but most machines I checked was Win10+ and structure is the same):

```
struct WIN81_ENTRY_DATA_SINGLE {
    uint16 path_len;
    wchar path[path_len/2];
    uint32 flags;
};
```

Unfortunately I cannot reproduce exact exception as above (with EOFError) in test without using exact data as it was on machine, so current test checks basic support - without the fix it returns `NotImplementedError`