### PR TITLE
Add Terminal Server Client username parser

### DIFF
--- a/dissect/target/plugins/os/windows/regf/terminalserverclient.py
+++ b/dissect/target/plugins/os/windows/regf/terminalserverclient.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from dissect.target.exceptions import RegistryError, UnsupportedPluginError
+from dissect.target.helpers.descriptor_extensions import (
+    RegistryRecordDescriptorExtension,
+    UserRecordDescriptorExtension,
+)
+from dissect.target.helpers.record import create_extended_descriptor
+from dissect.target.plugin import Plugin, export
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+TerminalServerClientRecord = create_extended_descriptor(
+    [RegistryRecordDescriptorExtension, UserRecordDescriptorExtension]
+)(
+    "windows/registry/terminal_server_client/server",
+    [
+        ("datetime", "ts"),
+        ("string", "server"),
+        ("string", "username_hint"),
+    ],
+)
+
+
+class TerminalServerClientPlugin(Plugin):
+    """Parse cached Microsoft Terminal Server Client server username hints."""
+
+    KEY = "HKCU\\Software\\Microsoft\\Terminal Server Client\\Servers"
+
+    def check_compatible(self) -> None:
+        if not any(self.target.registry.keys(self.KEY)):
+            raise UnsupportedPluginError("No Terminal Server Client Servers registry keys found")
+
+    @export(record=TerminalServerClientRecord)
+    def terminal_server_client(self) -> Iterator[TerminalServerClientRecord]:
+        """Return cached Microsoft Terminal Server Client server username hints.
+
+        The ``HKCU\\Software\\Microsoft\\Terminal Server Client\\Servers`` registry key
+        contains server names previously entered in the Terminal Server Client GUI. A
+        server subkey can contain a ``UsernameHint`` value with a cached username.
+
+        These values do not prove that an RDP connection or connection attempt occurred.
+        Corroborate them with other artifacts, such as Windows event logs.
+
+        References:
+            - https://www.magnetforensics.com/blog/rdp-artifacts-in-incident-response/
+        """
+        for servers_key in self.target.registry.keys(self.KEY):
+            user = self.target.registry.get_user(servers_key)
+
+            for server_key in servers_key.subkeys():
+                try:
+                    username_hint = server_key.value("UsernameHint").value
+                except RegistryError:
+                    continue
+
+                yield TerminalServerClientRecord(
+                    ts=server_key.ts,
+                    server=server_key.name,
+                    username_hint=username_hint,
+                    _target=self.target,
+                    _key=server_key,
+                    _user=user,
+                )

--- a/tests/plugins/os/windows/regf/test_terminalserverclient.py
+++ b/tests/plugins/os/windows/regf/test_terminalserverclient.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from dissect.target.exceptions import UnsupportedPluginError
+from dissect.target.helpers.regutil import VirtualKey
+from dissect.target.plugins.os.windows.regf.terminalserverclient import TerminalServerClientPlugin
+from dissect.target.target import Target
+
+if TYPE_CHECKING:
+    from dissect.target.helpers.regutil import VirtualHive
+
+
+KEY = "Software\\Microsoft\\Terminal Server Client\\Servers"
+
+
+def test_terminal_server_client(target_win_users: Target, hive_hku: VirtualHive) -> None:
+    server_key = VirtualKey(hive_hku, f"{KEY}\\rdp.example.com")
+    server_key.add_value("UsernameHint", "EXAMPLE\\analyst")
+    hive_hku.map_key(server_key.path, server_key)
+
+    target_win_users.add_plugin(TerminalServerClientPlugin)
+    records = list(target_win_users.terminal_server_client())
+
+    assert len(records) == 1
+    assert records[0].server == "rdp.example.com"
+    assert records[0].username_hint == "EXAMPLE\\analyst"
+    assert records[0].regf_key_path == ("Software\\Microsoft\\Terminal Server Client\\Servers\\rdp.example.com")
+
+
+def test_terminal_server_client_skips_missing_username_hint(target_win_users: Target, hive_hku: VirtualHive) -> None:
+    server_key = VirtualKey(hive_hku, f"{KEY}\\rdp.example.com")
+    hive_hku.map_key(server_key.path, server_key)
+
+    target_win_users.add_plugin(TerminalServerClientPlugin)
+
+    assert list(target_win_users.terminal_server_client()) == []
+
+
+def test_terminal_server_client_incompatible() -> None:
+    with pytest.raises(UnsupportedPluginError):
+        TerminalServerClientPlugin(Target()).check_compatible()


### PR DESCRIPTION
Parse cached username hints stored by the Microsoft Terminal Server
Client for previously entered server names.

These registry values represent cached GUI input and do not prove that
an RDP connection or connection attempt occurred. Analysts should
corroborate the results with other artifacts, such as Windows event
logs. No assumption is made about the retention limit of the `Servers`
key.

## Proposed Changes

- Add a parser for
  `HKCU\Software\Microsoft\Terminal Server Client\Servers`.
- Parse server names and their cached `UsernameHint` values.
- Return the registry timestamp, user metadata, and registry metadata.
- Skip server entries without a `UsernameHint` value.
- Document the forensic interpretation limitations of this artifact.
- Add tests for valid entries, missing values, and incompatible targets.

## Testing

```console
$ uv run --no-sync pytest tests/plugins/os/windows/regf/test_terminalserverclient.py -q
3 passed 

$ uv run --no-sync pytest tests/plugins/os/windows/regf -q
27 passed 
```

```console
$ uv run --no-sync ruff check dissect/target/plugins/os/windows/regf/terminalserverclient.py tests/plugins/os/windows/regf/test_terminalserverclient.py
All checks passed!

$ uv run --no-sync ruff format --check dissect/target/plugins/os/windows/regf/terminalserverclient.py tests/plugins/os/windows/regf/test_terminalserverclient.py
2 files already formatted
```

## Checklist

- [x] PR Title is descriptive of the changes
- [x] The description is descriptive of the changes
- [x] Tests are included and pass
- [x] Closes #1450

Closes #1450