### PR TITLE
Add support for new record types in defender.quarantine

### DIFF
--- a/dissect/target/plugins/os/windows/defender/_plugin.py
+++ b/dissect/target/plugins/os/windows/defender/_plugin.py
@@ -30,6 +30,7 @@ from dissect.target.plugins.os.windows.defender.mplog import (
 from dissect.target.plugins.os.windows.defender.quarantine import (
     DefenderFileQuarantineRecord,
     DefenderQuarantineRecord,
+    DefenderRegKeyQuarantineRecord,
     DefenderTaskSchedulerQuarantineRecord,
     QuarantineEntry,
     recover_quarantined_file_streams,
@@ -235,13 +236,17 @@ class MicrosoftDefenderPlugin(Plugin):
         record=[
             DefenderQuarantineRecord,
             DefenderFileQuarantineRecord,
+            DefenderRegKeyQuarantineRecord,
             DefenderTaskSchedulerQuarantineRecord,
         ]
     )
     def quarantine(
         self,
     ) -> Iterator[
-        DefenderQuarantineRecord | DefenderFileQuarantineRecord | DefenderTaskSchedulerQuarantineRecord
+        DefenderQuarantineRecord
+        | DefenderFileQuarantineRecord
+        | DefenderRegKeyQuarantineRecord
+        | DefenderTaskSchedulerQuarantineRecord
     ]:
         """Parse the quarantine folder of Microsoft Defender for quarantine entry resources.
 
@@ -269,6 +274,12 @@ class MicrosoftDefenderPlugin(Plugin):
                         last_accessed_time=resource.last_access_time,
                         resource_id=resource.resource_id,
                         file_size=resource.file_size,
+                        _target=self.target,
+                    )
+                elif resource.detection_type == b"regkey":
+                    yield DefenderRegKeyQuarantineRecord(
+                        **fields,
+                        detection_path=resource.detection_path,
                         _target=self.target,
                     )
                 elif resource.detection_type == b"taskscheduler":

--- a/dissect/target/plugins/os/windows/defender/_plugin.py
+++ b/dissect/target/plugins/os/windows/defender/_plugin.py
@@ -31,6 +31,7 @@ from dissect.target.plugins.os.windows.defender.quarantine import (
     DefenderFileQuarantineRecord,
     DefenderQuarantineRecord,
     DefenderRegKeyQuarantineRecord,
+    DefenderStartupQuarantineRecord,
     DefenderTaskSchedulerQuarantineRecord,
     QuarantineEntry,
     recover_quarantined_file_streams,
@@ -237,6 +238,7 @@ class MicrosoftDefenderPlugin(Plugin):
             DefenderQuarantineRecord,
             DefenderFileQuarantineRecord,
             DefenderRegKeyQuarantineRecord,
+            DefenderStartupQuarantineRecord,
             DefenderTaskSchedulerQuarantineRecord,
         ]
     )
@@ -246,6 +248,7 @@ class MicrosoftDefenderPlugin(Plugin):
         DefenderQuarantineRecord
         | DefenderFileQuarantineRecord
         | DefenderRegKeyQuarantineRecord
+        | DefenderStartupQuarantineRecord
         | DefenderTaskSchedulerQuarantineRecord
     ]:
         """Parse the quarantine folder of Microsoft Defender for quarantine entry resources.
@@ -264,8 +267,7 @@ class MicrosoftDefenderPlugin(Plugin):
             }
             for resource in entry.resources:
                 fields.update({"detection_type": resource.detection_type})
-                if resource.detection_type in (b"file", b"startup"):
-                    # These fields are only available for file based detections
+                if resource.detection_type == b"file":
                     yield DefenderFileQuarantineRecord(
                         **fields,
                         detection_path=resource.detection_path,
@@ -278,6 +280,12 @@ class MicrosoftDefenderPlugin(Plugin):
                     )
                 elif resource.detection_type == b"regkey":
                     yield DefenderRegKeyQuarantineRecord(
+                        **fields,
+                        detection_path=resource.detection_path,
+                        _target=self.target,
+                    )
+                elif resource.detection_type == b"startup":
+                    yield DefenderStartupQuarantineRecord(
                         **fields,
                         detection_path=resource.detection_path,
                         _target=self.target,

--- a/dissect/target/plugins/os/windows/defender/_plugin.py
+++ b/dissect/target/plugins/os/windows/defender/_plugin.py
@@ -30,6 +30,7 @@ from dissect.target.plugins.os.windows.defender.mplog import (
 from dissect.target.plugins.os.windows.defender.quarantine import (
     DefenderFileQuarantineRecord,
     DefenderQuarantineRecord,
+    DefenderTaskSchedulerQuarantineRecord,
     QuarantineEntry,
     recover_quarantined_file_streams,
 )
@@ -111,7 +112,7 @@ DEFENDER_MPCMDRUN_SYSTEM_DIRS = (
     "sysvol/Windows/Microsoft Antimalware/Tmp",
 )
 DEFENDER_MPCMDRUN_USER_DIRS = ("AppData/Local/Temp",)
-DEFENDER_KNOWN_DETECTION_TYPES = [b"internalbehavior", b"regkey", b"runkey", b"startup"]
+DEFENDER_KNOWN_DETECTION_TYPES = [b"internalbehavior", b"regkey", b"runkey", b"startup", b"taskscheduler"]
 
 DEFENDER_EXCLUSION_KEY = "HKLM\\SOFTWARE\\Microsoft\\Windows Defender\\Exclusions"
 
@@ -230,8 +231,18 @@ class MicrosoftDefenderPlugin(Plugin):
 
             yield DefenderLogRecord(**record_fields, _target=self.target)
 
-    @export(record=[DefenderQuarantineRecord, DefenderFileQuarantineRecord])
-    def quarantine(self) -> Iterator[DefenderQuarantineRecord | DefenderFileQuarantineRecord]:
+    @export(
+        record=[
+            DefenderQuarantineRecord,
+            DefenderFileQuarantineRecord,
+            DefenderTaskSchedulerQuarantineRecord,
+        ]
+    )
+    def quarantine(
+        self,
+    ) -> Iterator[
+        DefenderQuarantineRecord | DefenderFileQuarantineRecord | DefenderTaskSchedulerQuarantineRecord
+    ]:
         """Parse the quarantine folder of Microsoft Defender for quarantine entry resources.
 
         Quarantine entry resources contain metadata about detected threats that Microsoft Defender has placed in
@@ -250,16 +261,23 @@ class MicrosoftDefenderPlugin(Plugin):
                 fields.update({"detection_type": resource.detection_type})
                 if resource.detection_type in (b"file", b"startup"):
                     # These fields are only available for file based detections
-                    fields.update(
-                        {
-                            "detection_path": resource.detection_path,
-                            "creation_time": resource.creation_time,
-                            "last_write_time": resource.last_write_time,
-                            "last_accessed_time": resource.last_access_time,
-                            "resource_id": resource.resource_id,
-                        }
+                    yield DefenderFileQuarantineRecord(
+                        **fields,
+                        detection_path=resource.detection_path,
+                        creation_time=resource.creation_time,
+                        last_write_time=resource.last_write_time,
+                        last_accessed_time=resource.last_access_time,
+                        resource_id=resource.resource_id,
+                        file_size=resource.file_size,
+                        _target=self.target,
                     )
-                    yield DefenderFileQuarantineRecord(**fields, _target=self.target)
+                elif resource.detection_type == b"taskscheduler":
+                    yield DefenderTaskSchedulerQuarantineRecord(
+                        **fields,
+                        detection_path=resource.detection_path,
+                        file_size=resource.file_size,
+                        _target=self.target,
+                    )
                 else:
                     # For these types, we know that they have no known additional data to add to the Quarantine Record.
                     if resource.detection_type not in DEFENDER_KNOWN_DETECTION_TYPES:

--- a/dissect/target/plugins/os/windows/defender/_plugin.py
+++ b/dissect/target/plugins/os/windows/defender/_plugin.py
@@ -111,7 +111,7 @@ DEFENDER_MPCMDRUN_SYSTEM_DIRS = (
     "sysvol/Windows/Microsoft Antimalware/Tmp",
 )
 DEFENDER_MPCMDRUN_USER_DIRS = ("AppData/Local/Temp",)
-DEFENDER_KNOWN_DETECTION_TYPES = [b"internalbehavior", b"regkey", b"runkey"]
+DEFENDER_KNOWN_DETECTION_TYPES = [b"internalbehavior", b"regkey", b"runkey", b"startup"]
 
 DEFENDER_EXCLUSION_KEY = "HKLM\\SOFTWARE\\Microsoft\\Windows Defender\\Exclusions"
 
@@ -248,7 +248,7 @@ class MicrosoftDefenderPlugin(Plugin):
             }
             for resource in entry.resources:
                 fields.update({"detection_type": resource.detection_type})
-                if resource.detection_type == b"file":
+                if resource.detection_type in (b"file", b"startup"):
                     # These fields are only available for file based detections
                     fields.update(
                         {

--- a/dissect/target/plugins/os/windows/defender/quarantine.py
+++ b/dissect/target/plugins/os/windows/defender/quarantine.py
@@ -69,6 +69,20 @@ DefenderRegKeyQuarantineRecord = TargetRecordDescriptor(
     ],
 )
 
+DefenderStartupQuarantineRecord = TargetRecordDescriptor(
+    "filesystem/windows/defender/quarantine/startup",
+    [
+        ("datetime", "ts"),
+        ("string", "quarantine_id"),
+        ("string", "scan_id"),
+        ("varint", "threat_id"),
+        ("string", "detection_type"),
+        ("string", "detection_name"),
+        ("string", "detection_path"),
+    ],
+)
+
+
 # Source: https://github.com/brad-sp/cuckoo-modified/blob/master/lib/cuckoo/common/quarantine.py#L188
 # fmt: off
 DEFENDER_QUARANTINE_RC4_KEY = [

--- a/dissect/target/plugins/os/windows/defender/quarantine.py
+++ b/dissect/target/plugins/os/windows/defender/quarantine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from io import BytesIO
+import struct
 from typing import TYPE_CHECKING, BinaryIO
 
 import dissect.util.ts as ts
@@ -37,6 +38,21 @@ DefenderFileQuarantineRecord = TargetRecordDescriptor(
         ("datetime", "last_write_time"),
         ("datetime", "last_accessed_time"),
         ("string", "resource_id"),
+        ("varint", "file_size"),
+    ],
+)
+
+DefenderTaskSchedulerQuarantineRecord = TargetRecordDescriptor(
+    "filesystem/windows/defender/quarantine/taskscheduler",
+    [
+        ("datetime", "ts"),
+        ("string", "quarantine_id"),
+        ("string", "scan_id"),
+        ("varint", "threat_id"),
+        ("string", "detection_type"),
+        ("string", "detection_name"),
+        ("string", "detection_path"),
+        ("varint", "file_size"),
     ],
 )
 
@@ -106,7 +122,8 @@ enum FIELD_IDENTIFIER : WORD {
     Unknown                 = 0x0E,
     CreationTime            = 0x0F,
     LastAccessTime          = 0x10,
-    LastWriteTime           = 0x11
+    LastWriteTime           = 0x11,
+    FileSize                = 0x12,
 };
 
 enum FIELD_TYPE : WORD {
@@ -267,6 +284,7 @@ class QuarantineEntryResource:
 
         # It is possible that certain fields miss from a QuarantineEntryResource even though we expect them. Thus, we
         # initialize them in advance with a None value.
+        self.file_size = None
         self.resource_id = None
         self.creation_time = None
         self.last_access_time = None
@@ -299,5 +317,7 @@ class QuarantineEntryResource:
             self.last_access_time = ts.wintimestamp(int.from_bytes(field.Data, "little"))
         elif field.Identifier == FIELD_IDENTIFIER.LastWriteTime:
             self.last_write_time = ts.wintimestamp(int.from_bytes(field.Data, "little"))
+        elif field.Identifier == FIELD_IDENTIFIER.FileSize:
+            self.file_size = struct.unpack("<Q", field.Data)[0]
         elif field.Identifier not in FIELD_IDENTIFIER:
             self.unknown_fields.append(field)

--- a/dissect/target/plugins/os/windows/defender/quarantine.py
+++ b/dissect/target/plugins/os/windows/defender/quarantine.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from io import BytesIO
-import struct
 from typing import TYPE_CHECKING, BinaryIO
 
 import dissect.util.ts as ts
@@ -345,6 +344,6 @@ class QuarantineEntryResource:
         elif field.Identifier == FIELD_IDENTIFIER.LastWriteTime:
             self.last_write_time = ts.wintimestamp(int.from_bytes(field.Data, "little"))
         elif field.Identifier == FIELD_IDENTIFIER.FileSize:
-            self.file_size = struct.unpack("<Q", field.Data)[0]
+            self.file_size = int.from_bytes(field.Data, "little")
         elif field.Identifier not in FIELD_IDENTIFIER:
             self.unknown_fields.append(field)

--- a/dissect/target/plugins/os/windows/defender/quarantine.py
+++ b/dissect/target/plugins/os/windows/defender/quarantine.py
@@ -56,6 +56,19 @@ DefenderTaskSchedulerQuarantineRecord = TargetRecordDescriptor(
     ],
 )
 
+DefenderRegKeyQuarantineRecord = TargetRecordDescriptor(
+    "filesystem/windows/defender/quarantine/regkey",
+    [
+        ("datetime", "ts"),
+        ("string", "quarantine_id"),
+        ("string", "scan_id"),
+        ("varint", "threat_id"),
+        ("string", "detection_type"),
+        ("string", "detection_name"),
+        ("string", "detection_path"),
+    ],
+)
+
 # Source: https://github.com/brad-sp/cuckoo-modified/blob/master/lib/cuckoo/common/quarantine.py#L188
 # fmt: off
 DEFENDER_QUARANTINE_RC4_KEY = [

--- a/tests/_data/plugins/os/windows/defender/quarantine/Entries/{8006A512-0000-0000-2E01-A7D5DA185F14}
+++ b/tests/_data/plugins/os/windows/defender/quarantine/Entries/{8006A512-0000-0000-2E01-A7D5DA185F14}
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:039bd66f0e30b3d1d376c54e83b040b2967cff2c13bf8141735cf953f4d91c2c
+size 725

--- a/tests/_data/plugins/os/windows/defender/quarantine/Entries/{8006A512-0000-0000-2E11-A7D5DA185F24}
+++ b/tests/_data/plugins/os/windows/defender/quarantine/Entries/{8006A512-0000-0000-2E11-A7D5DA185F24}
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92cc0caf7cb7809f5ea75794b27fe3694f8e67761267b19127532f1f2417020c
+size 1199

--- a/tests/plugins/os/windows/test_defender.py
+++ b/tests/plugins/os/windows/test_defender.py
@@ -117,6 +117,8 @@ def test_defender_quarantine_entries(target_win: Target, fs_win: VirtualFilesyst
     regkey_records = [r for r in tasksched_records if r.detection_type == "regkey"]
     assert len(regkey_records) == 2
     assert regkey_records[0].detection_name == "HackTool:Win32/AutoKMS"
+    assert regkey_records[0].detection_path == "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tree\\KMSAuto"
+    assert regkey_records[1].detection_path == "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\{EBCB386F-05C8-4545-9455-922990114435}"
 
     file_records = [r for r in tasksched_records if r.detection_type == "file"]
     assert len(file_records) == 2

--- a/tests/plugins/os/windows/test_defender.py
+++ b/tests/plugins/os/windows/test_defender.py
@@ -109,7 +109,6 @@ def test_defender_quarantine_entries(target_win: Target, fs_win: VirtualFilesyst
     ie_startup_record = ie_records[1]
     assert ie_startup_record.detection_type == "startup"
     assert ie_startup_record.detection_path == "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Internet Explorer.lnk"
-    assert ie_startup_record.file_size is None
 
     tasksched_records = [r for r in records if r.quarantine_id == "3c1f228000000000270c270b71d096cd"]
     assert len(tasksched_records) == 5

--- a/tests/plugins/os/windows/test_defender.py
+++ b/tests/plugins/os/windows/test_defender.py
@@ -103,12 +103,16 @@ def test_defender_quarantine_entries(target_win: Target, fs_win: VirtualFilesyst
 
     ie_file_record = ie_records[0]
     assert ie_file_record.detection_type == "file"
-    assert ie_file_record.detection_path == "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Internet Explorer.lnk"
+    assert ie_file_record.detection_path == (
+        "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Internet Explorer.lnk"
+    )
     assert ie_file_record.file_size == 1784
 
     ie_startup_record = ie_records[1]
     assert ie_startup_record.detection_type == "startup"
-    assert ie_startup_record.detection_path == "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Internet Explorer.lnk"
+    assert ie_startup_record.detection_path == (
+        "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Internet Explorer.lnk"
+    )
 
     tasksched_records = [r for r in records if r.quarantine_id == "3c1f228000000000270c270b71d096cd"]
     assert len(tasksched_records) == 5
@@ -116,8 +120,13 @@ def test_defender_quarantine_entries(target_win: Target, fs_win: VirtualFilesyst
     regkey_records = [r for r in tasksched_records if r.detection_type == "regkey"]
     assert len(regkey_records) == 2
     assert regkey_records[0].detection_name == "HackTool:Win32/AutoKMS"
-    assert regkey_records[0].detection_path == "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tree\\KMSAuto"
-    assert regkey_records[1].detection_path == "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\{EBCB386F-05C8-4545-9455-922990114435}"
+    assert regkey_records[0].detection_path == (
+        "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tree\\KMSAuto"
+    )
+    assert regkey_records[1].detection_path == (
+        "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\"
+        "Tasks\\{EBCB386F-05C8-4545-9455-922990114435}"
+    )
 
     file_records = [r for r in tasksched_records if r.detection_type == "file"]
     assert len(file_records) == 2

--- a/tests/plugins/os/windows/test_defender.py
+++ b/tests/plugins/os/windows/test_defender.py
@@ -78,7 +78,7 @@ def test_defender_quarantine_entries(target_win: Target, fs_win: VirtualFilesyst
 
     records = list(target_win.defender.quarantine())
 
-    assert len(records) == 1
+    assert len(records) == 3
 
     # Test whether the quarantining of a Mimikatz binary is properly parsed.
     mimikatz_record = records[0]
@@ -96,6 +96,17 @@ def test_defender_quarantine_entries(target_win: Target, fs_win: VirtualFilesyst
     assert mimikatz_record.quarantine_id == "a762038000000000fb1112639186e0d6"
     assert mimikatz_record.scan_id == "cdbe4600e43a964b8dc2416b0ef7a207"
     assert mimikatz_record.threat_id == 2147705511
+
+    ie_records = [r for r in records if r.quarantine_id == "229c0170000000004d02ef183c202f42"]
+    assert len(ie_records) == 2
+
+    ie_file_record = ie_records[0]
+    assert ie_file_record.detection_type == "file"
+    assert ie_file_record.detection_path == "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Internet Explorer.lnk"
+
+    ie_startup_record = ie_records[1]
+    assert ie_startup_record.detection_type == "startup"
+    assert ie_startup_record.detection_path == "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Internet Explorer.lnk"
 
 
 def test_defender_quarantine_recovery(target_win: Target, fs_win: VirtualFilesystem, tmp_path: Path) -> None:

--- a/tests/plugins/os/windows/test_defender.py
+++ b/tests/plugins/os/windows/test_defender.py
@@ -78,7 +78,7 @@ def test_defender_quarantine_entries(target_win: Target, fs_win: VirtualFilesyst
 
     records = list(target_win.defender.quarantine())
 
-    assert len(records) == 3
+    assert len(records) == 8
 
     # Test whether the quarantining of a Mimikatz binary is properly parsed.
     mimikatz_record = records[0]
@@ -92,6 +92,7 @@ def test_defender_quarantine_entries(target_win: Target, fs_win: VirtualFilesyst
     assert mimikatz_record.creation_time.date() == detection_date
     assert mimikatz_record.last_write_time.date() == detection_date
     assert mimikatz_record.last_accessed_time.date() == detection_date
+    assert mimikatz_record.file_size == 37376
 
     assert mimikatz_record.quarantine_id == "a762038000000000fb1112639186e0d6"
     assert mimikatz_record.scan_id == "cdbe4600e43a964b8dc2416b0ef7a207"
@@ -103,10 +104,35 @@ def test_defender_quarantine_entries(target_win: Target, fs_win: VirtualFilesyst
     ie_file_record = ie_records[0]
     assert ie_file_record.detection_type == "file"
     assert ie_file_record.detection_path == "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Internet Explorer.lnk"
+    assert ie_file_record.file_size == 1784
 
     ie_startup_record = ie_records[1]
     assert ie_startup_record.detection_type == "startup"
     assert ie_startup_record.detection_path == "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Internet Explorer.lnk"
+    assert ie_startup_record.file_size is None
+
+    tasksched_records = [r for r in records if r.quarantine_id == "3c1f228000000000270c270b71d096cd"]
+    assert len(tasksched_records) == 5
+
+    regkey_records = [r for r in tasksched_records if r.detection_type == "regkey"]
+    assert len(regkey_records) == 2
+    assert regkey_records[0].detection_name == "HackTool:Win32/AutoKMS"
+
+    file_records = [r for r in tasksched_records if r.detection_type == "file"]
+    assert len(file_records) == 2
+    assert file_records[0].detection_path == "C:\\WINDOWS\\System32\\Tasks\\KMSAuto"
+    assert file_records[0].resource_id == "FCC63B61E24395BA6AA3E40EA16E3D2DD24A2916"
+    assert file_records[0].file_size == 3108
+    assert file_records[1].detection_path == "C:\\Windows\\KMSAutoS\\KMSAuto x64.exe"
+    assert file_records[1].file_size == 1711464
+
+    ts_records = [r for r in tasksched_records if r.detection_type == "taskscheduler"]
+    assert len(ts_records) == 1
+    ts_record = ts_records[0]
+    assert ts_record.detection_type == "taskscheduler"
+    assert ts_record.detection_name == "HackTool:Win32/AutoKMS"
+    assert ts_record.detection_path == "C:\\WINDOWS\\System32\\Tasks\\KMSAuto"
+    assert ts_record.file_size is None
 
 
 def test_defender_quarantine_recovery(target_win: Target, fs_win: VirtualFilesystem, tmp_path: Path) -> None:


### PR DESCRIPTION
This PR implements following improvements to `defender.quarantine` plugin:

  - Support `startup` and `taskscheduler` types of quarantine entries. These gave me a bunch of exceptions like this on different machines:

```
Traceback (most recent call last):
  File "/home/user/venv/bin/target-query", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/tools/utils/cli.py", line 475, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/tools/query.py", line 260, in main
    for record in record_generator:
                  ^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/plugins/os/windows/defender/_plugin.py", line 271, in quarantine
    yield DefenderQuarantineRecord(**fields, _target=self.target)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/target/helpers/record.py", line 86, in __call__
    return super().__call__(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/flow/record/base.py", line 602, in __call__
    return self.recordType(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: filesystem_windows_defender_quarantine.__init__() got an unexpected keyword argument 'detection_path'
```

  - Support for field with type 0x12 for `file` and `tasksheduler` record types. Its value matches size of original file that was put in quarantine (for files with ADS streams - file size + ADS streams size, streams are appended after file content)

  - Extend support for `regkey` quarantine type - it was defined in the plugin, but used generic record for it, which missed detection path from the record, which contains actual registry paths of found and quarantined files (or just detected registry keys)
