### PR TITLE
Add Splashtop client log support

### DIFF
--- a/dissect/target/plugins/apps/remoteaccess/splashtop.py
+++ b/dissect/target/plugins/apps/remoteaccess/splashtop.py
@@ -22,6 +22,10 @@ if TYPE_CHECKING:
 
 
 RE_TS = re.compile(r"(\w{3}\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3})")
+RE_CLIENT_TS = re.compile(r"(\w{3}\s+\d{1,2}\s+\d{1,2}:\d{2}:\d{2}\.\d{3})")
+
+TS_FORMAT = "%b%d %H:%M:%S.%f"
+CLIENT_TS_FORMAT = "%b %d %H:%M:%S.%f"
 
 
 class SplashtopPlugin(RemoteAccessPlugin):
@@ -48,14 +52,20 @@ class SplashtopPlugin(RemoteAccessPlugin):
         # "sysvol/ProgramData/Splashtop/Temp/log/FTCLog.txt",
     )
 
+    CLIENT_LOG_GLOBS = ("sysvol/ProgramData/Splashtop/Splashtop Remote Client for ST*/*/log/win_client.txt*",)
+
     def __init__(self, target: Target):
         super().__init__(target)
 
-        self.log_files: set[TargetPath] = set()
+        self.log_files: dict[TargetPath, tuple[re.Pattern[str], str]] = {}
 
         for log_path in self.LOG_PATHS:
             if (log_file := self.target.fs.path(log_path)).exists():
-                self.log_files.add(log_file)
+                self.log_files[log_file] = (RE_TS, TS_FORMAT)
+
+        for log_glob in self.CLIENT_LOG_GLOBS:
+            for log_file in self.target.fs.glob(log_glob):
+                self.log_files[self.target.fs.path(log_file)] = (RE_CLIENT_TS, CLIENT_TS_FORMAT)
 
     def check_compatible(self) -> None:
         if not self.log_files:
@@ -73,17 +83,20 @@ class SplashtopPlugin(RemoteAccessPlugin):
         """
         target_tz = self.target.datetime.tzinfo
 
-        for log_file in self.log_files:
+        for log_file, (re_ts, ts_format) in self.log_files.items():
             try:
-                for ts, line in year_rollover_helper(log_file, RE_TS, "%b%d %H:%M:%S.%f", target_tz):
+                for ts, line in year_rollover_helper(log_file, re_ts, ts_format, target_tz):
                     try:
-                        # The line is of format "<#>%b%d %H:%M:%S.%f ..." check if the start matches an expected line
+                        # All supported Splashtop logs prefix records with a numeric level in angle brackets.
                         if (line[0], line[2]) != ("<", ">"):
                             self.target.log.error("LINE %s", line)
                             raise ValueError("Line does not match expected format")  # noqa: TRY301
 
-                        # The prefix contains two spaces splitting off the timestamp, grab only the message part
-                        message = line.split(" ", maxsplit=2)[-1]
+                        timestamp_match = re_ts.search(line)
+                        if not timestamp_match:
+                            raise ValueError("Line does not contain the expected timestamp")  # noqa: TRY301
+
+                        message = line[timestamp_match.end() :].lstrip()
 
                         yield self.RemoteAccessLogRecord(
                             ts=ts,

--- a/tests/plugins/apps/remoteaccess/test_splashtop.py
+++ b/tests/plugins/apps/remoteaccess/test_splashtop.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from io import BytesIO
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -17,6 +18,7 @@ if TYPE_CHECKING:
 
 
 SPLASHTOP_LOG_PATH = "Program Files (x86)/Splashtop/Splashtop Remote/Server/log/SPLog.txt"
+SPLASHTOP_CLIENT_LOG_PATH = "ProgramData/Splashtop/Splashtop Remote Client for STB/analyst/log/win_client.txt.099"
 
 
 @pytest.fixture
@@ -30,6 +32,24 @@ def target_splashtop(target_win_users: Target, fs_win: VirtualFilesystem) -> Ite
     # the starting year
     # A new source checkout would result in different modification timestamps, so mock it to be in 2025
     entry = fs_win.get(SPLASHTOP_LOG_PATH)
+    stat_result = entry.stat()
+    stat_result.st_mtime = 1735732800
+
+    with patch.object(entry, "stat") as mock_stat:
+        mock_stat.return_value = stat_result
+        target_win_users.add_plugin(SplashtopPlugin)
+        yield target_win_users
+
+
+@pytest.fixture
+def target_splashtop_client(target_win_users: Target, fs_win: VirtualFilesystem) -> Iterator[Target]:
+    log_data = (
+        b"<1>Feb  1 17:48:17.564 [wm_39215]:(Session     ) peer public addr {203.0.113.42:61761-2}, 816\n"
+        b"<0>May  4  9:36:03.163 [wm_29446]:(VideoUI     ) Fail to notify Wacom rectangle 3\n"
+    )
+    fs_win.map_file_fh(SPLASHTOP_CLIENT_LOG_PATH, BytesIO(log_data))
+
+    entry = fs_win.get(SPLASHTOP_CLIENT_LOG_PATH)
     stat_result = entry.stat()
     stat_result.st_mtime = 1735732800
 
@@ -59,3 +79,16 @@ def test_splashtop_plugin_filetransfer(target_splashtop: Target) -> None:
     )
     assert records[0].source == f"sysvol/{SPLASHTOP_LOG_PATH}"
     assert records[0].filename == "NOTE.txt"
+
+
+def test_splashtop_plugin_client_log(target_splashtop_client: Target) -> None:
+    records = list(target_splashtop_client.splashtop.logs())
+    assert len(records) == 2
+
+    assert records[0].ts == datetime(2025, 5, 4, 9, 36, 3, 163000, tzinfo=timezone.utc)
+    assert records[0].message == "[wm_29446]:(VideoUI     ) Fail to notify Wacom rectangle 3"
+    assert records[0].source == f"sysvol/{SPLASHTOP_CLIENT_LOG_PATH}"
+
+    assert records[1].ts == datetime(2025, 2, 1, 17, 48, 17, 564000, tzinfo=timezone.utc)
+    assert records[1].message == "[wm_39215]:(Session     ) peer public addr {203.0.113.42:61761-2}, 816"
+    assert records[1].source == f"sysvol/{SPLASHTOP_CLIENT_LOG_PATH}"


### PR DESCRIPTION
# Add Splashtop client log support

Splashtop Business and Enterprise client logs live outside the existing
server log path and use a different timestamp layout. This extends the plugin
to discover their rotated `win_client.txt*` files and parse that layout while
preserving the existing `SPLog.txt` behavior.

## Proposed Changes

- discover STB/STE client logs below `ProgramData/Splashtop`
- select the timestamp expression and format for each supported log family
- extract messages relative to the matched timestamp so both layouts work
- add a regression fixture based on the representative lines in the issue

Validation:

- `ruff check dissect/target/plugins/apps/remoteaccess/splashtop.py tests/plugins/apps/remoteaccess/test_splashtop.py`
- `ruff format --check dissect/target/plugins/apps/remoteaccess/splashtop.py tests/plugins/apps/remoteaccess/test_splashtop.py`
- `pytest -q tests/plugins/apps/remoteaccess/test_splashtop.py` (3 passed)

## Checklist

- [x] PR Title is descriptive of the changes
- [x] The description is descriptive of the changes
- [x] Tests are included and pass
- [x] Closes #1749

Closes #1749
