### PR TITLE
Improve error handling when running unsupported function in target-shell

### DIFF
--- a/dissect/target/helpers/excutil.py
+++ b/dissect/target/helpers/excutil.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import sys
+
+try:
+    _ExceptionGroup = BaseExceptionGroup
+except NameError:  # Python 3.10 has no exception groups
+    _ExceptionGroup = ()
+
+
+def _is_stdlib(module: str) -> bool:
+    """Return True if the module is part of the standard library."""
+    return module != "__main__" and module.partition(".")[0] in sys.stdlib_module_names
+
+
+def _location(exc: BaseException) -> str:
+    """Return a string describing the location of the exception, e.g. " (dissect.target.target:851)"."""
+    tb = exc.__traceback__
+    if tb is None:
+        return ""
+    chosen = last = None
+    while tb:
+        if not _is_stdlib(tb.tb_frame.f_globals.get("__name__", "")):
+            chosen = tb  # innermost non-stdlib frame so far
+        last = tb
+        tb = tb.tb_next
+    tb = chosen or last  # all frames are stdlib: use the innermost one
+    frame = tb.tb_frame
+    module = frame.f_globals.get("__name__") or frame.f_code.co_filename
+    return f" ({module}:{tb.tb_lineno})"
+
+
+def summarize_exceptions(exc: BaseException, depth: int = 0) -> list[str]:
+    """Summarize exceptions into a list of strings."""
+    chain, seen = [], set()
+    while isinstance(exc, BaseException) and id(exc) not in seen:
+        seen.add(id(exc))
+        chain.append(exc)
+        exc = exc.__cause__ or (None if exc.__suppress_context__ else exc.__context__)
+
+    lines = []
+    for e in reversed(chain):  # oldest first, same order Python prints them
+        lines.append(f"{'  ' * depth}{type(e).__name__}: {e}{_location(e)}")
+        if isinstance(e, _ExceptionGroup):
+            for sub in e.exceptions:
+                lines.extend(summarize_exceptions(sub, depth + 1))
+    return lines

--- a/dissect/target/target.py
+++ b/dissect/target/target.py
@@ -847,8 +847,9 @@ class Target:
                     if descriptor:
                         # In this case we made at least one iteration but it was skipped due incompatibility.
                         # Just take the last known cause for now
+                        os = self.os if self._os_plugin else None
                         raise UnsupportedPluginError(
-                            f"Unsupported function `{function}` for target with OS plugin {self._os_plugin}",
+                            f"Unsupported function `{function}` for this target with OS {os}",
                             extra=causes[1:] if len(causes) > 1 else None,
                         ) from (causes[0] if causes else None)
 

--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -64,6 +64,7 @@ from dissect.target.exceptions import (
     RegistryKeyNotFoundError,
     RegistryValueNotFoundError,
     TargetError,
+    UnsupportedPluginError,
 )
 from dissect.target.helpers import cyber, fsutil, regutil
 from dissect.target.helpers.logging import get_logger
@@ -689,6 +690,9 @@ class TargetCmd(ExtendedCmd):
         def _exec_(argparts: list[str], stdout: TextIO) -> None:
             try:
                 output, value = execute_function_on_target(self.target, func, argparts)
+            except UnsupportedPluginError as e:
+                print(e)
+                return
             except SystemExit:
                 return
 

--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -66,7 +66,7 @@ from dissect.target.exceptions import (
     TargetError,
     UnsupportedPluginError,
 )
-from dissect.target.helpers import cyber, fsutil, regutil
+from dissect.target.helpers import cyber, excutil, fsutil, regutil
 from dissect.target.helpers.logging import get_logger
 from dissect.target.helpers.utils import StrEnum
 from dissect.target.plugin import alias, arg, clone_alias
@@ -692,7 +692,12 @@ class TargetCmd(ExtendedCmd):
             try:
                 output, value = execute_function_on_target(self.target, func, argparts)
             except UnsupportedPluginError as e:
-                print(e)
+                if self.debug == DebugMode.ON:
+                    print("\n".join(excutil.summarize_exceptions(e)))
+                elif self.debug == DebugMode.POST_MORTEM:
+                    raise
+                else:
+                    print(e)
                 return
             except SystemExit:
                 return

--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -64,6 +64,7 @@ from dissect.target.exceptions import (
     RegistryKeyNotFoundError,
     RegistryValueNotFoundError,
     TargetError,
+    UnsupportedPluginError,
 )
 from dissect.target.helpers import cyber, fsutil, regutil
 from dissect.target.helpers.logging import get_logger
@@ -690,6 +691,9 @@ class TargetCmd(ExtendedCmd):
         def _exec_(argparts: list[str], stdout: TextIO) -> None:
             try:
                 output, value = execute_function_on_target(self.target, func, argparts)
+            except UnsupportedPluginError as e:
+                print(e)
+                return
             except SystemExit:
                 return
 

--- a/tests/tools/test_shell.py
+++ b/tests/tools/test_shell.py
@@ -1082,3 +1082,10 @@ def test_target_cli_tar_unknown_path(tmp_path: Path, capsys: pytest.CaptureFixtu
     captured = capsys.readouterr()
     assert captured.err == "tar: missing.txt: No such file or directory\n"
     assert outpath.is_file()
+
+
+def test_target_cli_unsupported_plugin(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    """Test if the output of an unsupported plugin invocation in target-shell is not too verbose."""
+    target_path = str(absolute_path("_data/tools/info/image.tar"))
+    out, _ = run_target_shell(monkeypatch, capsys, target_path, "msn")
+    assert out == "ubuntu:/$ Unsupported function `msn` for this target with OS linux\nubuntu:/$ \n"

--- a/tests/tools/test_shell.py
+++ b/tests/tools/test_shell.py
@@ -1105,6 +1105,6 @@ def test_target_cli_unsupported_plugin_debug_pm(monkeypatch: pytest.MonkeyPatch,
     target_path = str(absolute_path("_data/tools/info/image.tar"))
     out, _ = run_target_shell(monkeypatch, capsys, target_path, "debug pm\nmsn")
     # test if we drop into the debugger on unsupported plugin invocation
-    assert "-->" in out
+    assert "->" in out
     assert "raise UnsupportedPluginError" in out
-    assert "ipdb>" in out
+    assert ("ipdb>" in out) or ("(Pdb)" in out)  # ipdb or pdb depending on availability

--- a/tests/tools/test_shell.py
+++ b/tests/tools/test_shell.py
@@ -477,8 +477,8 @@ def test_target_cli_save(
 
 
 def run_target_shell(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, argv: str | list, stdin: str
-) -> tuple[bytes, bytes]:
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], argv: str | list, stdin: str
+) -> tuple[str, str]:
     with monkeypatch.context() as m:
         m.setattr("sys.argv", ["target-shell"] + (argv if isinstance(argv, list) else [argv]))
         m.setattr("sys.stdin", StringIO(stdin))
@@ -1089,3 +1089,22 @@ def test_target_cli_unsupported_plugin(monkeypatch: pytest.MonkeyPatch, capsys: 
     target_path = str(absolute_path("_data/tools/info/image.tar"))
     out, _ = run_target_shell(monkeypatch, capsys, target_path, "msn")
     assert out == "ubuntu:/$ Unsupported function `msn` for this target with OS linux\nubuntu:/$ \n"
+
+
+def test_target_cli_unsupported_plugin_debug_on(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    """Test if the output of an unsupported plugin invocation in target-shell is not too verbose (debug on)."""
+    target_path = str(absolute_path("_data/tools/info/image.tar"))
+    out, _ = run_target_shell(monkeypatch, capsys, target_path, "debug on\nmsn")
+    # test if we get a summary of exceptions on unsupported plugin invocation
+    assert "UnsupportedPluginError: No Microsoft MSN installs found on target" in out
+    assert "UnsupportedPluginError: Unsupported function `msn` for this target with OS linux" in out
+
+
+def test_target_cli_unsupported_plugin_debug_pm(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    """Test if the output of an unsupported plugin invocation in target-shell is not too verbose (debug pm)."""
+    target_path = str(absolute_path("_data/tools/info/image.tar"))
+    out, _ = run_target_shell(monkeypatch, capsys, target_path, "debug pm\nmsn")
+    # test if we drop into the debugger on unsupported plugin invocation
+    assert "-->" in out
+    assert "raise UnsupportedPluginError" in out
+    assert "ipdb>" in out


### PR DESCRIPTION
Removes the enormous stack trace `target-shell` shows when attempting to run a plugin that is not supported on the current target.

Also slightly modifies the `UnsupportedPluginError` message `get_function` throws to improve readability.
```
WIN-EXAMPLE:/$ msn
Unsupported function `msn` for this target with OS Windows
WIN-EXAMPLE:/$
```