### PR TITLE
Add `source` field to records of 13 plugins

### DIFF
--- a/dissect/target/helpers/record.py
+++ b/dissect/target/helpers/record.py
@@ -143,7 +143,7 @@ COMMON_UNIX_FIELDS = [
     ("string", "gecos"),
     ("path", "home"),
     ("string", "shell"),
-    ("string", "source"),
+    ("path", "source"),
 ]
 
 UnixUserRecord = TargetRecordDescriptor(

--- a/dissect/target/plugins/os/unix/bsd/citrix/_os.py
+++ b/dissect/target/plugins/os/unix/bsd/citrix/_os.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from dissect.target.filesystem import Filesystem
+    from dissect.target.helpers.compat.pathlib import TargetPath
     from dissect.target.target import Target
 
 RE_CONFIG_IP = re.compile(r"-IPAddress (?P<ip>[^ ]+) ")
@@ -41,12 +42,11 @@ class CitrixPlugin(BsdPlugin):
         super().__init__(target)
         self._ips = []
         self._hostname = None
-        self._config_usernames = []
+        self._config_usernames: dict[str, TargetPath] = {}
         self._parse_netscaler_configs()
 
     def _parse_netscaler_configs(self) -> None:
         ips = set()
-        usernames = set()
 
         for path in self.target.fs.path("/flash/nsconfig/").glob("ns.conf*"):
             config = path.read_text()
@@ -55,13 +55,12 @@ class CitrixPlugin(BsdPlugin):
                 ips.add(match.groupdict()["ip"])
 
             for match in RE_CONFIG_USER.finditer(config):
-                usernames.add(match.groupdict()["user"])
+                self._config_usernames[match.groupdict()["user"]] = path
 
             if path.name == "ns.conf" and (match := RE_CONFIG_HOSTNAME.search(config)):
                 # Current configuration of the netscaler
                 self._hostname = match.groupdict()["hostname"]
 
-        self._config_usernames = list(usernames)
         self._ips = list(ips)
 
     @classmethod
@@ -211,7 +210,7 @@ class CitrixPlugin(BsdPlugin):
                     nstmp_users.add(username)
 
         # Yield users from the config, matching them to their 'home' in /var/nstmp if it exists.
-        for username in self._config_usernames:
+        for username, config_source in self._config_usernames.items():
             nstmp_home = nstmp_path.joinpath(username)
             user_home = nstmp_home if nstmp_home.exists() else None
 
@@ -227,14 +226,14 @@ class CitrixPlugin(BsdPlugin):
                 user_home = self.target.fs.path("/root")
 
             seen.add((username, user_home.as_posix() if user_home else None, None))
-            yield UnixUserRecord(name=username, home=user_home)
+            yield UnixUserRecord(name=username, home=user_home, source=config_source)
 
         # Yield all users in nstmp that were not observed in the config
         for username in nstmp_users:
             # The nsmonitor user has a home directory of /var/nstmp/monitors rather than /var/nstmp/nsmonitor
             home = nstmp_path.joinpath(username) if username != "nsmonitor" else nstmp_path.joinpath("monitors")
             seen.add((username, home.as_posix(), None))
-            yield UnixUserRecord(name=username, home=home)
+            yield UnixUserRecord(name=username, home=home, source=home)
 
         # Yield users from /etc/passwd if we have not seem them in previous loops
         for user in super().users():

--- a/dissect/target/plugins/os/unix/bsd/citrix/_os.py
+++ b/dissect/target/plugins/os/unix/bsd/citrix/_os.py
@@ -47,8 +47,10 @@ class CitrixPlugin(BsdPlugin):
 
     def _parse_netscaler_configs(self) -> None:
         ips = set()
-
-        for path in self.target.fs.path("/flash/nsconfig/").glob("ns.conf*"):
+        # sort file to ensure the most recent backup/config file is used as source for an user
+        for path in sorted(
+            self.target.fs.path("/flash/nsconfig/").glob("ns.conf*"), key=lambda x: x.name, reverse=True
+        ):
             config = path.read_text()
 
             for match in RE_CONFIG_IP.finditer(config):

--- a/dissect/target/plugins/os/unix/linux/cmdline.py
+++ b/dissect/target/plugins/os/unix/linux/cmdline.py
@@ -17,6 +17,7 @@ CmdlineRecord = TargetRecordDescriptor(
         ("varint", "pid"),
         ("string", "state"),
         ("string", "cmdline"),
+        ("path", "source"),
     ],
 )
 
@@ -55,5 +56,6 @@ class CmdlinePlugin(Plugin):
                 pid=process.pid,
                 state=process.state,
                 cmdline=process.cmdline,
+                source=process.get("cmdline"),
                 _target=self.target,
             )

--- a/dissect/target/plugins/os/unix/linux/debian/apt.py
+++ b/dissect/target/plugins/os/unix/linux/debian/apt.py
@@ -17,6 +17,7 @@ from dissect.target.plugins.os.unix.packagemanager import (
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from dissect.target.helpers.compat.pathlib import TargetPath
     from dissect.target.target import Target
 
 
@@ -61,7 +62,7 @@ class AptPlugin(PackageManagerPlugin):
 
                 # Indicates the end of a log chunk
                 if line == "":
-                    yield from split_into_records(chunk, target_tz, self.target)
+                    yield from split_into_records(chunk, target_tz, self.target, source=path)
 
                     chunk = []
                     continue
@@ -70,7 +71,7 @@ class AptPlugin(PackageManagerPlugin):
 
 
 def split_into_records(
-    chunk: Iterator[str], tzinfo: datetime.tzinfo, target: Target
+    chunk: Iterator[str], tzinfo: datetime.tzinfo, target: Target, source: TargetPath
 ) -> Iterator[PackageManagerLogRecord]:
     """Parse the chunk line for line and try to extract as much information from each line as possible."""
     packages = []
@@ -103,6 +104,7 @@ def split_into_records(
             operation=OperationTypes.infer(operation).value,
             requested_by_user=user,
             command=command,
+            source=source,
             _target=target,
         )
 

--- a/dissect/target/plugins/os/unix/linux/environ.py
+++ b/dissect/target/plugins/os/unix/linux/environ.py
@@ -17,6 +17,7 @@ EnvironmentVariableRecord = TargetRecordDescriptor(
         ("varint", "pid"),
         ("string", "variable"),
         ("string", "content"),
+        ("path", "source"),
     ],
 )
 
@@ -55,5 +56,6 @@ class EnvironPlugin(Plugin):
                     pid=process.pid,
                     variable=environ.variable,
                     content=environ.contents,
+                    source=process.get("environ"),
                     _target=self.target,
                 )

--- a/dissect/target/plugins/os/unix/linux/proc.py
+++ b/dissect/target/plugins/os/unix/linux/proc.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
     from typing_extensions import Self
 
+    from dissect.target.helpers.compat.pathlib import TargetPath
     from dissect.target.target import Target
 
 
@@ -75,6 +76,8 @@ class NetSocket:
     name: str | None = None  # process name associated to the socket
     cmdline: str | None = None  # process cmdline associated to the socket
 
+    source: TargetPath | None = None  # File from which this structure was generate.
+
     @classmethod
     def from_line(cls, line: str, ip_vers: int = 4) -> Self:
         socket = cls(*line.split())
@@ -110,6 +113,8 @@ class UnixSocket:
     stream_type_string: str | None = None
     protocol_string: str = "unix"
 
+    source: TargetPath | None = None  # File from which this structure was generate.
+
     @classmethod
     def from_line(cls, line: str) -> Self:
         socket = cls(*line.split())
@@ -142,6 +147,8 @@ class PacketSocket:
     protocol_type: int | None = None  # value parsed from protocol field
     owner: str | None = None  # resolved owner from user (uid) field
     protocol_string: str = "packet"
+
+    source: TargetPath | None = None  # File from which this structure was generate.
 
     @classmethod
     def from_line(cls, line: str) -> Self:
@@ -345,6 +352,7 @@ class Sockets:
             user = self.target.user_details.find(uid=socket.uid)
             user_name = user.user.name if user else str(socket.uid)
             socket.owner = user_name
+            socket.source = entry
 
             # inode 0 could indicate a kernel process, which has no assiciated PID or FDs in /proc
             # or a inode of 0 could mean the socket is in a TIME_WAIT state.
@@ -375,6 +383,7 @@ class Sockets:
 
             socket.stream_type_string = self.SocketStreamType(socket.type).name
             socket.state_string = self.SocketStateType(socket.state).name
+            socket.source = entry
 
             yield socket
 
@@ -394,7 +403,7 @@ class Sockets:
             processes = self.target.proc.inode_to_pids(socket.inode)
 
             socket.protocol_type = self.PacketProtocolTypes(socket.protocol).name
-
+            socket.source = entry
             user = self.target.user_details.find(uid=socket.user)
             user_name = user.user.name if user else str(socket.user)
             socket.owner = user_name

--- a/dissect/target/plugins/os/unix/linux/proc.py
+++ b/dissect/target/plugins/os/unix/linux/proc.py
@@ -76,7 +76,7 @@ class NetSocket:
     name: str | None = None  # process name associated to the socket
     cmdline: str | None = None  # process cmdline associated to the socket
 
-    source: TargetPath | None = None  # File from which this structure was generate.
+    source: TargetPath | None = None  # File from which this structure was generated.
 
     @classmethod
     def from_line(cls, line: str, ip_vers: int = 4) -> Self:
@@ -148,7 +148,7 @@ class PacketSocket:
     owner: str | None = None  # resolved owner from user (uid) field
     protocol_string: str = "packet"
 
-    source: TargetPath | None = None  # File from which this structure was generate.
+    source: TargetPath | None = None  # File from which this structure was generated.
 
     @classmethod
     def from_line(cls, line: str) -> Self:

--- a/dissect/target/plugins/os/unix/linux/proc.py
+++ b/dissect/target/plugins/os/unix/linux/proc.py
@@ -113,7 +113,7 @@ class UnixSocket:
     stream_type_string: str | None = None
     protocol_string: str = "unix"
 
-    source: TargetPath | None = None  # File from which this structure was generate.
+    source: TargetPath | None = None  # File from which this structure was generated.
 
     @classmethod
     def from_line(cls, line: str) -> Self:

--- a/dissect/target/plugins/os/unix/linux/processes.py
+++ b/dissect/target/plugins/os/unix/linux/processes.py
@@ -19,6 +19,7 @@ ProcProcessRecord = TargetRecordDescriptor(
         ("datetime", "runtime"),
         ("varint", "ppid"),
         ("string", "parent"),
+        ("path", "source"),
     ],
 )
 
@@ -60,5 +61,6 @@ class ProcProcesses(Plugin):
                 ppid=process.ppid,
                 state=process.state,
                 parent=process.parent.name,
+                source=process.entry,
                 _target=self.target,
             )

--- a/dissect/target/plugins/os/unix/linux/recentlyused.py
+++ b/dissect/target/plugins/os/unix/linux/recentlyused.py
@@ -30,7 +30,7 @@ RecentlyUsedRecord = TargetRecordDescriptor(
         ("string", "mimetype"),
         ("string", "groups"),
         ("boolean", "private"),
-        ("string", "source"),
+        ("path", "source"),
     ],
 )
 
@@ -40,7 +40,7 @@ RecentlyUsedIconRecord = TargetRecordDescriptor(
         ("string", "type"),
         ("string", "href"),
         ("string", "name"),
-        ("string", "source"),
+        ("path", "source"),
     ],
 )
 
@@ -51,7 +51,7 @@ RecentlyUsedApplicationRecord = TargetRecordDescriptor(
         ("string", "name"),
         ("string", "exec"),
         ("varint", "count"),
-        ("string", "source"),
+        ("path", "source"),
     ],
 )
 ns = {
@@ -124,7 +124,10 @@ def parse_recently_used_xbel(
             # Icon is optional, spec says at most one.
             for icon in bookmark.findall("./info/metadata/bookmark:icon", ns):
                 iconrecord = RecentlyUsedIconRecord(
-                    type=icon.get("type"), href=icon.get("href"), name=icon.get("name"), source=xbel_file
+                    type=icon.get("type"),
+                    href=icon.get("href"),
+                    name=icon.get("name"),
+                    source=xbel_file,
                 )
                 yield GroupedRecord("unix/linux/recently_used/icon", [cur, iconrecord])
 

--- a/dissect/target/plugins/os/unix/linux/recentlyused.py
+++ b/dissect/target/plugins/os/unix/linux/recentlyused.py
@@ -23,7 +23,6 @@ RecentlyUsedRecord = TargetRecordDescriptor(
     [
         ("datetime", "ts"),
         ("string", "user"),
-        ("string", "source"),
         ("string", "href"),
         ("datetime", "added"),
         ("datetime", "modified"),
@@ -31,6 +30,7 @@ RecentlyUsedRecord = TargetRecordDescriptor(
         ("string", "mimetype"),
         ("string", "groups"),
         ("boolean", "private"),
+        ("string", "source"),
     ],
 )
 
@@ -40,6 +40,7 @@ RecentlyUsedIconRecord = TargetRecordDescriptor(
         ("string", "type"),
         ("string", "href"),
         ("string", "name"),
+        ("string", "source"),
     ],
 )
 
@@ -50,6 +51,7 @@ RecentlyUsedApplicationRecord = TargetRecordDescriptor(
         ("string", "name"),
         ("string", "exec"),
         ("varint", "count"),
+        ("string", "source"),
     ],
 )
 ns = {
@@ -107,7 +109,6 @@ def parse_recently_used_xbel(
             cur = RecentlyUsedRecord(
                 ts=parse_ts(target, bookmark.get("visited")),
                 user=username,
-                source=xbel_file,
                 href=bookmark.get("href"),
                 added=parse_ts(target, bookmark.get("added")),
                 modified=parse_ts(target, bookmark.get("modified")),
@@ -115,6 +116,7 @@ def parse_recently_used_xbel(
                 mimetype=mimetype,
                 groups=group_list,
                 private=private,
+                source=xbel_file,
                 _target=target,
             )
             yield cur
@@ -122,9 +124,7 @@ def parse_recently_used_xbel(
             # Icon is optional, spec says at most one.
             for icon in bookmark.findall("./info/metadata/bookmark:icon", ns):
                 iconrecord = RecentlyUsedIconRecord(
-                    type=icon.get("type"),
-                    href=icon.get("href"),
-                    name=icon.get("name"),
+                    type=icon.get("type"), href=icon.get("href"), name=icon.get("name"), source=xbel_file
                 )
                 yield GroupedRecord("unix/linux/recently_used/icon", [cur, iconrecord])
 
@@ -135,6 +135,7 @@ def parse_recently_used_xbel(
                     name=app.get("name"),
                     exec=app.get("exec"),
                     count=app.get("count"),
+                    source=xbel_file,
                 )
                 yield GroupedRecord("unix/linux/recently_used/application", [cur, apprecord])
 

--- a/dissect/target/plugins/os/unix/linux/redhat/yum.py
+++ b/dissect/target/plugins/os/unix/linux/redhat/yum.py
@@ -57,5 +57,6 @@ class YumPlugin(PackageManagerPlugin):
                     package_manager="yum",
                     operation=OperationTypes.infer(operation.strip()).value,
                     package_name=package_name,
+                    source=path,
                     _target=self.target,
                 )

--- a/dissect/target/plugins/os/unix/linux/sockets.py
+++ b/dissect/target/plugins/os/unix/linux/sockets.py
@@ -33,7 +33,7 @@ NetSocketRecord = TargetRecordDescriptor(
         ("uint32", "pid"),
         ("string", "name"),
         ("string", "cmdline"),
-        ("string", "source"),
+        ("path", "source"),
     ],
 )
 
@@ -47,7 +47,7 @@ UnixSocketRecord = TargetRecordDescriptor(
         ("string", "state"),
         ("uint32", "inode"),
         ("string", "path"),
-        ("string", "source"),
+        ("path", "source"),
     ],
 )
 
@@ -68,7 +68,7 @@ PacketSocketRecord = TargetRecordDescriptor(
         ("uint32", "pid"),
         ("string", "name"),
         ("string", "cmdline"),
-        ("string", "source"),
+        ("path", "source"),
     ],
 )
 

--- a/dissect/target/plugins/os/unix/linux/sockets.py
+++ b/dissect/target/plugins/os/unix/linux/sockets.py
@@ -33,6 +33,7 @@ NetSocketRecord = TargetRecordDescriptor(
         ("uint32", "pid"),
         ("string", "name"),
         ("string", "cmdline"),
+        ("string", "source"),
     ],
 )
 
@@ -46,6 +47,7 @@ UnixSocketRecord = TargetRecordDescriptor(
         ("string", "state"),
         ("uint32", "inode"),
         ("string", "path"),
+        ("string", "source"),
     ],
 )
 
@@ -66,6 +68,7 @@ PacketSocketRecord = TargetRecordDescriptor(
         ("uint32", "pid"),
         ("string", "name"),
         ("string", "cmdline"),
+        ("string", "source"),
     ],
 )
 
@@ -215,6 +218,7 @@ class NetSocketPlugin(Plugin):
             state=data.state_string,
             inode=data.inode,
             path=data.path,
+            source=data.source,
             _target=self.target,
         )
 
@@ -234,6 +238,7 @@ class NetSocketPlugin(Plugin):
             name=data.name,
             cmdline=data.cmdline,
             owner=data.owner,
+            source=data.source,
             _target=self.target,
         )
 
@@ -252,5 +257,6 @@ class NetSocketPlugin(Plugin):
             pid=data.pid,
             name=data.name,
             cmdline=data.cmdline,
+            source=data.source,
             _target=self.target,
         )

--- a/dissect/target/plugins/os/unix/linux/suse/zypper.py
+++ b/dissect/target/plugins/os/unix/linux/suse/zypper.py
@@ -68,6 +68,7 @@ class ZypperPlugin(PackageManagerPlugin):
                     ts=ts,
                     package_manager="zypper",
                     operation=operation.value,
+                    source=path,
                     _target=self.target,
                 )
 

--- a/dissect/target/plugins/os/unix/locale.py
+++ b/dissect/target/plugins/os/unix/locale.py
@@ -19,6 +19,7 @@ UnixKeyboardRecord = TargetRecordDescriptor(
         ("string", "variant"),
         ("string", "options"),
         ("string", "backspace"),
+        ("path", "source"),
     ],
 )
 
@@ -125,6 +126,7 @@ class UnixLocalePlugin(LocalePlugin):
                     variant=k.get("VARIANT"),
                     options=k.get("OPTIONS"),
                     backspace=k.get("BACKSPACE"),
+                    source=path,
                     _target=self.target,
                 )
 

--- a/dissect/target/plugins/os/unix/shadow.py
+++ b/dissect/target/plugins/os/unix/shadow.py
@@ -26,6 +26,7 @@ UnixShadowRecord = TargetRecordDescriptor(
         ("varint", "inactivity_period"),
         ("datetime", "expiration_date"),
         ("string", "unused_field"),
+        ("path", "source"),
     ],
 )
 
@@ -118,6 +119,7 @@ class ShadowPlugin(Plugin):
                         inactivity_period=shent.get(6) if shent.get(6) else None,
                         expiration_date=epoch_days_to_datetime(expiration_date) if expiration_date else None,
                         unused_field=shent.get(8),
+                        source=path,
                         _target=self.target,
                     )
 

--- a/dissect/target/plugins/os/windows/cim.py
+++ b/dissect/target/plugins/os/windows/cim.py
@@ -25,6 +25,7 @@ COMMON_ELEMENTS = [
     ("string", "filter_name"),
     ("string", "filter_query_language"),
     ("string", "filter_creator_sid"),
+    ("path", "source"),
 ]
 
 CommandLineEventConsumerRecord = TargetRecordDescriptor(
@@ -119,6 +120,7 @@ class CimPlugin(Plugin):
 
         self._filters: dict[str, EventFilter] = {}
         repodir = repodirs[0]
+        self.source = repodir
         index = repodir.joinpath("index.btr")
         objects = repodir.joinpath("objects.data")
         mappings = [repodir.joinpath(f"mapping{i}.map") for i in range(1, 4)]
@@ -186,6 +188,7 @@ class CimPlugin(Plugin):
                     machine_name=get_property_value_safe(consumer, "MachineName", ""),
                     name=get_property_value_safe(consumer, "Name", ""),
                     creator_sid=get_creator_sid(consumer),
+                    source=self.source,
                     _target=self.target,
                     **asdict(self._filters.get(filter_name, EventFilter(filter_name=filter_name))),
                 )
@@ -195,6 +198,7 @@ class CimPlugin(Plugin):
                     executable_path=get_property_value_safe(consumer, "ExecutablePath", ""),
                     working_directory=get_property_value_safe(consumer, "WorkingDirectory", ""),
                     creator_sid=get_creator_sid(consumer),
+                    source=self.source,
                     _target=self.target,
                     **asdict(self._filters.get(filter_name, EventFilter(filter_name=filter_name))),
                 )

--- a/dissect/target/plugins/os/windows/log/evt.py
+++ b/dissect/target/plugins/os/windows/log/evt.py
@@ -196,5 +196,4 @@ class EvtPlugin(WindowsEventlogsMixin, Plugin):
     def _parse_chunk(self, needle: bytes, chunk: bytes) -> Iterator[Record]:
         for record in evt.parse_chunk(chunk):
             # we may provide disk + offset, but this would require more change in scrap internal
-            # We keep
             yield self._build_record(record, source=None)

--- a/dissect/target/plugins/os/windows/log/evt.py
+++ b/dissect/target/plugins/os/windows/log/evt.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 
     from flow.record import Record
 
+    from dissect.target.helpers.compat.pathlib import TargetPath
+
 
 re_illegal_characters = re.compile(r"[\(\): \.\-#]")
 
@@ -43,6 +45,7 @@ EvtRecordDescriptor = TargetRecordDescriptor(
         ("string", "UserSid"),
         ("string[]", "Strings"),
         ("bytes", "Data"),
+        ("path", "source"),
     ],
 )
 
@@ -152,9 +155,9 @@ class EvtPlugin(WindowsEventlogsMixin, Plugin):
                 continue
 
             for record in evt.Evt(entry_data):
-                yield self._build_record(record)
+                yield self._build_record(record, source=entry)
 
-    def _build_record(self, record: Any) -> Record:
+    def _build_record(self, record: Any, source: TargetPath | None) -> Record:
         return EvtRecordDescriptor(
             ts=record.TimeGenerated,
             TimeGenerated=record.TimeGenerated,
@@ -170,6 +173,7 @@ class EvtPlugin(WindowsEventlogsMixin, Plugin):
             Computername=record.Computername,
             Strings=record.Strings,
             Data=record.Data,
+            source=source,
             _target=self.target,
         )
 
@@ -191,4 +195,6 @@ class EvtPlugin(WindowsEventlogsMixin, Plugin):
 
     def _parse_chunk(self, needle: bytes, chunk: bytes) -> Iterator[Record]:
         for record in evt.parse_chunk(chunk):
-            yield self._build_record(record)
+            # we may provide disk + offset, but this would require more change in scrap internal
+            # We keep
+            yield self._build_record(record, source=None)

--- a/dissect/target/plugins/os/windows/log/schedlgu.py
+++ b/dissect/target/plugins/os/windows/log/schedlgu.py
@@ -29,6 +29,7 @@ SchedLgURecord = TargetRecordDescriptor(
         ("string", "status"),
         ("uint32", "exit_code"),
         ("string", "version"),
+        ("path", "source"),
     ],
 )
 
@@ -159,5 +160,6 @@ class SchedLgUPlugin(Plugin):
                     status=event.status,
                     exit_code=event.exit_code,
                     version=event.version,
+                    source=path,
                     _target=self.target,
                 )

--- a/dissect/target/plugins/os/windows/tasks/_plugin.py
+++ b/dissect/target/plugins/os/windows/tasks/_plugin.py
@@ -40,10 +40,9 @@ if TYPE_CHECKING:
 TaskRecord = TargetRecordDescriptor(
     "filesystem/windows/task",
     [
-        ("path", "task_path"),
         ("string", "uri"),
         ("string", "security_descriptor"),
-        ("string", "source"),
+        ("string", "registration_source"),
         ("datetime", "date"),
         ("datetime", "last_run_date"),
         ("string", "author"),
@@ -92,6 +91,7 @@ TaskRecord = TargetRecordDescriptor(
         ("boolean", "disallow_start_on_remote_app_session"),
         ("string", "data"),
         ("string", "raw_data"),
+        ("path", "source"),
     ],
 )
 
@@ -99,6 +99,7 @@ TriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger",
     {
         ("string", "uri"),
+        ("path", "source"),
         *BaseTriggerRecord.target_fields,
         *BootTriggerRecord.target_fields,
         *CalendarTriggerRecord.target_fields,
@@ -121,6 +122,7 @@ ActionRecord = TargetRecordDescriptor(
     "filesystem/windows/task/action",
     {
         ("string", "uri"),
+        ("path", "source"),
         *ComHandlerRecord.target_fields,
         *ExecRecord.target_fields,
         *SendEmailRecord.target_fields,
@@ -206,6 +208,9 @@ class TasksPlugin(Plugin):
                 for attr in TaskRecord.fields:
                     record_kwargs[attr] = getattr(task_object, attr, None)
 
+                record_kwargs["source"] = task_object.source
+                if task_object.source is None:
+                    print(task_object)
                 task_record = TaskRecord(**record_kwargs, _target=self.target)
                 yield task_record
 

--- a/dissect/target/plugins/os/windows/tasks/_plugin.py
+++ b/dissect/target/plugins/os/windows/tasks/_plugin.py
@@ -209,8 +209,6 @@ class TasksPlugin(Plugin):
                     record_kwargs[attr] = getattr(task_object, attr, None)
 
                 record_kwargs["source"] = task_object.source
-                if task_object.source is None:
-                    print(task_object)
                 task_record = TaskRecord(**record_kwargs, _target=self.target)
                 yield task_record
 

--- a/dissect/target/plugins/os/windows/tasks/job.py
+++ b/dissect/target/plugins/os/windows/tasks/job.py
@@ -218,7 +218,11 @@ class AtTask:
         wrkdir = self.at_data.working_dir.rstrip("\x00")
 
         yield ExecRecord(
-            action_type=action_type, command=command, arguments=args, working_directory=wrkdir, source=self.source
+            action_type=action_type,
+            command=command,
+            arguments=args,
+            working_directory=wrkdir,
+            source=self.source,
         )
 
     def get_triggers(self) -> Iterator[GroupedRecord]:
@@ -269,7 +273,10 @@ class AtTask:
                 source=self.source,
             )
             padding_record = PaddingTriggerRecord(
-                padding=trigger.padding, reserved2=trigger.reserved2, reserved3=trigger.reserved3, source=self.source
+                padding=trigger.padding,
+                reserved2=trigger.reserved2,
+                reserved3=trigger.reserved3,
+                source=self.source,
             )
 
             if trigger_type == "EVENT_AT_LOGON":
@@ -292,7 +299,11 @@ class AtTask:
                 interval = trigger.trigger_specific0
                 unused = [trigger.trigger_specific1, trigger.trigger_specific2]
 
-                record = DailyTriggerRecord(days_between_triggers=interval, unused=unused, source=self.source)
+                record = DailyTriggerRecord(
+                    days_between_triggers=interval,
+                    unused=unused,
+                    source=self.source,
+                )
 
                 yield GroupedRecord("filesystem/windows/task/daily", [base, record, padding_record])
 
@@ -304,7 +315,10 @@ class AtTask:
                 unused = [trigger.trigger_specific2]
 
                 record = WeeklyTriggerRecord(
-                    weeks_between_triggers=interval, days_of_week=days_of_week, unused=unused, source=self.source
+                    weeks_between_triggers=interval,
+                    days_of_week=days_of_week,
+                    unused=unused,
+                    source=self.source,
                 )
 
                 yield GroupedRecord("filesystem/windows/task/weekly", [base, record, padding_record])
@@ -322,7 +336,9 @@ class AtTask:
                 months_of_year = self.get_months_of_year(trigger.trigger_specific2)
 
                 record = MonthlyDateTriggerRecord(
-                    day_of_month=[day_of_month], months_of_year=months_of_year, source=self.source
+                    day_of_month=[day_of_month],
+                    months_of_year=months_of_year,
+                    source=self.source,
                 )
 
                 yield GroupedRecord("filesystem/windows/task/monthly_date", [base, record, padding_record])
@@ -332,7 +348,10 @@ class AtTask:
                 days = self.get_days_of_week(trigger.trigger_specific1)
                 months = self.get_months_of_year(trigger.trigger_specific2)
                 record = MonthlyDowTriggerRecord(
-                    which_week=[week], days_of_week=days, months_of_year=months, source=self.source
+                    which_week=[week],
+                    days_of_week=days,
+                    months_of_year=months,
+                    source=self.source,
                 )
 
                 yield GroupedRecord("filesystem/windows/task/monthly_dow", [base, record, padding_record])

--- a/dissect/target/plugins/os/windows/tasks/job.py
+++ b/dissect/target/plugins/os/windows/tasks/job.py
@@ -153,7 +153,7 @@ class AtTask:
         except Exception as e:
             raise InvalidTaskError(e)
 
-        self.task_path = job_file
+        self.source = job_file
         self.tzinfo = tzinfo
 
         last_year = self.at_data.last_year
@@ -218,10 +218,7 @@ class AtTask:
         wrkdir = self.at_data.working_dir.rstrip("\x00")
 
         yield ExecRecord(
-            action_type=action_type,
-            command=command,
-            arguments=args,
-            working_directory=wrkdir,
+            action_type=action_type, command=command, arguments=args, working_directory=wrkdir, source=self.source
         )
 
     def get_triggers(self) -> Iterator[GroupedRecord]:
@@ -269,11 +266,10 @@ class AtTask:
                 repetition_duration=repetition_duration,
                 repetition_stop_duration_end=repetition_stop_duration_end,
                 execution_time_limit=execution_time_limit,
+                source=self.source,
             )
             padding_record = PaddingTriggerRecord(
-                padding=trigger.padding,
-                reserved2=trigger.reserved2,
-                reserved3=trigger.reserved3,
+                padding=trigger.padding, reserved2=trigger.reserved2, reserved3=trigger.reserved3, source=self.source
             )
 
             if trigger_type == "EVENT_AT_LOGON":
@@ -296,10 +292,7 @@ class AtTask:
                 interval = trigger.trigger_specific0
                 unused = [trigger.trigger_specific1, trigger.trigger_specific2]
 
-                record = DailyTriggerRecord(
-                    days_between_triggers=interval,
-                    unused=unused,
-                )
+                record = DailyTriggerRecord(days_between_triggers=interval, unused=unused, source=self.source)
 
                 yield GroupedRecord("filesystem/windows/task/daily", [base, record, padding_record])
 
@@ -311,9 +304,7 @@ class AtTask:
                 unused = [trigger.trigger_specific2]
 
                 record = WeeklyTriggerRecord(
-                    weeks_between_triggers=interval,
-                    days_of_week=days_of_week,
-                    unused=unused,
+                    weeks_between_triggers=interval, days_of_week=days_of_week, unused=unused, source=self.source
                 )
 
                 yield GroupedRecord("filesystem/windows/task/weekly", [base, record, padding_record])
@@ -331,8 +322,7 @@ class AtTask:
                 months_of_year = self.get_months_of_year(trigger.trigger_specific2)
 
                 record = MonthlyDateTriggerRecord(
-                    day_of_month=[day_of_month],
-                    months_of_year=months_of_year,
+                    day_of_month=[day_of_month], months_of_year=months_of_year, source=self.source
                 )
 
                 yield GroupedRecord("filesystem/windows/task/monthly_date", [base, record, padding_record])
@@ -342,9 +332,7 @@ class AtTask:
                 days = self.get_days_of_week(trigger.trigger_specific1)
                 months = self.get_months_of_year(trigger.trigger_specific2)
                 record = MonthlyDowTriggerRecord(
-                    which_week=[week],
-                    days_of_week=days,
-                    months_of_year=months,
+                    which_week=[week], days_of_week=days, months_of_year=months, source=self.source
                 )
 
                 yield GroupedRecord("filesystem/windows/task/monthly_dow", [base, record, padding_record])

--- a/dissect/target/plugins/os/windows/tasks/records.py
+++ b/dissect/target/plugins/os/windows/tasks/records.py
@@ -4,29 +4,22 @@ from dissect.target.helpers.record import TargetRecordDescriptor
 
 BootTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/boot",
-    [],
+    [("path", "source")],
 )
 
 CalendarTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/calendar",
-    [],
+    [("path", "source")],
 )
 
 DailyTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/daily",
-    [
-        ("uint16", "days_between_triggers"),
-        ("uint16[]", "unused"),
-    ],
+    [("uint16", "days_between_triggers"), ("uint16[]", "unused"), ("path", "source")],
 )
 
 ComHandlerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/action/comhandler",
-    [
-        ("string", "action_type"),
-        ("string", "class_id"),
-        ("string", "com_data"),
-    ],
+    [("string", "action_type"), ("string", "class_id"), ("string", "com_data"), ("path", "source")],
 )
 
 EventTriggerRecord = TargetRecordDescriptor(
@@ -37,6 +30,7 @@ EventTriggerRecord = TargetRecordDescriptor(
         ("uint16", "number_of_occurences"),
         ("string", "matching_elements"),
         ("string", "value_queries"),
+        ("path", "source"),
     ],
 )
 
@@ -47,24 +41,23 @@ ExecRecord = TargetRecordDescriptor(
         ("string", "command"),
         ("string", "arguments"),
         ("string", "working_directory"),
+        ("path", "source"),
     ],
 )
 
 IdleTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/idle",
-    [],
+    [("path", "source")],
 )
 
 LogonTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/logon",
-    [
-        ("string", "user_id"),
-    ],
+    [("string", "user_id"), ("path", "source")],
 )
 
 TimeTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/time",
-    [],
+    [("path", "source")],
 )
 
 BaseTriggerRecord = TargetRecordDescriptor(
@@ -80,33 +73,23 @@ BaseTriggerRecord = TargetRecordDescriptor(
         ("string", "delay"),
         ("string", "random_delay"),
         ("string", "trigger_data"),
+        ("path", "source"),
     ],
 )
 
 MonthlyDateTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/monthly",
-    [
-        ("uint16[]", "day_of_month"),
-        ("string[]", "months_of_year"),
-    ],
+    [("uint16[]", "day_of_month"), ("string[]", "months_of_year"), ("path", "source")],
 )
 
 MonthlyDowTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/monthly_dow",
-    [
-        ("uint16[]", "which_week"),
-        ("string[]", "days_of_week"),
-        ("string[]", "months_of_year"),
-    ],
+    [("uint16[]", "which_week"), ("string[]", "days_of_week"), ("string[]", "months_of_year"), ("path", "source")],
 )
 
 PaddingTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/padding",
-    [
-        ("uint16", "padding"),
-        ("uint16", "reserved2"),
-        ("uint16", "reserved3"),
-    ],
+    [("uint16", "padding"), ("uint16", "reserved2"), ("uint16", "reserved3"), ("path", "source")],
 )
 
 SendEmailRecord = TargetRecordDescriptor(
@@ -124,44 +107,31 @@ SendEmailRecord = TargetRecordDescriptor(
         ("string", "header_value"),
         ("string", "body"),
         ("string", "attachment"),
+        ("path", "source"),
     ],
 )
 
 SessionStateChangeTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/session_state_change",
-    [
-        ("string", "user_id"),
-        ("string", "state_change"),
-    ],
+    [("string", "user_id"), ("string", "state_change"), ("path", "source")],
 )
 
 ShowMessageRecord = TargetRecordDescriptor(
     "filesystem/windows/task/action/show_message",
-    [
-        ("string", "tile"),
-        ("string", "body"),
-    ],
+    [("string", "tile"), ("string", "body"), ("path", "source")],
 )
 
 WeeklyTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/weekly",
-    [
-        ("uint16", "weeks_between_triggers"),
-        ("string[]", "days_of_week"),
-        ("uint16[]", "unused"),
-    ],
+    [("uint16", "weeks_between_triggers"), ("string[]", "days_of_week"), ("uint16[]", "unused"), ("path", "source")],
 )
 
 WnfTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/wnf",
-    [
-        ("string", "state_name"),
-    ],
+    [("string", "state_name"), ("path", "source")],
 )
 
 RegistrationTrigger = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/registration",
-    [
-        ("datetime", "date"),
-    ],
+    [("datetime", "date"), ("path", "source")],
 )

--- a/dissect/target/plugins/os/windows/tasks/records.py
+++ b/dissect/target/plugins/os/windows/tasks/records.py
@@ -4,22 +4,35 @@ from dissect.target.helpers.record import TargetRecordDescriptor
 
 BootTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/boot",
-    [("path", "source")],
+    [
+        ("path", "source"),
+    ],
 )
 
 CalendarTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/calendar",
-    [("path", "source")],
+    [
+        ("path", "source"),
+    ],
 )
 
 DailyTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/daily",
-    [("uint16", "days_between_triggers"), ("uint16[]", "unused"), ("path", "source")],
+    [
+        ("uint16", "days_between_triggers"),
+        ("uint16[]", "unused"),
+        ("path", "source"),
+    ],
 )
 
 ComHandlerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/action/comhandler",
-    [("string", "action_type"), ("string", "class_id"), ("string", "com_data"), ("path", "source")],
+    [
+        ("string", "action_type"),
+        ("string", "class_id"),
+        ("string", "com_data"),
+        ("path", "source"),
+    ],
 )
 
 EventTriggerRecord = TargetRecordDescriptor(
@@ -47,17 +60,24 @@ ExecRecord = TargetRecordDescriptor(
 
 IdleTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/idle",
-    [("path", "source")],
+    [
+        ("path", "source"),
+    ],
 )
 
 LogonTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/logon",
-    [("string", "user_id"), ("path", "source")],
+    [
+        ("string", "user_id"),
+        ("path", "source"),
+    ],
 )
 
 TimeTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/time",
-    [("path", "source")],
+    [
+        ("path", "source"),
+    ],
 )
 
 BaseTriggerRecord = TargetRecordDescriptor(
@@ -79,17 +99,31 @@ BaseTriggerRecord = TargetRecordDescriptor(
 
 MonthlyDateTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/monthly",
-    [("uint16[]", "day_of_month"), ("string[]", "months_of_year"), ("path", "source")],
+    [
+        ("uint16[]", "day_of_month"),
+        ("string[]", "months_of_year"),
+        ("path", "source"),
+    ],
 )
 
 MonthlyDowTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/monthly_dow",
-    [("uint16[]", "which_week"), ("string[]", "days_of_week"), ("string[]", "months_of_year"), ("path", "source")],
+    [
+        ("uint16[]", "which_week"),
+        ("string[]", "days_of_week"),
+        ("string[]", "months_of_year"),
+        ("path", "source"),
+    ],
 )
 
 PaddingTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/padding",
-    [("uint16", "padding"), ("uint16", "reserved2"), ("uint16", "reserved3"), ("path", "source")],
+    [
+        ("uint16", "padding"),
+        ("uint16", "reserved2"),
+        ("uint16", "reserved3"),
+        ("path", "source"),
+    ],
 )
 
 SendEmailRecord = TargetRecordDescriptor(
@@ -113,25 +147,44 @@ SendEmailRecord = TargetRecordDescriptor(
 
 SessionStateChangeTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/session_state_change",
-    [("string", "user_id"), ("string", "state_change"), ("path", "source")],
+    [
+        ("string", "user_id"),
+        ("string", "state_change"),
+        ("path", "source"),
+    ],
 )
 
 ShowMessageRecord = TargetRecordDescriptor(
     "filesystem/windows/task/action/show_message",
-    [("string", "tile"), ("string", "body"), ("path", "source")],
+    [
+        ("string", "tile"),
+        ("string", "body"),
+        ("path", "source"),
+    ],
 )
 
 WeeklyTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/weekly",
-    [("uint16", "weeks_between_triggers"), ("string[]", "days_of_week"), ("uint16[]", "unused"), ("path", "source")],
+    [
+        ("uint16", "weeks_between_triggers"),
+        ("string[]", "days_of_week"),
+        ("uint16[]", "unused"),
+        ("path", "source"),
+    ],
 )
 
 WnfTriggerRecord = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/wnf",
-    [("string", "state_name"), ("path", "source")],
+    [
+        ("string", "state_name"),
+        ("path", "source"),
+    ],
 )
 
 RegistrationTrigger = TargetRecordDescriptor(
     "filesystem/windows/task/trigger/registration",
-    [("datetime", "date"), ("path", "source")],
+    [
+        ("datetime", "date"),
+        ("path", "source"),
+    ],
 )

--- a/dissect/target/plugins/os/windows/tasks/xml.py
+++ b/dissect/target/plugins/os/windows/tasks/xml.py
@@ -41,7 +41,7 @@ class ScheduledTasks:
         except Exception as e:
             raise InvalidTaskError(e)
 
-        self.task_path = xml_file
+        self.source = xml_file
         self.tasks = self.get_tasks()
 
     def strip_namespace(self, data: Element) -> Element:
@@ -65,9 +65,9 @@ class ScheduledTasks:
     def get_tasks(self) -> list[XmlTask]:
         tasks = []
         if self.xml_data.tag == "Task":
-            tasks.append(XmlTask(self.xml_data, self.task_path))
+            tasks.append(XmlTask(self.xml_data, self.source))
         else:
-            tasks.extend(XmlTask(task_element, self.task_path) for task_element in self.xml_data.findall(".//{*}Task"))
+            tasks.extend(XmlTask(task_element, self.source) for task_element in self.xml_data.findall(".//{*}Task"))
 
         return tasks
 
@@ -109,7 +109,7 @@ class XmlTask:
     """
 
     def __init__(self, task_element: Element, task_path: TargetPath):
-        self.task_path = task_path
+        self.source = task_path
         self.task_element = task_element
 
         # Properties
@@ -124,7 +124,7 @@ class XmlTask:
 
         self.uri = self.get_element("RegistrationInfo/URI")
         self.security_descriptor = self.get_element("RegistrationInfo/SecurityDescriptor")
-        self.source = self.get_element("RegistrationInfo/Source")
+        self.registration_source = self.get_element("RegistrationInfo/Source")
         self.date = self.get_element("RegistrationInfo/Date")
         self.author = self.get_element("RegistrationInfo/Author")
         self.version = self.get_element("RegistrationInfo/Version")
@@ -266,13 +266,12 @@ class XmlTask:
                 delay=delay,
                 random_delay=random_delay,
                 trigger_data=trigger_data,
+                source=self.source,
             )
 
             if trigger_type == "LogonTrigger":
                 user_id = self.get_element("UserId", trigger)
-                record = LogonTriggerRecord(
-                    user_id=user_id,
-                )
+                record = LogonTriggerRecord(user_id=user_id, source=self.source)
                 yield GroupedRecord(LogonTriggerRecord.name, [base, record])
 
             elif trigger_type == "BootTrigger":
@@ -297,6 +296,7 @@ class XmlTask:
                     number_of_occurences=number_of_occurences,
                     matching_elements=matching_elements,
                     value_queries=value_queries,
+                    source=self.source,
                 )
 
                 yield GroupedRecord(EventTriggerRecord.name, [base, record])
@@ -305,32 +305,27 @@ class XmlTask:
                 user_id = self.get_element("UserId", trigger)
                 state_change = self.get_element("StateChange", trigger)
 
-                record = SessionStateChangeTriggerRecord(
-                    user_id=user_id,
-                    state_change=state_change,
-                )
+                record = SessionStateChangeTriggerRecord(user_id=user_id, state_change=state_change, source=self.source)
 
                 yield GroupedRecord(SessionStateChangeTriggerRecord.name, [base, record])
 
             elif trigger_type == "CalendarTrigger":
                 if days_between_triggers := self.get_element("ScheduleByDay/DaysInterval", trigger):
-                    record = DailyTriggerRecord(
-                        days_between_triggers=int(days_between_triggers),
-                    )
+                    record = DailyTriggerRecord(days_between_triggers=int(days_between_triggers), source=self.source)
 
                 elif weeks_between_triggers := self.get_element("ScheduleByWeek/WeeksInterval", trigger):
                     days_of_week = [day.tag for day in trigger.find("ScheduleByWeek/DaysOfWeek/").iter("*")]
                     record = WeeklyTriggerRecord(
                         weeks_between_triggers=int(weeks_between_triggers),
                         days_of_week=days_of_week,
+                        source=self.source,
                     )
 
                 elif trigger.find("ScheduleByMonth/") is not None:
                     day_of_month = [int(day.text) for day in trigger.iter("Day")]
                     months_of_year = [month.tag for month in trigger.findall("*/Months/*")]
                     record = MonthlyDateTriggerRecord(
-                        day_of_month=day_of_month,
-                        months_of_year=months_of_year,
+                        day_of_month=day_of_month, months_of_year=months_of_year, source=self.source
                     )
 
                 elif trigger.find("ScheduleByMonthDayOfWeek/") is not None:
@@ -341,6 +336,7 @@ class XmlTask:
                         which_week=which_week,
                         days_of_week=days_of_week,
                         months_of_year=months_of_year,
+                        source=self.source,
                     )
 
                 else:
@@ -351,18 +347,14 @@ class XmlTask:
             elif trigger_type == "WnfStateChangeTrigger":
                 state_name = self.get_element("StateName", trigger)
 
-                record = WnfTriggerRecord(
-                    state_name=state_name,
-                )
+                record = WnfTriggerRecord(state_name=state_name, source=self.source)
 
                 yield GroupedRecord(WnfTriggerRecord.name, [base, record])
 
             elif trigger_type == "RegistrationTrigger":
                 date = self.get_element("Date", trigger)
 
-                record = RegistrationTrigger(
-                    date=date,
-                )
+                record = RegistrationTrigger(date=date, source=self.source)
 
                 yield GroupedRecord(RegistrationTrigger.name, [base, record])
 
@@ -386,15 +378,14 @@ class XmlTask:
                     command=command,
                     arguments=args,
                     working_directory=wrkdir,
+                    source=self.source,
                 )
 
             if action_type == "ComHandler":
                 com_class_id = self.get_element("Actions/ComHandler/ClassId")
                 com_data = self.get_raw("Actions/ComHandler/Data")
                 yield ComHandlerRecord(
-                    action_type=action_type,
-                    class_id=com_class_id,
-                    com_data=com_data,
+                    action_type=action_type, class_id=com_class_id, com_data=com_data, source=self.source
                 )
 
             if action_type == "SendEmail":
@@ -422,13 +413,10 @@ class XmlTask:
                     header_value=email_headers_value,
                     body=email_body,
                     attachment=email_attachments,
+                    source=self.source,
                 )
 
             if action_type == "ShowMessage":
                 title = self.get_element("Actions/ShowMessage/Title")
                 body = self.get_element("Actions/ShowMessage/Body")
-                yield ShowMessageRecord(
-                    action_type=action,
-                    title=title,
-                    body=body,
-                )
+                yield ShowMessageRecord(action_type=action, title=title, body=body, source=self.source)

--- a/dissect/target/plugins/os/windows/tasks/xml.py
+++ b/dissect/target/plugins/os/windows/tasks/xml.py
@@ -271,7 +271,10 @@ class XmlTask:
 
             if trigger_type == "LogonTrigger":
                 user_id = self.get_element("UserId", trigger)
-                record = LogonTriggerRecord(user_id=user_id, source=self.source)
+                record = LogonTriggerRecord(
+                    user_id=user_id,
+                    source=self.source,
+                )
                 yield GroupedRecord(LogonTriggerRecord.name, [base, record])
 
             elif trigger_type == "BootTrigger":
@@ -305,13 +308,20 @@ class XmlTask:
                 user_id = self.get_element("UserId", trigger)
                 state_change = self.get_element("StateChange", trigger)
 
-                record = SessionStateChangeTriggerRecord(user_id=user_id, state_change=state_change, source=self.source)
+                record = SessionStateChangeTriggerRecord(
+                    user_id=user_id,
+                    state_change=state_change,
+                    source=self.source,
+                )
 
                 yield GroupedRecord(SessionStateChangeTriggerRecord.name, [base, record])
 
             elif trigger_type == "CalendarTrigger":
                 if days_between_triggers := self.get_element("ScheduleByDay/DaysInterval", trigger):
-                    record = DailyTriggerRecord(days_between_triggers=int(days_between_triggers), source=self.source)
+                    record = DailyTriggerRecord(
+                        days_between_triggers=int(days_between_triggers),
+                        source=self.source,
+                    )
 
                 elif weeks_between_triggers := self.get_element("ScheduleByWeek/WeeksInterval", trigger):
                     days_of_week = [day.tag for day in trigger.find("ScheduleByWeek/DaysOfWeek/").iter("*")]
@@ -325,7 +335,9 @@ class XmlTask:
                     day_of_month = [int(day.text) for day in trigger.iter("Day")]
                     months_of_year = [month.tag for month in trigger.findall("*/Months/*")]
                     record = MonthlyDateTriggerRecord(
-                        day_of_month=day_of_month, months_of_year=months_of_year, source=self.source
+                        day_of_month=day_of_month,
+                        months_of_year=months_of_year,
+                        source=self.source,
                     )
 
                 elif trigger.find("ScheduleByMonthDayOfWeek/") is not None:
@@ -347,14 +359,20 @@ class XmlTask:
             elif trigger_type == "WnfStateChangeTrigger":
                 state_name = self.get_element("StateName", trigger)
 
-                record = WnfTriggerRecord(state_name=state_name, source=self.source)
+                record = WnfTriggerRecord(
+                    state_name=state_name,
+                    source=self.source,
+                )
 
                 yield GroupedRecord(WnfTriggerRecord.name, [base, record])
 
             elif trigger_type == "RegistrationTrigger":
                 date = self.get_element("Date", trigger)
 
-                record = RegistrationTrigger(date=date, source=self.source)
+                record = RegistrationTrigger(
+                    date=date,
+                    source=self.source,
+                )
 
                 yield GroupedRecord(RegistrationTrigger.name, [base, record])
 
@@ -385,7 +403,10 @@ class XmlTask:
                 com_class_id = self.get_element("Actions/ComHandler/ClassId")
                 com_data = self.get_raw("Actions/ComHandler/Data")
                 yield ComHandlerRecord(
-                    action_type=action_type, class_id=com_class_id, com_data=com_data, source=self.source
+                    action_type=action_type,
+                    class_id=com_class_id,
+                    com_data=com_data,
+                    source=self.source,
                 )
 
             if action_type == "SendEmail":
@@ -419,4 +440,9 @@ class XmlTask:
             if action_type == "ShowMessage":
                 title = self.get_element("Actions/ShowMessage/Title")
                 body = self.get_element("Actions/ShowMessage/Body")
-                yield ShowMessageRecord(action_type=action, title=title, body=body, source=self.source)
+                yield ShowMessageRecord(
+                    action_type=action,
+                    title=title,
+                    body=body,
+                    source=self.source,
+                )

--- a/dissect/target/plugins/os/windows/wer.py
+++ b/dissect/target/plugins/os/windows/wer.py
@@ -201,8 +201,7 @@ class WindowsErrorReportingPlugin(Plugin):
         """
         for files in self.wer_files:
             record_fields = []
-            files = list(files)
-            if not files:
+            if not (files := list(files)):
                 continue
             record_values = {
                 "_target": self.target,

--- a/dissect/target/plugins/os/windows/wer.py
+++ b/dissect/target/plugins/os/windows/wer.py
@@ -28,6 +28,7 @@ def _create_record_descriptor(record_name: str, record_fields: list[tuple[str, s
         [
             ("path", "wer_file_path"),
             ("path", "metadata_file_path"),
+            ("path", "source"),
         ]
     )
     return TargetRecordDescriptor(record_name, record_fields)
@@ -200,7 +201,14 @@ class WindowsErrorReportingPlugin(Plugin):
         """
         for files in self.wer_files:
             record_fields = []
-            record_values = {"_target": self.target}
+            files = list(files)
+            if not files:
+                continue
+            record_values = {
+                "_target": self.target,
+                # As record is made from multiple files in the same folder, we use the folder as the source.
+                "source": files[0].parent,
+            }
 
             for file in files:
                 if file.suffix == ".wer":

--- a/tests/plugins/os/unix/bsd/citrix/test__os.py
+++ b/tests/plugins/os/unix/bsd/citrix/test__os.py
@@ -63,24 +63,31 @@ def test_citrix_os(target_citrix: Target, fs_bsd: VirtualFilesystem) -> None:
     assert users[0].home == posix_path("/var/nstmp/alfred")
 
     assert users[1].name == "batman"  # Only listed in config
+    assert users[1].source == "/flash/nsconfig/ns.conf"
     assert users[1].home is None
 
     assert users[2].name == "bind"  # User entry from /etc/passwd, home overwritten from '/' to None
+    assert users[2].source == "/etc/passwd"
     assert users[2].home is None
 
     assert users[3].name == "jasontodd"  # Only listed in config backup
+    assert users[3].source == "/flash/nsconfig/ns.conf.0"
     assert users[3].home is None
 
     assert users[4].name == "nobody"  # User entry for the nobody user from /etc/passwd
+    assert users[4].source == "/etc/passwd"
     assert users[4].home == posix_path("/nonexistent")
 
     assert users[5].name == "robin"  # Listed in config and /var/nstmp
+    assert users[5].source == "/flash/nsconfig/ns.conf"
     assert users[5].home == posix_path("/var/nstmp/robin")
 
     assert users[6].name == "root"  # User entry for /root, from the config
+    assert users[6].source == "/flash/nsconfig/ns.conf"
     assert users[6].home == posix_path("/root")
     assert users[6].shell is None
 
     assert users[7].name == "root"  # User entry for /root, from /etc/passwd
+    assert users[7].source == "/etc/passwd"
     assert users[7].home == posix_path("/root")
     assert users[7].shell == "/usr/bin/bash"

--- a/tests/plugins/os/unix/linux/debian/test_apt.py
+++ b/tests/plugins/os/unix/linux/debian/test_apt.py
@@ -38,9 +38,11 @@ def test_apt_logs(test_file: str, target_unix: Target, fs_unix: VirtualFilesyste
     assert results[0].package_name == "libcurl4:amd64 (7.68.0-1ubuntu2.12, 7.68.0-1ubuntu2.13)"
     assert results[0].command == "/usr/bin/unattended-upgrade"
     assert results[0].requested_by_user is None
+    assert results[0].source == f"/var/log/apt/{test_file}"
 
     assert results[-1].ts == datetime(2022, 9, 7, 7, 48, 28, tzinfo=tz)
     assert results[-1].operation == "update"
     assert results[-1].package_name == "linux-generic:amd64 (5.4.0.125.126, 5.4.0.126.127)"
     assert results[-1].command == "/usr/bin/unattended-upgrade"
     assert results[-1].requested_by_user == "user (1000)"
+    assert results[-1].source == f"/var/log/apt/{test_file}"

--- a/tests/plugins/os/unix/linux/redhat/test_yum.py
+++ b/tests/plugins/os/unix/linux/redhat/test_yum.py
@@ -50,9 +50,11 @@ def test_yum_logs(test_file: str, target_unix: Target, fs_unix: VirtualFilesyste
         assert results[0].package_name == "unzip-6.0-24.el7_9.x86_64"
         assert results[0].command is None
         assert results[0].requested_by_user is None
+        assert results[0].source == f"/var/log/{test_file}"
 
         assert results[-1].ts == datetime(2023, 12, 16, 4, 41, 22, tzinfo=tz)
         assert results[-1].operation == "install"
         assert results[-1].package_name == "unzip-6.0-24.el7_9.x86_64"
         assert results[-1].command is None
         assert results[-1].requested_by_user is None
+        assert results[-1].source == f"/var/log/{test_file}"

--- a/tests/plugins/os/unix/linux/suse/test_zypper.py
+++ b/tests/plugins/os/unix/linux/suse/test_zypper.py
@@ -38,9 +38,11 @@ def test_zypper_logs(target_unix: Target, fs_unix: VirtualFilesystem, test_file:
     assert results[0].package_name is None
     assert results[0].command == "zypper install unzip"
     assert results[0].requested_by_user == "root"
+    assert results[0].source == f"/var/log/zypp/{test_file}"
 
     assert results[-1].ts == datetime(2022, 12, 16, 13, 2, 44, tzinfo=tz)
     assert results[-1].operation == "install"
     assert results[-1].package_name == "yast2-4.5.20-1.1:x86_64"
     assert results[-1].command is None
     assert results[-1].requested_by_user is None
+    assert results[-1].source == f"/var/log/zypp/{test_file}"

--- a/tests/plugins/os/unix/linux/test_cmdline.py
+++ b/tests/plugins/os/unix/linux/test_cmdline.py
@@ -13,3 +13,8 @@ def test_cmdline(target_linux_users: Target, fs_linux_proc: VirtualFilesystem) -
     target_linux_users.add_plugin(ProcPlugin)
     results = list(target_linux_users.cmdline())
     assert len(results) == 4
+    results.sort(key=lambda x: x.pid)
+    assert results[3].pid == 1337
+    assert results[3].source == "/proc/1337/cmdline"
+    assert results[3].name == "acquire"
+    assert results[3].cmdline == "acquire -p full --proc"

--- a/tests/plugins/os/unix/linux/test_environ.py
+++ b/tests/plugins/os/unix/linux/test_environ.py
@@ -13,3 +13,8 @@ def test_environ(target_linux_users: Target, fs_linux_proc: VirtualFilesystem) -
     target_linux_users.add_plugin(ProcPlugin)
     results = list(target_linux_users.environ())
     assert len(results) == 3
+    results.sort(key=lambda x: x.pid)
+    assert results[0].source == "/proc/1/environ"
+    assert results[0].name == "systemd"
+    assert results[0].variable == "VAR"
+    assert results[0].content == "1"

--- a/tests/plugins/os/unix/linux/test_recentlyused.py
+++ b/tests/plugins/os/unix/linux/test_recentlyused.py
@@ -30,6 +30,7 @@ def test_recently_used(target_unix_users: Target, fs_unix: VirtualFilesystem) ->
     assert results[0].modified == dt("2023-10-18 13:14:09.483576Z")
     assert results[0].visited == dt("2023-10-18 13:12:41.905277Z")
     assert results[0].mimetype == "text/plain"
+    assert results[0].source == "/home/user/.local/share/recently-used.xbel"
 
 
 def test_recently_used_invalid_data(target_unix_users: Target, fs_unix: VirtualFilesystem) -> None:

--- a/tests/plugins/os/unix/test_locale.py
+++ b/tests/plugins/os/unix/test_locale.py
@@ -38,6 +38,7 @@ def test_locale_plugin_unix(target_unix_users: Target, fs_unix: VirtualFilesyste
     assert keyboard[0].variant == ""
     assert keyboard[0].options == ""
     assert keyboard[0].backspace == "guess"
+    assert keyboard[0].source == "/etc/default/keyboard"
 
 
 def test_locale_plugin_unix_quotes(target_unix_users: Target, fs_unix: VirtualFilesystem) -> None:

--- a/tests/plugins/os/unix/test_shadow.py
+++ b/tests/plugins/os/unix/test_shadow.py
@@ -38,6 +38,7 @@ def test_unix_shadow(target_unix_users: Target, fs_unix: VirtualFilesystem) -> N
     assert results[0].inactivity_period is None
     assert results[0].expiration_date is None
     assert results[0].unused_field == ""
+    assert results[0].source == "/etc/shadow"
 
 
 def test_unix_shadow_backup_file(target_unix_users: Target, fs_unix: VirtualFilesystem) -> None:
@@ -53,8 +54,9 @@ def test_unix_shadow_backup_file(target_unix_users: Target, fs_unix: VirtualFile
     results = list(target_unix_users.passwords())
     assert len(results) == 2
     assert results[0].name == "test"
+    assert results[0].source == "/etc/shadow"
     assert results[1].name == "other-user"
-    assert results[0].hash == results[1].hash
+    assert results[1].source == "/etc/shadow-"
 
 
 def test_unix_shadow_invalid_shent(

--- a/tests/plugins/os/unix/test_shadow.py
+++ b/tests/plugins/os/unix/test_shadow.py
@@ -56,6 +56,7 @@ def test_unix_shadow_backup_file(target_unix_users: Target, fs_unix: VirtualFile
     assert results[0].name == "test"
     assert results[0].source == "/etc/shadow"
     assert results[1].name == "other-user"
+    assert results[0].hash == results[1].hash
     assert results[1].source == "/etc/shadow-"
 
 

--- a/tests/plugins/os/windows/log/test_evt.py
+++ b/tests/plugins/os/windows/log/test_evt.py
@@ -109,3 +109,4 @@ def test_evt_direct_mode() -> None:
     records = list(target.evt())
 
     assert len(records) == 5
+    assert {str(record.source) for record in records} == {str(data_path)}

--- a/tests/plugins/os/windows/log/test_schedlgu.py
+++ b/tests/plugins/os/windows/log/test_schedlgu.py
@@ -27,6 +27,7 @@ def test_shedlgu(target_win: Target, fs_win: VirtualFilesystem) -> None:
     assert task_scheduler_started_event.ts == datetime("2006-11-02 07:35:17+00:00")
     assert task_scheduler_started_event.job == "Task Scheduler Service"
     assert task_scheduler_started_event.status == "Started"
+    assert task_scheduler_started_event.source == "c:\\Windows\\SchedLgU.txt"
 
     assert task_scheduler_version_event.job == "Task Scheduler Service"
     assert task_scheduler_version_event.version == "6.0.6000.16386 (vista_rtm.061101-2205)"
@@ -40,3 +41,4 @@ def test_shedlgu(target_win: Target, fs_win: VirtualFilesystem) -> None:
     assert job_task_event.command == "NDETECT.EXE"
     assert job_task_event.status == "Finished"
     assert job_task_event.exit_code == 65
+    assert job_task_event.source == "c:\\Windows\\SchedLgU.txt"

--- a/tests/plugins/os/windows/test_cim.py
+++ b/tests/plugins/os/windows/test_cim.py
@@ -26,6 +26,7 @@ def test_cim_plugin(target_win: Target, fs_win: VirtualFilesystem) -> None:
     assert len([r for r in consumer_records if type(r) == ActiveScriptEventConsumerRecord.recordType]) == 2  # noqa: E721
     # Ensure associated filter query was correctly found for all
     assert len([record for record in target_win.cim() if record.filter_query]) == 3
+    assert {str(r.source) for r in consumer_records} == {"c:\\Windows\\system32\\wbem\\repository"}
 
 
 def test_cim_direct_mode() -> None:
@@ -34,6 +35,7 @@ def test_cim_direct_mode() -> None:
     records = list(target.cim.consumerbindings())
 
     assert len(records) == 3
+    assert {str(r.source) for r in records} == {str(data_path)}
 
 
 r"""
@@ -283,3 +285,4 @@ def test_consumerbindings_all_namespaces(target_win: Target, fs_win: VirtualFile
     consumer_records = list(target_win.cim.consumerbindings())
     binding_names = [r.filter_name for r in consumer_records]
     assert "Pentestlab-WMI" in binding_names
+    assert {str(r.source) for r in consumer_records} == {"c:\\Windows\\system32\\wbem\\repository"}

--- a/tests/plugins/os/windows/test_tasks.py
+++ b/tests/plugins/os/windows/test_tasks.py
@@ -52,7 +52,9 @@ def assert_xml_task_properties(xml_task: TaskRecord) -> None:
         xml_task.security_descriptor
         == "D:(A;;0x111FFFFF;;;SY)(A;;0x111FFFFF;;;BA)(A;;0x111FFFFF;;;S-1-5-80-3028837079-3186095147-955107200-3701964851-1150726376)(A;;FRFX;;;AU)"  # noqa: E501
     )
-    assert xml_task.source is None
+    assert xml_task.source == (
+        "c:\\Windows\\system32\\GroupPolicy\\DataStore\\ANY_SID\\Machine\\Preferences\\ScheduledTasks\\test_xml.xml"
+    )
     assert xml_task.date == datetime(2014, 11, 5, 0, 0, 0, tzinfo=timezone.utc)
     assert xml_task.last_run_date is None
     assert xml_task.author == "$(@%SystemRoot%\\system32\\mapstoasttask.dll,-600)"
@@ -96,8 +98,8 @@ def assert_xml_task_properties(xml_task: TaskRecord) -> None:
 
 def assert_at_task_properties(at_task: TaskRecord) -> None:
     assert at_task.uri is None
+    assert at_task.source == "c:\\Windows\\tasks\\AtTask.job"
     assert at_task.security_descriptor is None
-    assert str(at_task.task_path) == "c:\\Windows\\tasks\\AtTask.job"
     assert at_task.date is None
     assert at_task.last_run_date == datetime(2023, 5, 21, 10, 44, 25, 794000, tzinfo=timezone.utc)
     assert at_task.author == "user1"
@@ -161,6 +163,7 @@ def assert_at_task_grouped_daily(at_task_grouped: GroupedRecord) -> None:
     assert at_task_grouped.repetition_interval == "PT12M"
     assert at_task_grouped.repetition_stop_duration_end
     assert at_task_grouped.start_boundary == datetime.fromisoformat("2023-05-11 00:00:00+00:00")
+    assert at_task_grouped.source == "c:\\Windows\\tasks\\AtTask.job"
     assert_at_task_grouped_padding(at_task_grouped)
 
 

--- a/tests/plugins/os/windows/test_wer.py
+++ b/tests/plugins/os/windows/test_wer.py
@@ -46,3 +46,4 @@ def test_wer_plugin(target_win: Target, fs_win: VirtualFilesystem) -> None:
     assert record.ts == datetime.datetime(2021, 11, 22, 15, 39, 49, 20733, tzinfo=datetime.timezone.utc)
     assert record.os_version == "6.1.7601.2.1.0.256.48"
     assert record.app_name == "Microsoft Malware Protection Command Line Utility"
+    assert record.source == "sysvol\\ProgramData\\Microsoft\\Windows\\WER\\ReportQueue\\test\\windows7"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1900,7 +1900,7 @@ def test_plugin_record_field_have_source_field() -> None:
             if "source" not in fields and "path" not in fields:
                 record_without_source.add(record.name)
 
-    if len(record_without_source) != 81:
+    if len(record_without_source) != 68:
         pytest.fail(
             f"Found {len(record_without_source)} inconsistencies in "
             f"RecordDescriptors:\n" + "\n".join(record_without_source)


### PR DESCRIPTION
# Add source field to record of 13 plugins

Some plugins records does not define the source field, and does not allows to quickly identified from which file an record was generated. This PR add this missing field to following plugins 
* Windows wer
* Windows cim
* Windows task
* Windows evt
* Windows SchedLgU (Task Scheduler Service transaction log file )
* citrix (users)
* Linux processes (cmdline/environ/socket)
* Linux package manager (yum/apt/zypper)
* Linux recently used
* Unix shadow
* Unix locale

## Proposed Changes

* For most records, just add the related source when record is created + update tests.
* For netscaler, change a bit the username plugins to keep trace from how user was identified. 
* For windows task plugins, rename already existing `source` to [registration_source](https://learn.microsoft.com/en-us/windows/win32/taskschd/registrationinfo-source) to prevent conflict. It will cause small resolvable conflicts with #1901 , as this plugin doesn't have source and _target fields
* For evt/evtx, this value is not set in `scrape` mode, this would require to update how scrape works (E.g by providing to the chunk_parser function the current disk + offset). If we want to do this, it's probably better in a dedicated P.R.

## Checklist
- [x] PR Title is descriptive of the changes
- [x] The description is descriptive of the changes
- [x] Tests are included and pass
- [x] Related to #1892 
