### PR TITLE
Add fix for reboot wtmp entries

### DIFF
--- a/dissect/target/plugins/os/unix/log/utmp.py
+++ b/dissect/target/plugins/os/unix/log/utmp.py
@@ -210,7 +210,7 @@ class WtmpDbFile:
                 ut_line=row.TTY,
                 ut_id=None,
                 ut_host=row.RemoteHost or None,
-                ut_addr=row.RemoteHost or None,
+                ut_addr=(row.RemoteHost or None) if row.TTY == "ssh" else None,
                 ut_service=row.Service,
             )
 

--- a/tests/_data/plugins/os/unix/log/wtmp/wtmp.db
+++ b/tests/_data/plugins/os/unix/log/wtmp/wtmp.db
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:870e7fcd09ed7efb68b536caec520354ac77fe9a6715c60a924c0180070e9fac
+oid sha256:3ee06c411914bfb70b84842ea6e74f37c9d4c22576c374af92b7b0d8ae84465d
 size 8192

--- a/tests/plugins/os/unix/log/test_utmp.py
+++ b/tests/plugins/os/unix/log/test_utmp.py
@@ -90,7 +90,7 @@ def test_wtmpdb(target_linux: Target, fs_linux: VirtualFilesystem) -> None:
     plugin = target_linux.add_plugin(UtmpPlugin)
     results = list(target_linux.wtmp())
 
-    assert len(results) == 3
+    assert len(results) == 4
     assert list(map(str, plugin.wtmp_paths)) == [
         "/var/log/wtmp.db",
         "/var/lib/wtmpdb/wtmp.db",
@@ -118,3 +118,25 @@ def test_wtmpdb(target_linux: Target, fs_linux: VirtualFilesystem) -> None:
     assert results[1].ut_service == "sshd"
     assert results[1].source == "/var/log/wtmp.db"
     assert results[1].hostname == "localhost"
+
+    assert results[2].ts == datetime(2026, 1, 28, 13, 14, 2, 776830, tzinfo=timezone.utc)
+    assert results[2].ts_logout == datetime(2026, 1, 28, 13, 14, 5, 776830, tzinfo=timezone.utc)
+    assert results[2].ut_type == "USER_PROCESS"
+    assert results[2].ut_user == "root"
+    assert results[2].ut_line == "ssh"
+    assert results[2].ut_host == "127.0.0.1"
+    assert results[2].ut_addr == "127.0.0.1"
+    assert results[2].ut_service == "sshd"
+    assert results[2].source == "/var/log/wtmp.db"
+    assert results[2].hostname == "localhost"
+
+    assert results[3].ts == datetime(2026, 1, 28, 13, 14, 2, 776830, tzinfo=timezone.utc)
+    assert results[3].ts_logout == datetime(2026, 1, 28, 13, 14, 5, 776830, tzinfo=timezone.utc)
+    assert results[3].ut_type == "BOOT_TIME"
+    assert results[3].ut_user == "reboot"
+    assert results[3].ut_line == "~"
+    assert results[3].ut_host == "6.12.105+deb13-amd64"
+    assert results[3].ut_addr is None
+    assert results[3].ut_service is None
+    assert results[3].source == "/var/log/wtmp.db"
+    assert results[3].hostname == "localhost"


### PR DESCRIPTION
Wtmp entries can contain invalid IP addresses in `RemoteHost` if the TTY is not `ssh`, e.g. when the system is rebooted.