### PR TITLE
Fix wrong replacement of subfolders containing fs/

### DIFF
--- a/dissect/target/loaders/acquire.py
+++ b/dissect/target/loaders/acquire.py
@@ -82,7 +82,11 @@ class AcquireTarSubLoader(TarSubLoader):
 
             entry_cls = TarFilesystemDirectoryEntry if member.isdir() else TarFilesystemEntry
             entry = entry_cls(volume, fsutil.normpath(mname), member)
-            volume.map_file_entry(entry.path, entry)
+
+            try:
+                volume.map_file_entry(entry.path, entry)
+            except KeyError as e:
+                log.debug("Skipping member %r in tar as %r is already mapped: %s", member, entry.path, e)
 
         for vol_name, vol in volumes.items():
             loaderutil.add_virtual_ntfs_filesystem(

--- a/dissect/target/loaders/acquire.py
+++ b/dissect/target/loaders/acquire.py
@@ -51,14 +51,7 @@ class AcquireTarSubLoader(TarSubLoader):
             if member.name == ".":
                 continue
 
-            if member.name.startswith(("/fs/", "fs/")):
-                # Current acquire
-                parts = member.name.replace("fs/", "").split("/")
-                if parts[0] == "":
-                    parts.pop(0)
-            else:
-                # Legacy acquire
-                parts = member.name.lstrip("/").split("/")
+            parts = member.name.removeprefix("/").removeprefix("fs/").split("/")
             volume_name = parts[0].lower()
 
             # NOTE: older versions of acquire would write to "sysvol" instead of a driver letter

--- a/tests/loaders/test_acquire.py
+++ b/tests/loaders/test_acquire.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import tarfile
 from typing import TYPE_CHECKING
 
 import pytest
@@ -11,6 +12,7 @@ from dissect.target.loaders.zip import ZipLoader
 from dissect.target.plugins.os.windows._os import WindowsPlugin
 from dissect.target.target import Target
 from tests._utils import absolute_path
+from tests.filesystems.test_tar import _mkdir, _mkfile
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -103,9 +105,38 @@ def test_windows_sysvol_formats_zip() -> None:
     assert isinstance(loader.subloader, AcquireZipSubLoader)
 
     assert WindowsPlugin.detect(t)
-    # NOTE: for the sysvol archives, this also tests the backwards compatibility
+    # NOTE: for the sysvol archives, this also tests the backwards compatibilityk
     assert sorted(t.fs.mounts.keys()) == ["c:"]
     assert t.fs.get("c:/Windows/System32/foo.txt")
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "fs/",
+        "/fs/",
+    ],
+)
+def test_linux_acquire_with_fs_subfolder(prefix: str, tmp_path: Path) -> None:
+    """Test that we correctly handle Linux Acquire archives with a subfolder called named fs."""
+    path = tmp_path.joinpath("target.tar.gz")
+    with tarfile.open(path, "w:gz") as tf:
+        _mkdir(tf, f"{prefix}$rootfs$/")
+        _mkdir(tf, f"{prefix}$rootfs$/")
+        _mkdir(tf, f"{prefix}$rootfs$/etc")
+        _mkdir(tf, f"{prefix}$rootfs$/etc/fs/")
+        _mkfile(tf, f"{prefix}$rootfs$/etc/test", b"testdata1")
+        _mkfile(tf, f"{prefix}$rootfs$/etc/fs/test", b"testdata2")
+
+    loader = loader_open(path)
+    assert isinstance(loader, TarLoader)
+
+    t = Target()
+    loader.map(t)
+    assert isinstance(loader.subloader, AcquireTarSubLoader)
+
+    assert t.fs.get("/etc/test").open().read() == b"testdata1"
+    assert t.fs.get("/etc/fs/test").open().read() == b"testdata2"
 
 
 def test_anonymous_filesystems() -> None:

--- a/tests/loaders/test_acquire.py
+++ b/tests/loaders/test_acquire.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from dissect.target.loader import open as loader_open
-from dissect.target.loaders.acquire import AcquireTarSubLoader, AcquireZipSubLoader
+from dissect.target.loaders.acquire import FILESYSTEMS_ROOT, AcquireTarSubLoader, AcquireZipSubLoader
 from dissect.target.loaders.tar import TarLoader
 from dissect.target.loaders.zip import ZipLoader
 from dissect.target.plugins.os.windows._os import WindowsPlugin
@@ -105,28 +105,30 @@ def test_windows_sysvol_formats_zip() -> None:
     assert isinstance(loader.subloader, AcquireZipSubLoader)
 
     assert WindowsPlugin.detect(t)
-    # NOTE: for the sysvol archives, this also tests the backwards compatibilityk
+    # NOTE: for the sysvol archives, this also tests the backwards compatibility
     assert sorted(t.fs.mounts.keys()) == ["c:"]
     assert t.fs.get("c:/Windows/System32/foo.txt")
 
 
 @pytest.mark.parametrize(
-    "prefix",
+    ("prefix", "subfolder"),
     [
-        "fs/",
-        "/fs/",
+        (f"{FILESYSTEMS_ROOT}/", "java.prefs"),
+        (f"{FILESYSTEMS_ROOT}/", FILESYSTEMS_ROOT),
+        (f"/{FILESYSTEMS_ROOT}/", "java.prefs"),
+        (f"/{FILESYSTEMS_ROOT}/", FILESYSTEMS_ROOT),
     ],
 )
-def test_linux_acquire_with_fs_subfolder(prefix: str, tmp_path: Path) -> None:
+def test_linux_acquire_with_fs_subfolder(prefix: str, subfolder: str, tmp_path: Path) -> None:
     """Test that we correctly handle Linux Acquire archives with a subfolder called named fs."""
     path = tmp_path.joinpath("target.tar.gz")
     with tarfile.open(path, "w:gz") as tf:
         _mkdir(tf, f"{prefix}$rootfs$/")
         _mkdir(tf, f"{prefix}$rootfs$/")
         _mkdir(tf, f"{prefix}$rootfs$/etc")
-        _mkdir(tf, f"{prefix}$rootfs$/etc/fs/")
+        _mkdir(tf, f"{prefix}$rootfs$/etc/{subfolder}/")
         _mkfile(tf, f"{prefix}$rootfs$/etc/test", b"testdata1")
-        _mkfile(tf, f"{prefix}$rootfs$/etc/fs/test", b"testdata2")
+        _mkfile(tf, f"{prefix}$rootfs$/etc/{subfolder}/test", b"testdata2")
 
     loader = loader_open(path)
     assert isinstance(loader, TarLoader)
@@ -135,8 +137,14 @@ def test_linux_acquire_with_fs_subfolder(prefix: str, tmp_path: Path) -> None:
     loader.map(t)
     assert isinstance(loader.subloader, AcquireTarSubLoader)
 
+    # Test directly on $rootfs$
+    assert t.fs.get("$rootfs$/etc/test").open().read() == b"testdata1"
+    assert t.fs.get(f"$rootfs$/etc/{subfolder}/test").open().read() == b"testdata2"
+
+    # The OS plugin is not applied, so manually mount to also test this case
+    t.fs.mount("/", t.fs.mounts["$rootfs$"])
     assert t.fs.get("/etc/test").open().read() == b"testdata1"
-    assert t.fs.get("/etc/fs/test").open().read() == b"testdata2"
+    assert t.fs.get(f"/etc/{subfolder}/test").open().read() == b"testdata2"
 
 
 def test_anonymous_filesystems() -> None:

--- a/tests/loaders/test_acquire.py
+++ b/tests/loaders/test_acquire.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import logging
 import tarfile
 from typing import TYPE_CHECKING
 
 import pytest
 
 from dissect.target.loader import open as loader_open
-from dissect.target.loaders.acquire import FILESYSTEMS_ROOT, AcquireTarSubLoader, AcquireZipSubLoader
+from dissect.target.loaders.acquire import (
+    FILESYSTEMS_LEGACY_ROOT,
+    FILESYSTEMS_ROOT,
+    AcquireTarSubLoader,
+    AcquireZipSubLoader,
+)
 from dissect.target.loaders.tar import TarLoader
 from dissect.target.loaders.zip import ZipLoader
 from dissect.target.plugins.os.windows._os import WindowsPlugin
@@ -141,6 +147,30 @@ def test_linux_acquire_with_fs_subfolder(prefix: str, subfolder: str, tmp_path: 
     t.fs.mount("/", t.fs.mounts["$rootfs$"])
     assert t.fs.get("/etc/test").open().read() == b"testdata1"
     assert t.fs.get(f"/etc/{subfolder}/test").open().read() == b"testdata2"
+
+
+def test_duplicate_sysvol_and_drive_letter(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Test that we correctly handle legacy Acquire archives containing both 'sysvol' and a drive letter."""
+    path = tmp_path.joinpath("target.tar.gz")
+    with tarfile.open(path, "w:gz") as tf:
+        _mkfile(tf, f"{FILESYSTEMS_ROOT}/c:/Windows/System32/foo.txt", b"testdata1")
+        _mkfile(tf, f"{FILESYSTEMS_ROOT}/{FILESYSTEMS_LEGACY_ROOT}/Windows/System32/foo.txt", b"testdata2")
+
+    loader = loader_open(path)
+    assert isinstance(loader, TarLoader)
+
+    t = Target()
+    with caplog.at_level(logging.DEBUG, "dissect.target.loaders.acquire"):
+        loader.map(t)
+    assert isinstance(loader.subloader, AcquireTarSubLoader)
+
+    # Test if sysvols is ignored and the file is present at c:
+    assert set(t.fs.mounts.keys()) == {"c:"}
+    assert t.fs.get("c:/Windows/System32/foo.txt").open().read() == b"testdata1"
+
+    # Test that the duplicate entry is skipped and logged
+    assert "Skipping member" in caplog.text
+    assert "in tar as 'Windows/System32/foo.txt' is already mapped" in caplog.text
 
 
 def test_anonymous_filesystems() -> None:

--- a/tests/loaders/test_acquire.py
+++ b/tests/loaders/test_acquire.py
@@ -12,7 +12,7 @@ from dissect.target.loaders.zip import ZipLoader
 from dissect.target.plugins.os.windows._os import WindowsPlugin
 from dissect.target.target import Target
 from tests._utils import absolute_path
-from tests.filesystems.test_tar import _mkdir, _mkfile
+from tests.filesystems.test_tar import _mkfile
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/tests/loaders/test_acquire.py
+++ b/tests/loaders/test_acquire.py
@@ -120,13 +120,9 @@ def test_windows_sysvol_formats_zip() -> None:
     ],
 )
 def test_linux_acquire_with_fs_subfolder(prefix: str, subfolder: str, tmp_path: Path) -> None:
-    """Test that we correctly handle Linux Acquire archives with a subfolder called named fs."""
+    """Test that we correctly handle Linux Acquire archives with a subfolder containing 'fs/'."""
     path = tmp_path.joinpath("target.tar.gz")
     with tarfile.open(path, "w:gz") as tf:
-        _mkdir(tf, f"{prefix}$rootfs$/")
-        _mkdir(tf, f"{prefix}$rootfs$/")
-        _mkdir(tf, f"{prefix}$rootfs$/etc")
-        _mkdir(tf, f"{prefix}$rootfs$/etc/{subfolder}/")
         _mkfile(tf, f"{prefix}$rootfs$/etc/test", b"testdata1")
         _mkfile(tf, f"{prefix}$rootfs$/etc/{subfolder}/test", b"testdata2")
 


### PR DESCRIPTION
# Fix wrong replacement of subfolders containing fs/

The recently merged changes regarding the clobber in https://github.com/fox-it/dissect.target/pull/1301 suddenly raised the new `KeyError` in some test acquire tar files of Linux distributions. It turns out that when subfolders actually contain the string `fs/`, they are then wrongly replaced because the loader assumes it's part of the `fs/` prefix. This applies to folders like `java.prefs/`, `java.zipfs` and common folders on linux like `/etc/brltty/Input/fs/pacmate.ktb` which contain `fs/`.

## Proposed Changes

This PR replaces the old logic with a oneliner that catches both the old and new Acquire tar format. `removeprefix` will return the original string if the prefix is not found. Test cases are added to verify this.