### PR TITLE
Add --absolute-names to tar command in target-shell

### DIFF
--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -1139,7 +1139,7 @@ class TargetCli(TargetCmd):
 
         return False
 
-    @arg("path", nargs="+", type=TargetPathArgument)
+    @arg("path", nargs="+", metavar="PATH", type=TargetPathArgument)
     @arg(
         "-f",
         "--file",
@@ -1162,6 +1162,12 @@ class TargetCli(TargetCmd):
         "--dereference",
         action="store_true",
         help="follow symlinks and archive the files they point to instead of the symlinks themselves",
+    )
+    @arg(
+        "-P",
+        "--absolute-names",
+        action="store_true",
+        help="store the absolute path of a file",
     )
     @arg("-v", "--verbose", action="store_true")
     def cmd_tar(self, args: argparse.Namespace, stdout: TextIO) -> bool:
@@ -1247,8 +1253,11 @@ class TargetCli(TargetCmd):
                 print(f"tar: {PurePosixPath(path)}: unsupported file type, skipping", file=sys.stderr)
                 return
             if info.isreg():
-                with path.open("rb") as f:
-                    tar.addfile(info, fileobj=f)
+                with path.open("rb") as fh:
+                    try:
+                        tar.addfile(info, fileobj=fh)
+                    except Exception as e:
+                        print(f"tar: {PurePosixPath(path)}: failed to read file: {e}", file=sys.stderr)
             elif info.isdir():
                 tar.addfile(info)
                 for child in path.iterdir():
@@ -1265,11 +1274,11 @@ class TargetCli(TargetCmd):
         fobj = stdout.buffer if args.file == "-" else Path(args.file).open("wb")  # noqa: SIM115
         mode = "w|"
         if args.gzip:
-            mode = "w|gz"
+            mode += "gz"
         elif args.bzip2:
-            mode = "w|bz2"
+            mode += "bz2"
         elif args.xz:
-            mode = "w|xz"
+            mode += "xz"
 
         try:
             inodes_cache = {}
@@ -1286,11 +1295,18 @@ class TargetCli(TargetCmd):
                         continue
 
                     for path in paths:
-                        arcname = str(PurePosixPath(path).relative_to("/"))
-                        if not Path(arg_path).is_absolute():
-                            pure_path = PurePosixPath(path).relative_to(PurePosixPath(self.cwd))
-                            arcname = "/".join(p for p in pure_path.parts if p not in (".", ".."))
-                            arcname = arcname or "."
+                        if args.absolute_names:
+                            arcname = str(PurePosixPath(path))
+                            if arcname.startswith("/"):
+                                arcname = arcname.lstrip("/")
+                        else:
+                            if Path(arg_path).is_absolute():
+                                arcname = str(PurePosixPath(path).relative_to(path.drive or "/"))
+                            else:
+                                pure_path = PurePosixPath(path).relative_to(PurePosixPath(self.cwd))
+                                arcname = "/".join(p for p in pure_path.parts if p not in (".", ".."))
+                                arcname = arcname or "."
+
                         add_to_tar(tar, path, arcname, dereference=args.dereference, inodes=inodes_cache)
         finally:
             if fobj is not stdout.buffer:


### PR DESCRIPTION
This PR adds the ability to save absolute member names (`--absolute-names` / `-P`) to the `target-shell` `tar` command.

Without `-P`:
```
localhost:/var$ tar -cvf log.tar ./log
a log
a log/alternatives.log
a log/apt
a log/apt/eipp.log.xz
a log/apt/history.log
a log/bootstrap.log
a log/btmp
a log/dpkg.log
a log/lastlog
a log/wtmp
```

With `-P`:
```
localhost:/var$ tar -cvPf log.tar ./log
a var/log
a var/log/alternatives.log
a var/log/apt
a var/log/apt/eipp.log.xz
a var/log/apt/history.log
a var/log/bootstrap.log
a var/log/btmp
a var/log/dpkg.log
a var/log/lastlog
a var/log/wtmp
```