### PR TITLE
Fix NTFS relative paths and target-shell tar for Windows targets

### DIFF
--- a/dissect/target/filesystems/ntfs.py
+++ b/dissect/target/filesystems/ntfs.py
@@ -150,10 +150,21 @@ class NtfsFilesystemEntry(FilesystemEntry):
             self.path, self.ads = path.rsplit(":", maxsplit=1)
 
     def get(self, path: str) -> NtfsFilesystemEntry:
+        if path == "..":
+            # NTFS directories don't carry an explicit ".." index entry, so a lone parent
+            # traversal has to be resolved via the parent segment reference in $FILE_NAME.
+            fn_attrs = self.entry.attributes.FILE_NAME
+            if not fn_attrs:
+                raise FileNotFoundError(fsutil.join(self.path, path, sep=self.fs.sep))
+            parent_seg = segment_reference(fn_attrs[0].attribute.attr.ParentDirectory)
+            entry = self.fs.ntfs.mft(parent_seg)
+        else:
+            entry = self.fs._get_record(path, self.entry)
+
         return NtfsFilesystemEntry(
             self.fs,
             fsutil.join(self.path, path, sep=self.fs.sep),
-            self.fs._get_record(path, self.entry),
+            entry,
         )
 
     def open(self, name: str = "") -> BinaryIO:
@@ -225,7 +236,7 @@ class NtfsFilesystemEntry(FilesystemEntry):
                 real_size = record.size(self.ads, allocated=True)
             except NtfsFileNotFoundError as e:
                 # Occurs when it cannot find the the specific ads inside its attributes
-                raise FileNotFoundError from e
+                raise FileNotFoundError(f"ADS record not found: {self.path}") from e
         else:
             mode = stat.S_IFDIR
 

--- a/dissect/target/tools/shell.py
+++ b/dissect/target/tools/shell.py
@@ -385,6 +385,8 @@ class ExtendedCmd(cmd.Cmd):
                         return func(argparts, pipe_stdin)
             except OSError as e:
                 # in case of a failure in a subprocess
+                if self.debug:
+                    raise
                 print(e)
                 return False
         else:
@@ -1242,7 +1244,13 @@ class TargetCli(TargetCmd):
             """This function is heavily inspired by tarfile.TarFile.add, but adapted to work with TargetPath."""
             if args.verbose:
                 print(f"a {arcname}", file=sys.stderr)
-            info = get_tarinfo(path, arcname, dereference=dereference, inodes=inodes)
+
+            try:
+                info = get_tarinfo(path, arcname, dereference=dereference, inodes=inodes)
+            except FileNotFoundError:
+                print(f"tar: {PurePosixPath(path)}: file not found, skipping", file=sys.stderr)
+                return
+
             if not info:
                 print(f"tar: {PurePosixPath(path)}: unsupported file type, skipping", file=sys.stderr)
                 return
@@ -1275,7 +1283,8 @@ class TargetCli(TargetCmd):
             inodes_cache = {}
             with tarfile.open(fileobj=fobj, mode=mode, format=tarfile.PAX_FORMAT) as tar:
                 for arg_path in args.path:
-                    base_path = self.target.fs.path("/") if Path(arg_path).is_absolute() else self.cwd
+                    is_absolute = self.target.fs.path(arg_path).is_absolute()
+                    base_path = self.target.fs.path("/") if is_absolute else self.cwd
                     glob_path = arg_path.lstrip("/")
 
                     # This is a workaround for Python 3.12 and lower
@@ -1286,11 +1295,14 @@ class TargetCli(TargetCmd):
                         continue
 
                     for path in paths:
-                        arcname = str(PurePosixPath(path).relative_to("/"))
-                        if not Path(arg_path).is_absolute():
-                            pure_path = PurePosixPath(path).relative_to(PurePosixPath(self.cwd))
-                            arcname = "/".join(p for p in pure_path.parts if p not in (".", ".."))
-                            arcname = arcname or "."
+                        if is_absolute:
+                            # Use lstrip rather than `.relative_to("/")`, because
+                            # drive-letter paths ("c:/...") aren't rooted at "/".
+                            arcname = fsutil.normpath(path, sep="/").lstrip("/")
+                        else:
+                            rel = path.relative_to(self.cwd)
+                            arcname = "/".join(p for p in rel.parts if p not in (".", ".."))
+                        arcname = arcname or "."
                         add_to_tar(tar, path, arcname, dereference=args.dereference, inodes=inodes_cache)
         finally:
             if fobj is not stdout.buffer:

--- a/dissect/target/tools/utils/completer.py
+++ b/dissect/target/tools/utils/completer.py
@@ -243,7 +243,7 @@ class QuotedPathCompleter(Completer):
             if not path:
                 return cwd
 
-            resolved = path if path.startswith("/") else posixpath.join(str(cwd), path)
+            resolved = path if self.target.fs.path(path).is_absolute() else posixpath.join(str(cwd), path)
             # TargetPath may keep literal '..' segments; normalize first so completion lists the intended directory.
             normalized = posixpath.normpath(resolved)
             return self._make_path(normalized)

--- a/tests/_data/filesystems/ntfs/README.md
+++ b/tests/_data/filesystems/ntfs/README.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21cce532706b048a6768b60743f9ac0dcc2d122757a84f9387c3d8a59026fdb2
+size 854

--- a/tests/_data/filesystems/ntfs/ntfs.qcow2
+++ b/tests/_data/filesystems/ntfs/ntfs.qcow2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25cd5793bb951fd8480a3016ecf19ba09e8f68c439591c22265479bab8f09650
+size 586752

--- a/tests/filesystems/test_ntfs.py
+++ b/tests/filesystems/test_ntfs.py
@@ -11,9 +11,11 @@ from dissect.ntfs.exceptions import FileNotFoundError as NtfsFileNotFoundError
 from dissect.ntfs.mft import MftRecord
 from dissect.ntfs.util import AttributeMap
 
+from dissect.target import Target
 from dissect.target.exceptions import FileNotFoundError
 from dissect.target.filesystem import VirtualFilesystem
 from dissect.target.filesystems.ntfs import NtfsFilesystem, NtfsFilesystemEntry
+from tests._utils import absolute_path
 
 
 @pytest.mark.parametrize(
@@ -151,3 +153,28 @@ def test_ntfs_identifier_no_guid() -> None:
     fs.ntfs = Mock(serial=serial_number)
 
     assert fs.identifier == serial_number
+
+
+def test_ntfs_parent_directory_traversal() -> None:
+    """NTFS filesystem correctly resolves a lone parent directory traversal ('..')."""
+    target = Target.open(absolute_path("_data/filesystems/ntfs/ntfs.qcow2"), apply=True)
+
+    resolved = target.fs.get("c:/Windows/System32/..")
+    parent = target.fs.get("c:/Windows")
+
+    # Same underlying NTFS MFT record (segment number)
+    assert resolved.entries[0].entry.segment == parent.entries[0].entry.segment
+
+    # Test fs.path and we are sure that it references the Downloads directory.
+    path = target.fs.path("c:/Users/User/Downloads/../Downloads")
+    assert path.exists()
+    filenames = {p.name for p in target.fs.path(path).iterdir()}
+    assert filenames == {"logo-konami.svg"}
+
+
+def test_ntfs_lstat_ads_exception() -> None:
+    """NTFS filesystem raises FileNotFoundError when an ADS record is not found."""
+    target = Target.open(absolute_path("_data/filesystems/ntfs/ntfs.qcow2"), apply=True)
+
+    with pytest.raises(FileNotFoundError, match="ADS record not found"):
+        target.fs.path("c:/$Extend/$ObjId").lstat()

--- a/tests/tools/test_shell.py
+++ b/tests/tools/test_shell.py
@@ -1082,3 +1082,44 @@ def test_target_cli_tar_unknown_path(tmp_path: Path, capsys: pytest.CaptureFixtu
     captured = capsys.readouterr()
     assert captured.err == "tar: missing.txt: No such file or directory\n"
     assert outpath.is_file()
+
+
+def test_target_cli_tar_windows_ntfs(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    """Test tar works correctly on an NTFS filesystem (mounted under c:/)."""
+    target = Target.open(absolute_path("_data/filesystems/ntfs/ntfs.qcow2"), apply=True)
+    cli = TargetCli(target)
+
+    # Test relative paths
+    outpath = tmp_path / "out.tar"
+    cli.onecmd("cd c:/Users/User/Downloads")
+    cli.onecmd(f"tar -cvf {outpath.as_posix()} ../Downloads")
+    captured = capsys.readouterr()
+    assert "No such file or directory" not in captured.err
+    assert outpath.is_file()
+    assert outpath.stat().st_size > 0
+    with tarfile.open(outpath, "r:*") as tar:
+        members = sorted(tar.getnames())
+    assert members == ["Downloads", "Downloads/logo-konami.svg"]
+
+    # Test path traversal
+    cli.onecmd(f"tar -cvf {outpath.as_posix()} c:/Users/User/Downloads/../Downloads")
+    captured = capsys.readouterr()
+    assert "No such file or directory" not in captured.err
+    assert outpath.is_file()
+    assert outpath.stat().st_size > 0
+
+    # Test . (cwd)
+    cli.onecmd("cd c:/Users/User/")
+    cli.onecmd(f"tar -cvf {outpath.as_posix()} .")
+    captured = capsys.readouterr()
+    assert "No such file or directory" not in captured.err
+    assert outpath.is_file()
+    assert outpath.stat().st_size > 0
+
+    # Test absolute paths
+    cli.onecmd(f"tar -cvf {outpath.as_posix()} c:/")
+    captured = capsys.readouterr()
+    assert "No such file or directory" not in captured.err
+    assert "tar: c:/$Secure: file not found, skipping" in captured.err
+    assert outpath.is_file()
+    assert outpath.stat().st_size > 0


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request. Please:

* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Associate the PR with an issue. If it doesn't exist, create it. Use 
  closing keywords in the body during creation, e.g.:
    * close(|s|d) #<nr>
    * fix(|es|ed) #<nr>
    * resolve(|s|d) #<nr>
-->

# Fix NTFS relative paths and target-shell tar for Windows targets

The target-shell `tar` command did not work on Windows targets, mainly when it was mounted under a drive letter such as `c:/`. This was mainly due to path handling and that there is no `c:` relative `/`. See also #1913

When fixing this bug I came across some other issues which is also fixed in this PR:

 * NTFS did not handle path traversal like `c:/Windows/System32/../System32`
 * NTFS raised an empty `FileNotFoundError` from `ntfs.py` when reading a non existing ADS record, this caused `tar` to return prematurely, but also with the non descriptive error message `None`.
   * This exception could happen in `get_tarinfo()` and was not caught properly.

If the changes need to be split, i'm happy to do so, but I think they are small and related enough that it could fit into this PR.

## Proposed Changes

I fixed all of these issues and created a small NTFS test disk image that is automatically mounted as a Windows target. Regression tests are included.

The tar command was fixed by mainly using `target.fs.path` in the `tar` command instead of using pathlib Path for path operations.

Instructions how I created this disk image and the image itself is added under:

* `tests/_data/filesystems/ntfs/README.md`
* `tests/_data/filesystems/ntfs/ntfs.qcow2` (573Kb)

## Checklist

- [x] PR Title is descriptive of the changes
- [x] The description is descriptive of the changes
- [x] Tests are included and pass
- [x] Closes #1913